### PR TITLE
ci: KV-purge polls the *pushed* commit, not the trigger commit

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -867,6 +867,7 @@ jobs:
       continue-on-error: true
 
     - name: Commit and push static site
+      id: commit_push
       timeout-minutes: 5
       run: |
         git add public/ .last_spell_check_timestamp .image_optimization_cache/ .indexnow_key 2>/dev/null || true
@@ -884,6 +885,9 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **Status:** No changes detected" >> $GITHUB_STEP_SUMMARY
           echo "- **Note:** Site is already up to date" >> $GITHUB_STEP_SUMMARY
+          # Signal to the KV-purge step that nothing new is on its way — no
+          # need to poll Cloudflare for a new deployment.
+          echo "pushed_sha=" >> $GITHUB_OUTPUT
           exit 0
         fi
 
@@ -904,6 +908,14 @@ jobs:
             exit 1
           fi
         fi
+
+        # Capture the SHA we *actually pushed* — this is what Cloudflare Pages
+        # will create a deployment for. $GITHUB_SHA refers to the commit that
+        # triggered the workflow (the previous main HEAD), so the KV-purge
+        # step polled for a deployment that never existed and timed out.
+        PUSHED_SHA=$(git rev-parse HEAD)
+        echo "pushed_sha=$PUSHED_SHA" >> $GITHUB_OUTPUT
+        echo "📌 Pushed commit: $PUSHED_SHA"
 
         echo "✅ Static site updated successfully"
         echo "" >> $GITHUB_STEP_SUMMARY
@@ -981,7 +993,13 @@ jobs:
       env:
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        GITHUB_SHA: ${{ github.sha }}
+        # IMPORTANT: not $GITHUB_SHA. github.sha is the commit that *triggered*
+        # the workflow; the deploy job itself pushes a new commit later, and
+        # Cloudflare Pages deploys *that* one. The Commit-and-push step exports
+        # its post-push HEAD via this output so we wait for the right deploy.
+        # When no commit was needed (no content changed), PUSHED_SHA is empty
+        # and we skip the wait entirely — the existing deployment is still live.
+        PUSHED_SHA: ${{ steps.commit_push.outputs.pushed_sha }}
       run: |
         echo "🗑️ Purging all HTML entries from Workers KV cache..."
 
@@ -991,16 +1009,10 @@ jobs:
           exit 0
         fi
 
-        # Wait for the new Cloudflare Pages deployment to propagate before purging.
-        # Without this, the purge hits the OLD deployment (which may not have the
-        # PURGE_TOKEN env var yet) and gets a 401. We poll the CF Pages API for
-        # the deployment that matches *this* commit ($GITHUB_SHA) — the previous
-        # query asked for `.result[0].latest_stage.status` which returned
-        # "unknown" forever because we either got the previous deployment (race)
-        # or the path didn't match the response shape. Filtering by commit_hash
-        # is unambiguous and short-circuits as soon as Pages picks up the push.
-        if [ -n "$CLOUDFLARE_API_TOKEN" ] && [ -n "$CLOUDFLARE_ACCOUNT_ID" ]; then
-          echo "⏳ Waiting for Cloudflare Pages deployment of ${GITHUB_SHA:0:7} to complete..."
+        if [ -z "$PUSHED_SHA" ]; then
+          echo "ℹ️  No new commit was pushed — previous deployment still live, purging immediately."
+        elif [ -n "$CLOUDFLARE_API_TOKEN" ] && [ -n "$CLOUDFLARE_ACCOUNT_ID" ]; then
+          echo "⏳ Waiting for Cloudflare Pages deployment of ${PUSHED_SHA:0:7} to complete..."
           MAX_ATTEMPTS=18   # 18 × 10s = 180s max
           ATTEMPT=0
           DEPLOY_STATUS="pending"
@@ -1010,7 +1022,7 @@ jobs:
               -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
               "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/jkcoukblog/deployments?per_page=10")
             DEPLOY_STATUS=$(printf '%s' "$DEPLOY_RESP" \
-              | jq -r --arg sha "$GITHUB_SHA" \
+              | jq -r --arg sha "$PUSHED_SHA" \
                   '[.result[]? | select(.deployment_trigger.metadata.commit_hash == $sha)] | .[0].latest_stage.status // "pending"' \
               2>/dev/null || echo "pending")
             echo "   Deployment status: $DEPLOY_STATUS (attempt $((ATTEMPT+1))/$MAX_ATTEMPTS)"
@@ -1029,7 +1041,7 @@ jobs:
             sleep 10
           done
           if [ "$DEPLOY_STATUS" != "success" ]; then
