### PR TITLE
ci: dump full CF Pages API response when KV-purge wait times out

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -1042,10 +1042,29 @@ jobs:
           done
           if [ "$DEPLOY_STATUS" != "success" ]; then
             echo "⚠️  Deployment for ${PUSHED_SHA:0:7} did not reach 'success' within timeout"
-            echo "   Last 3 deployments (id / status / commit) for debugging:"
+            echo "   Diagnosing — these are the bits the previous debug block silently swallowed:"
+            echo
+            echo "   [a] CF API success flag + error array:"
             printf '%s' "$DEPLOY_RESP" \
-              | jq -r '.result[0:3][]? | "   - \(.id[:8]) / \(.latest_stage.status // "?") / \(.deployment_trigger.metadata.commit_hash[:7] // "?")"' \
-              2>/dev/null || echo "   (unable to parse API response)"
+              | jq '{success, errors, messages, result_count: (.result | length? // 0)}' \
+                  2>&1 | sed 's/^/       /'
+            echo
+            echo "   [b] First 3 deployments returned (id / status / commit / created):"
+            printf '%s' "$DEPLOY_RESP" \
+              | jq -r '
+                  .result[0:3][]? as $d
+                  | "       - \($d.id[:8]) / \($d.latest_stage.name // "?"):\($d.latest_stage.status // "?") / \($d.deployment_trigger.metadata.commit_hash[:7] // "?") / \($d.created_on // "?")"
+                ' 2>&1
+            echo
+            echo "   [c] Did *any* returned deployment match $PUSHED_SHA?"
+            printf '%s' "$DEPLOY_RESP" \
+              | jq -r --arg sha "$PUSHED_SHA" \
+                  '[.result[]? | select(.deployment_trigger.metadata.commit_hash == $sha)] | "       matches: \(length)"' \
+                  2>&1
+            echo
+            echo "   [d] Raw response preview (first 600 chars):"
+            printf '%s' "${DEPLOY_RESP:0:600}" | sed 's/^/       /'
+            echo
             echo "   Continuing with a 30s safety buffer before purge..."
             sleep 30
           fi


### PR DESCRIPTION
## Why

After [#32](https://github.com/jameskilbynet/jkcoukblog/pull/32) landed, the post-merge deploy ([run 26455505736](https://github.com/jameskilbynet/jkcoukblog/actions/runs/26455505736)) still timed out the KV-purge wait — 8m 22s build, basically no savings. `PUSHED_SHA` is correctly captured (`📌 Pushed commit: 1b49fdd4...`), and the purge step uses it (`⏳ Waiting for Cloudflare Pages deployment of 1b49fdd...`), but Cloudflare's API never returns it as `success`.

The existing debug block printed nothing because:
```bash
printf '%s' "$DEPLOY_RESP" | jq -r '.result[0:3][]?...' 2>/dev/null || echo "(unable to parse)"
```
**jq exits 0 even when its filter selects nothing**, so `||` never fired, `2>/dev/null` ate any errors, and we got a 10ms gap between "Last 3 deployments:" and "Continuing with a 30s safety buffer". Pure black box.

## Change

When the polling loop times out, now dump four bits of diagnostic info:
- `[a]` `{success, errors, messages, result_count}` — tells us if auth/scope is the issue
- `[b]` first 3 deployments with stage name + status + commit + `created_on`
- `[c]` explicit `length` of deployments whose `commit_hash` equals `$PUSHED_SHA`
- `[d]` raw response preview (first 600 chars) — last resort if jq itself is failing

No behaviour change in the control flow — purge still happens after the safety buffer. This is purely so the *next* timeout actually tells us what went wrong.

## Hypotheses I want to confirm/rule out

1. CF API token missing `Pages:Read` scope → `result` array missing/empty
2. Deployment creation legitimately takes >180s → response shows our SHA but in `building`/`active` stage longer than expected
3. `per_page=10` not enough because of preview/branch deployments → our SHA is at index 11+
4. JSON shape changed → `latest_stage.status` lives somewhere else now

## Test plan

- [x] YAML still parses
- [ ] After merge, trigger a deploy. Read the `[a]`/`[b]`/`[c]`/`[d]` blocks in the KV-purge step log. Fix the real root cause based on what we see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)