### PR TITLE
ci: trim 4.5 min of waste + log noise + plausible coverage

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -981,6 +981,7 @@ jobs:
       env:
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        GITHUB_SHA: ${{ github.sha }}
       run: |
         echo "🗑️ Purging all HTML entries from Workers KV cache..."
 
@@ -992,34 +993,53 @@ jobs:
 
         # Wait for the new Cloudflare Pages deployment to propagate before purging.
         # Without this, the purge hits the OLD deployment (which may not have the
-        # PURGE_TOKEN env var yet) and gets a 401. Poll the CF Pages API until the
-        # latest deployment reaches "success", then add a short buffer.
+        # PURGE_TOKEN env var yet) and gets a 401. We poll the CF Pages API for
+        # the deployment that matches *this* commit ($GITHUB_SHA) — the previous
+        # query asked for `.result[0].latest_stage.status` which returned
+        # "unknown" forever because we either got the previous deployment (race)
+        # or the path didn't match the response shape. Filtering by commit_hash
+        # is unambiguous and short-circuits as soon as Pages picks up the push.
         if [ -n "$CLOUDFLARE_API_TOKEN" ] && [ -n "$CLOUDFLARE_ACCOUNT_ID" ]; then
-          echo "⏳ Waiting for Cloudflare Pages deployment to complete..."
+          echo "⏳ Waiting for Cloudflare Pages deployment of ${GITHUB_SHA:0:7} to complete..."
           MAX_ATTEMPTS=18   # 18 × 10s = 180s max
           ATTEMPT=0
-          DEPLOY_STATUS=""
+          DEPLOY_STATUS="pending"
+          DEPLOY_RESP=""
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
             DEPLOY_RESP=$(curl -s \
               -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-              "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/jkcoukblog/deployments?per_page=1")
-            DEPLOY_STATUS=$(echo "$DEPLOY_RESP" | jq -r '.result[0].latest_stage.status // "unknown"' 2>/dev/null || echo "unknown")
+              "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/jkcoukblog/deployments?per_page=10")
+            DEPLOY_STATUS=$(printf '%s' "$DEPLOY_RESP" \
+              | jq -r --arg sha "$GITHUB_SHA" \
+                  '[.result[]? | select(.deployment_trigger.metadata.commit_hash == $sha)] | .[0].latest_stage.status // "pending"' \
+              2>/dev/null || echo "pending")
             echo "   Deployment status: $DEPLOY_STATUS (attempt $((ATTEMPT+1))/$MAX_ATTEMPTS)"
-            if [ "$DEPLOY_STATUS" = "success" ]; then
-              echo "✅ Deployment complete — waiting 15s for global propagation..."
-              sleep 15
-              break
-            fi
+            case "$DEPLOY_STATUS" in
+              success)
+                echo "✅ Deployment complete — waiting 15s for global propagation..."
+                sleep 15
+                break
+                ;;
+              failure|canceled)
+                echo "❌ Pages deployment $DEPLOY_STATUS — skipping purge"
+                exit 0
+                ;;
+            esac
             ATTEMPT=$((ATTEMPT+1))
             sleep 10
           done
           if [ "$DEPLOY_STATUS" != "success" ]; then
-            echo "⚠️  Deployment did not reach 'success' within timeout — sleeping 90s as fallback..."
-            sleep 90
+            echo "⚠️  Deployment for ${GITHUB_SHA:0:7} did not reach 'success' within timeout"
+            echo "   Last 3 deployments (id / status / commit) for debugging:"
+            printf '%s' "$DEPLOY_RESP" \
+              | jq -r '.result[0:3][]? | "   - \(.id[:8]) / \(.latest_stage.status // "?") / \(.deployment_trigger.metadata.commit_hash[:7] // "?")"' \
+              2>/dev/null || echo "   (unable to parse API response)"
+            echo "   Continuing with a 30s safety buffer before purge..."
+            sleep 30
           fi
         else
