### PR TITLE
perf: run WP tiny-CSS inline in html_transformer (catches the homepage)

### DIFF
--- a/scripts/html_transformer.py
+++ b/scripts/html_transformer.py
@@ -117,6 +117,12 @@ class HTMLTransformer:
             if self._apply_critical_css(soup, file_path):
                 modified = True
 
+        # ── Phase 4.5: Inline tiny WP-shipped stylesheets ────────────────
+        # Has to run on every page (not only WP-regenerated ones) so list
+        # pages like the homepage get their rankmath.min.css inlined.
+        if self._apply_inline_tiny_wp_stylesheets(soup):
+            modified = True
+
         if not modified:
             return False
 
@@ -296,6 +302,53 @@ class HTMLTransformer:
             self.critical_css.css_inlined += 1
             return True
         return False
+
+    # WP-shipped stylesheets that survive the generator pass: small ones get
+    # inlined here so they don't cost a separate request. wp_to_static_generator
+    # also has this logic but only fires when a page is regenerated from WP —
+    # running it again here covers list pages (homepage, archives) that
+    # incremental builds skip.
+    _WP_INLINE_PATTERNS = (
+        'wp-content/themes/kadence/assets/css/rankmath.min.css',
+        'wp-content/themes/kadence/assets/css/footer.min.css',
+        'wp-content/cache/wpo-minify/',
+    )
+    _WP_INLINE_MAX_BYTES = 2048
+
+    def _apply_inline_tiny_wp_stylesheets(self, soup):
+        """Inline small WordPress-shipped CSS links into <head> as <style>."""
+        if not soup.head:
+            return False
+
+        inlined = 0
+        for link in list(soup.find_all('link', rel='stylesheet')):
+            if link.parent is None or link.attrs is None:
+                continue
+            raw_href = link.get('href') or ''
+            href = raw_href.lstrip('/').split('?', 1)[0]
+            if not any(p in href for p in self._WP_INLINE_PATTERNS):
+                continue
+            css_path = self.public_dir / href
+            if not css_path.exists():
+                continue
+            try:
+                content = css_path.read_text(encoding='utf-8').strip()
+            except Exception:
+                continue
+            if len(content) > self._WP_INLINE_MAX_BYTES:
+                continue
+
+            style_tag = soup.new_tag('style')
+            style_tag.string = content
+            link.insert_before(style_tag)
+            for companion in list(soup.find_all('link', href=raw_href)):
+                companion.decompose()
+            for noscript in list(soup.find_all('noscript')):
+                if noscript.find('link', href=raw_href):
+                    noscript.decompose()
+            inlined += 1
+
+        return inlined > 0
 
     @staticmethod
     def _dedup_head_string(html):

--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -368,10 +368,9 @@ class WordPressStaticGenerator:
         # Consolidate small inline CSS files to reduce critical request chain
         self.consolidate_inline_css_files(soup)
 
-        # Inline tiny WordPress-cached stylesheets so they don't cost a
-        # separate request (rankmath.min.css ships as a single 39-byte rule
-        # — a whole RTT for one CSS declaration).
-        self.inline_tiny_wp_stylesheets(soup)
+        # Inlining of small WP-shipped stylesheets (rankmath, kadence/footer,
+        # wpo-minify <2KB) is handled by html_transformer.py so it runs on
+        # every page — not just incrementally regenerated ones.
         
         # Process WordPress embeds (convert to proper iframes)
         self.process_wordpress_embeds(soup)
@@ -1691,65 +1690,6 @@ document.addEventListener('DOMContentLoaded', function() {
             soup.head.insert(0, consolidated_link)
         
         print(f"   ✅ Consolidated {len(css_links_to_consolidate)} CSS files → {consolidated_filename} ({len(consolidated_content)} bytes)")
-
-    def inline_tiny_wp_stylesheets(self, soup):
-        """Inline small WordPress-shipped CSS links into <head> as <style>.
-
-        WordPress emits several render-path stylesheets that survive the
-        generator pass and reach production unchanged (rankmath.min.css,
-        kadence/footer.min.css, wpo-minify-header-*.min.css). When the file
-        is small enough that the request overhead dwarfs the bytes, inline
-        it instead. Keeps any associated noscript fallback consistent by
-        stripping it too.
-        """
-        if not soup.head:
-            return
-
-        # 2 KB raw is the rule of thumb where one TCP round-trip costs more
-        # than the bytes themselves on a typical mobile connection.
-        max_inline_bytes = 2048
-        inline_patterns = (
-            'wp-content/themes/kadence/assets/css/rankmath.min.css',
-            'wp-content/themes/kadence/assets/css/footer.min.css',
-            'wp-content/cache/wpo-minify/',
-        )
-
-        inlined = 0
-        for link in list(soup.find_all('link', rel='stylesheet')):
-            # Iterating a snapshot can include nodes we already decomposed via
-            # the noscript companion sweep below — those have no parent and no
-            # attrs. Skip them.
-            if link.parent is None or link.attrs is None:
-                continue
-            raw_href = link.get('href') or ''
-            href = raw_href.lstrip('/')
-            if not any(p in href for p in inline_patterns):
-                continue
-            css_path = self.output_dir / href.split('?', 1)[0]
-            if not css_path.exists():
-                continue
-            try:
-                content = css_path.read_text(encoding='utf-8').strip()
-            except Exception:
-                continue
-            if len(content) > max_inline_bytes:
-                continue
-
-            style_tag = soup.new_tag('style')
-            style_tag.string = content
-            link.insert_before(style_tag)
-
-            # Drop the original link plus any preload/noscript companions
-            # pointing at the same href so we don't ship both inline and a fetch.
-            for companion in list(soup.find_all('link', href=raw_href)):
-                companion.decompose()
-            for noscript in list(soup.find_all('noscript')):
-                if noscript.find('link', href=raw_href):
-                    noscript.decompose()
-            inlined += 1
-
-        if inlined:
-            print(f"   📎 Inlined {inlined} tiny WordPress stylesheet(s)")
 
     def add_brutalist_theme_css(self, soup):
         """Add brutalist theme CSS with critical mobile CSS inlined"""


### PR DESCRIPTION
## Summary

Follow-up to [#29](https://github.com/jameskilbynet/jkcoukblog/pull/29). The post-deploy [GTmetrix HAR](https://github.com/jameskilbynet/jkcoukblog/pull/29) confirmed 5 of 6 fixes worked, but [`rankmath.min.css`](public/wp-content/themes/kadence/assets/css/rankmath.min.css) (39 bytes!) was still being fetched as a separate request on the homepage.

**Root cause:** `inline_tiny_wp_stylesheets` was added to [`wp_to_static_generator.process_html`](scripts/wp_to_static_generator.py), which only runs on pages WordPress reports as changed. List pages like the homepage weren't being regenerated, so the inline pass never fired on them.

**Fix:** Move the logic into [`html_transformer.py`](scripts/html_transformer.py) as a new phase (4.5). `html_transformer` runs over every HTML file in `static-output/` on every build, so the homepage now gets its `rankmath.min.css` inlined too.

The WP-side method is removed to avoid drift between two copies of the same logic.

## Test plan

- [x] Syntax check both files
- [x] Fixture: rankmath (39B) inlined, footer (5KB) + wpo-minify (99KB) left as links, idempotent on re-run
- [x] Run new phase against the *real* `public/index.html`: 2 rankmath link tags removed, `.rank-math-list-item` rule inlined as `<style>`
- [ ] After merge & deploy, confirm `curl https://jameskilby.co.uk/ | grep rankmath` shows zero hits (currently shows 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)