-            echo "⚠️  Deployment for ${GITHUB_SHA:0:7} did not reach 'success' within timeout"
+            echo "⚠️  Deployment for ${PUSHED_SHA:0:7} did not reach 'success' within timeout"
             echo "   Last 3 deployments (id / status / commit) for debugging:"
             printf '%s' "$DEPLOY_RESP" \
               | jq -r '.result[0:3][]? | "   - \(.id[:8]) / \(.latest_stage.status // "?") / \(.deployment_trigger.metadata.commit_hash[:7] // "?")"' \

--- a/scripts/validate_deployment.py
+++ b/scripts/validate_deployment.py
@@ -477,8 +477,12 @@ class DeploymentValidator:
 
         # Find all HTML files, excluding non-page artefacts that shouldn't ship
         # the tracker (RSS feeds are XML masquerading as .html, embeds run in
-        # iframes without analytics, sitemaps are crawler-only).
-        SKIP_PATTERNS = ('feed/', '/embed/', 'sitemap')
+        # iframes without analytics, sitemaps are crawler-only) and pages
+        # that get *generated after* this validator runs (stats and changelog
+        # are emitted directly into public/ post-validate — verified manually
+        # on production that the Plausible tag is present, so these warnings
+        # were spurious).
+        SKIP_PATTERNS = ('feed/', '/embed/', 'sitemap', 'stats/', 'changelog/')
         html_files = [
             f for f in self.site_dir.glob('**/*.html')
             if not any(pat in str(f) for pat in SKIP_PATTERNS)


### PR DESCRIPTION
## Summary

Follow-up to [#31](https://github.com/jameskilbynet/jkcoukblog/pull/31). The post-merge deploy ([run 26451916191](https://github.com/jameskilbynet/jkcoukblog/actions/runs/26451916191)) still spent 210 s in the KV-purge wait loop (vs. the projected ~30 s). Total build time dropped from 9 min to 8m 23s — only ~1 min of the projected ~4 min was actually saved.

## Root cause

I filtered the CF Pages deployments query by `$GITHUB_SHA`, but **`github.sha` is the commit that triggered the workflow** (the previous main HEAD). The deploy job itself pushes a *new* commit later in the same run, and Cloudflare Pages deploys *that* commit. So the polling loop was looking for a deployment Cloudflare never created and timed out every iteration:

```
⏳ Waiting for Cloudflare Pages deployment of d58a9a9 to complete...
   Deployment status: pending (attempt 1/18)
   ...
   Deployment status: pending (attempt 18/18)
⚠️  Deployment for d58a9a9 did not reach 'success' within timeout
   Last 3 deployments (id / status / commit) for debugging:
   Continuing with a 30s safety buffer before purge...
```

(Note: the debug dump printed an empty list — confirms `result[]` had no entry for `d58a9a9` because that SHA was never deployed; the deploy was for the newly-pushed auto-commit.)

## Fix

- **Commit and push** step now exports the post-push HEAD as a step output:
  ```yaml
  - name: Commit and push static site
    id: commit_push
    ...
        PUSHED_SHA=$(git rev-parse HEAD)
        echo "pushed_sha=$PUSHED_SHA" >> $GITHUB_OUTPUT
  ```
  Sets it to empty when there were no changes to commit.

- **Purge** step reads from `steps.commit_push.outputs.pushed_sha`. If empty (no content changed), skips the wait entirely — previous deployment is still live and the purge runs against it immediately. Otherwise polls for that exact `commit_hash`.

Expected: the loop now short-circuits in ~20-40 s once Pages picks up the push. Should finally deliver the ~4 min saving.

### Bonus fix: spurious Plausible warnings

The post-#31 validator still showed:
```
Pages with Plausible: 179/181 (98.9%)
- Missing Plausible: stats/index.html
- Missing Plausible: changelog/index.html
```

Verified via `curl`:
```
$ curl -s https://jameskilby.co.uk/stats/ | grep -o '<script[^>]*plausible[^>]*>'
<script defer data-cfasync="false" data-domain="jameskilby.co.uk" src="https://plausible.jameskilby.cloud/js/script.js"></script>
$ curl -s https://jameskilby.co.uk/changelog/ | grep -o '<script[^>]*plausible[^>]*>'
<script defer data-cfasync="false" data-domain="jameskilby.co.uk" src="https://plausible.jameskilby.cloud/js/script.js"></script>
```

Production has the tag. Why the warning? `stats/` and `changelog/` are generated by their own scripts that write **directly into `public/`** AFTER `validate_deployment.py` runs against `static-output/`. The validator sees the stale seed files from the previous deploy.

Added both paths to the existing `SKIP_PATTERNS` in `validate_deployment.py` so we stop emitting the false positives.

## Test plan

- [x] YAML parses cleanly; `validate_deployment.py` compiles
- [x] Manually confirmed via curl that production has Plausible on /stats/, /changelog/, /404.html
- [ ] After merge, watch the next deploy. Expected: build drops to ~4 min (from 8m 23s); KV-purge step logs `Deployment status: active → success` and breaks out in 1-3 attempts; validator no longer flags stats/changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)