-          echo "⚠️  CF API credentials not set — sleeping 90s to allow deployment propagation..."
-          sleep 90
+          echo "⚠️  CF API credentials not set — sleeping 30s to allow deployment propagation..."
+          sleep 30
         fi
 
         RESPONSE=$(curl -s -w "\n%{http_code}" \

--- a/scripts/convert_images_to_picture.py
+++ b/scripts/convert_images_to_picture.py
@@ -17,9 +17,16 @@ from typing import List, Tuple, Optional
 from bs4 import BeautifulSoup
 
 
+# Per-image AVIF/WebP-existence trace prints are useful when diagnosing why
+# specific <img> tags aren't being wrapped in <picture>, but they fired ~1,300×
+# per CI build — ~12% of the deploy log. Gate behind DEBUG_PICTURE so normal
+# runs stay quiet. Set DEBUG_PICTURE=1 (or any truthy value) to re-enable.
+_DEBUG_PICTURE = os.environ.get('DEBUG_PICTURE', '').lower() in ('1', 'true', 'yes')
+
+
 class ImageToPictureConverter:
     """Converts img tags to picture elements with AVIF/WebP sources and responsive srcsets"""
-    
+
     def __init__(self, directory: str):
         self.directory = Path(directory)
         self.stats = {
@@ -28,7 +35,10 @@ class ImageToPictureConverter:
             'images_skipped': 0,
             'responsive_srcsets_added': 0,
         }
-        self.debug_count = 0  # For debugging first few images
+        # Cap the trace to the first few images even when DEBUG_PICTURE is on
+        # so a verbose run still produces a readable log.
+        self.debug_count = 0
+        self.debug_limit = 3 if _DEBUG_PICTURE else 0
     
     def _get_responsive_srcset(self, img_srcset: str, format_ext: str) -> Optional[str]:
         """
@@ -94,30 +104,33 @@ class ImageToPictureConverter:
             img_path = img_src.lstrip('/')
         
         full_path = base_path / img_path
-        
-        # Debug first few images
-        if self.debug_count < 3:
+
+        # Debug first few images — only when DEBUG_PICTURE=1 in the env.
+        # The previous guard incremented debug_count only on the first 3 images
+        # but then printed unconditionally with `<= 3`, so once we hit 3 the
+        # trace fired for *every* subsequent image (~1,300 per CI build).
+        debug_this = self.debug_count < self.debug_limit
+        if debug_this:
             self.debug_count += 1
             print(f"\n🔍 DEBUG Image #{self.debug_count}:")
             print(f"   img_src: {img_src}")
             print(f"   img_path: {img_path}")
             print(f"   full_path: {full_path}")
             print(f"   full_path exists: {full_path.exists()}")
-        
-        if not full_path.exists():
-            if self.debug_count <= 3:
-                print(f"   ⚠️  Original image not found, checking for modern formats...")
+
+        if debug_this and not full_path.exists():
+            print(f"   ⚠️  Original image not found, checking for modern formats...")
 
         # Check for AVIF and WebP versions
         avif_path = full_path.with_suffix('.avif')
         webp_path = full_path.with_suffix('.webp')
-        
-        if self.debug_count <= 3:
+
+        if debug_this:
             print(f"   avif_path: {avif_path}")
             print(f"   avif exists: {avif_path.exists()}")
             print(f"   webp_path: {webp_path}")
             print(f"   webp exists: {webp_path.exists()}")
-        
+
         return avif_path.exists(), webp_path.exists()
     
     def _should_convert_img(self, img) -> bool:

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -496,6 +496,7 @@ def generate_changelog_html(lighthouse_scores, git_stats, changes):
             }}
         }}
     </style>
+    <script defer data-cfasync="false" data-domain="jameskilby.co.uk" src="https://plausible.jameskilby.cloud/js/script.js"></script>
 </head>
 <body>
     <div class="container">

--- a/scripts/generate_soft404_artefacts.py
+++ b/scripts/generate_soft404_artefacts.py
@@ -87,6 +87,7 @@ def write_404_html(public_dir: Path) -> Path:
     ul{list-style:none;padding:0;margin:2rem 0 0}
     li{margin:.5rem 0}
   </style>
+  <script defer data-cfasync="false" data-domain="jameskilby.co.uk" src="https://plausible.jameskilby.cloud/js/script.js"></script>
 </head>
 <body>
   <main>

--- a/scripts/generate_stats_page.py
+++ b/scripts/generate_stats_page.py
@@ -457,6 +457,7 @@ def generate_stats_html(lighthouse, build_metrics, git_stats):
             }}
         }}
     </style>
+    <script defer data-cfasync="false" data-domain="jameskilby.co.uk" src="https://plausible.jameskilby.cloud/js/script.js"></script>
 </head>
 <body>
     <div class="container">

--- a/scripts/validate_deployment.py
+++ b/scripts/validate_deployment.py
@@ -475,8 +475,14 @@ class DeploymentValidator:
         """Verify Plausible Analytics script is properly injected in all HTML pages."""
         print("\n📊 Validating Plausible Analytics...")
 
-        # Find all HTML files
-        html_files = list(self.site_dir.glob('**/*.html'))
+        # Find all HTML files, excluding non-page artefacts that shouldn't ship
+        # the tracker (RSS feeds are XML masquerading as .html, embeds run in
+        # iframes without analytics, sitemaps are crawler-only).
+        SKIP_PATTERNS = ('feed/', '/embed/', 'sitemap')
+        html_files = [
+            f for f in self.site_dir.glob('**/*.html')
+            if not any(pat in str(f) for pat in SKIP_PATTERNS)
+        ]
 
         if not html_files:
             self.errors.append("No HTML files found to validate")

--- a/scripts/validate_wordpress_source.py
+++ b/scripts/validate_wordpress_source.py
@@ -594,6 +594,56 @@ class WordPressSourceValidator:
 
         return report
 
+    # Categorical roll-up so the WordPress source step at the top of the
+    # build summarises debt instead of dumping a flat list of 90+ warnings.
+    # New types should be added here when added at the `self.warnings.append`
+    # sites — fall-through to "Other" if a type isn't categorised yet.
+    _WARNING_CATEGORIES = {
+        'SEO — titles': ('seo_title_short', 'seo_title_long'),
+        'SEO — excerpts': ('seo_excerpt_missing', 'seo_excerpt_short', 'seo_excerpt_long'),
+        'Featured images': ('missing_featured_image', 'broken_featured_image'),
+        'Taxonomy': (
+            'missing_categories', 'broken_category',
+            'missing_tags', 'tags_out_of_range', 'broken_tag',
+        ),
+        'Connectivity / API': (
+            'site_not_accessible', 'api_request_failed', 'auth_failed',
+            'auth_forbidden', 'api_error',
+            'endpoint_unreachable', 'endpoint_error',
+        ),
+        'Content gaps': ('no_posts', 'no_media'),
+    }
+
+    def _print_warning_rollup(self):
+        """Print a category-level roll-up of warning counts before the detail list."""
+        type_to_category = {
+            t: cat
+            for cat, types in self._WARNING_CATEGORIES.items()
+            for t in types
+        }
+
+        # Aggregate by category, with sub-counts by raw type for visibility.
+        from collections import Counter, defaultdict
+        category_totals = Counter()
+        category_breakdown = defaultdict(Counter)
+        for w in self.warnings:
+            wtype = w.get('type', 'unknown')
+            category = type_to_category.get(wtype, 'Other')
+            category_totals[category] += 1
+            category_breakdown[category][wtype] += 1
+
+        print("📊 WARNING ROLL-UP (by category):")
+        # Sort by descending count; tie-break alphabetically so output is
+        # deterministic between runs.
+        for category, total in sorted(
+            category_totals.items(), key=lambda kv: (-kv[1], kv[0])
+        ):
+            print(f"   • {category}: {total}")
+            for wtype, count in category_breakdown[category].most_common():
+                # Human-friendly type label: seo_title_short → seo title short
+                print(f"       - {wtype.replace('_', ' ')}: {count}")
+        print()
+
     def print_summary(self):
         """Print human-readable validation summary to console."""
         print("\n" + "=" * 80)
@@ -634,9 +684,13 @@ class WordPressSourceValidator:
                 print(f"   ... and {len(self.errors) - 10} more errors")
             print()
 
-        # Print first 10 warnings
+        # Print warnings: roll-up by category first (triage-friendly), then
+        # the first 10 individual entries for context. Previous behaviour
+        # dumped 10 + "and 84 more" with no idea what kind of debt remained.
         if self.warnings:
-            print("⚠️  WARNINGS:")
+            self._print_warning_rollup()
+
+            print("⚠️  WARNINGS (first 10):")
             for i, warning in enumerate(self.warnings[:10], 1):
                 content_type = warning.get('content_type', '')
                 content_title = warning.get('content_title', '')


### PR DESCRIPTION
## Summary

Four fixes informed by reviewing the [26-May deploy logs](https://github.com/jameskilbynet/jkcoukblog/actions/runs/70763594796). The KV-purge fix alone halves total build time (~9 min → ~4 min).

## What changed

### 1. KV-purge poll loop wasted ~4m30s per build — fixed
[`.github/workflows/deploy-static-site.yml`](.github/workflows/deploy-static-site.yml) (Purge all HTML from KV cache step)

Old query was `.result[0].latest_stage.status`, which always returned `"unknown"` for the full 180s polling window, then fell through to a 90 s sleep. Likely race: index 0 was the *previous* deployment whose status was already `success`, or the response shape didn't match.

Now we filter `.result[]` by `deployment_trigger.metadata.commit_hash == $GITHUB_SHA` so we wait on the right deployment. Other changes in the same block:
- Bail out early on `failure` / `canceled` (was always running purge regardless).
- Fallback sleep reduced 90s → 30s.
- On timeout, dump the last 3 deployments' status/SHA so a future failure is debuggable instead of completely silent.
- Same 30s (was 90s) fallback when CF credentials aren't set.

**Verified** the new `jq` expression against simulated CF API payloads (success / pending / failure).

### 2. Plausible now ships on 404 / stats / changelog
- [`scripts/generate_soft404_artefacts.py`](scripts/generate_soft404_artefacts.py) — `write_404_html` template
- [`scripts/generate_stats_page.py`](scripts/generate_stats_page.py) — `generate_stats_html` head section
- [`scripts/generate_changelog.py`](scripts/generate_changelog.py) — `generate_changelog_html` head section

All three are emitted by standalone generators that bypass `add_plausible_analytics`. Now they each include the same `<script defer data-cfasync="false" data-domain="jameskilby.co.uk" src="https://plausible.jameskilby.cloud/js/script.js">` tag as the WP-generated pages.

[`scripts/validate_deployment.py`](scripts/validate_deployment.py) also now skips `feed/`, `/embed/`, and `sitemap` when checking Plausible coverage — RSS shouldn't have JS at all and these were the remaining noise warnings.

### 3. Image-format debug prints fired 1,276× per build — gated behind env
[`scripts/convert_images_to_picture.py`](scripts/convert_images_to_picture.py)

The existing "log first 3 images" guard incremented `debug_count` only inside `if debug_count < 3:` but then printed AVIF/WebP existence with `if debug_count <= 3:`. Once we hit 3, the counter froze at 3 and `<= 3` stayed true forever, so the trace fired for every subsequent image (~1,300 per CI build, ~12% of the deploy log).

Now:
- Wrapped behind `DEBUG_PICTURE` env var (default off).
- When enabled, properly limits to 3 images via a `debug_limit` field (= 3 when env set, = 0 when not).

### 4. WordPress source validator now rolls up warnings by category
[`scripts/validate_wordpress_source.py`](scripts/validate_wordpress_source.py)

The validator emits 94+ warnings on every build and printed `... and 84 more warnings` with no categorical breakdown — useless for triage. New `_print_warning_rollup()` method runs before the detail list and groups by:

- SEO — titles (title-too-long, title-too-short)
- SEO — excerpts (missing/long/short)
- Featured images (missing/broken)
- Taxonomy (categories/tags issues)
- Connectivity / API
- Content gaps
- Other (uncategorised — fall-through)

Sample output from a 94-warning fixture:
```
📊 WARNING ROLL-UP (by category):
   • SEO — titles: 30
       - seo title long: 22
       - seo title short: 8
   • SEO — excerpts: 27
       - seo excerpt long: 18
       - seo excerpt short: 5
       - seo excerpt missing: 4
   • Other: 17
       - something unknown: 17
   • Taxonomy: 15
       - tags out of range: 12
       - missing categories: 3
   • Featured images: 5
       - missing featured image: 4
       - broken featured image: 1
```

## Test plan

- [x] All 7 changed scripts compile cleanly
- [x] New jq filter returns `success` / `pending` / `failure` correctly against simulated CF API payloads
- [x] `DEBUG_PICTURE=1` enables the first-3 image trace; unset keeps it silent
- [x] All 3 generator outputs now contain a `<script ... plausible ...>` tag in `<head>`
- [x] `_print_warning_rollup` produces the expected categorisation against a 94-warning fixture
- [x] Real end-to-end smoke: ran `write_404_html` against /tmp, confirmed Plausible tag is in `<head>`
- [ ] After merge, watch the next deploy to confirm: build time drops from ~9 min to ~4 min; deploy log loses 1,276 image-debug lines; validation summary shows the new roll-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)