### PR TITLE
perf: trim search-index.json (drop unused fields, scope content)

### DIFF
--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -4386,54 +4386,39 @@ document.addEventListener('DOMContentLoaded', function() {
                         words = content_text.split()
                         description = ' '.join(words[:150]) + ('...' if len(words) > 150 else '')
                 
-                # Extract full content for searching (limit to 1000 chars)
-                # Remove script and style elements
+                # Extract full content for searching (limit to 1000 chars).
+                # Scope to <main>/<article> first — the previous "strip nav/
+                # footer" approach left Kadence site-chrome ("Skip to content
+                # James Kilby Toggle Menu...") at the front of every entry,
+                # bloating the index by ~40 KB and matching every search.
                 content_soup = BeautifulSoup(html_content, 'html.parser')
-                for script in content_soup(["script", "style", "nav", "footer"]):
-                    script.decompose()
-                
-                full_content = content_soup.get_text()
+                content_root = (
+                    content_soup.find('main')
+                    or content_soup.find('article')
+                    or content_soup  # fall back to whole doc on list pages
+                )
+                for junk in content_root(["script", "style", "nav", "footer", "header"]):
+                    junk.decompose()
+
+                full_content = content_root.get_text()
                 # Clean up whitespace
                 lines = (line.strip() for line in full_content.splitlines())
                 chunks = (phrase.strip() for line in lines for phrase in line.split("  "))
                 full_content = ' '.join(chunk for chunk in chunks if chunk)
-                
+
                 # Skip if content is too short (likely navigation pages)
                 if len(full_content.split()) < 50:
                     continue
-                
-                # Extract categories and tags
-                categories = []
-                tags = []
-                
-                # Look for category and tag links
-                cat_links = soup.find_all('a', href=re.compile(r'/category/'))
-                for link in cat_links:
-                    cat_text = link.get_text().strip()
-                    if cat_text and cat_text not in categories:
-                        categories.append(cat_text)
-                
-                tag_links = soup.find_all('a', href=re.compile(r'/tag/'))
-                for link in tag_links:
-                    tag_text = link.get_text().strip()
-                    if tag_text and tag_text not in tags:
-                        tags.append(tag_text)
-                
-                # Extract date
-                date = ""
-                date_elem = soup.find('time', class_=re.compile(r'(entry-date|published)', re.I))
-                if date_elem:
-                    date = date_elem.get('datetime', '') or date_elem.get_text().strip()
-                
-                # Create search entry
+
+                # Create search entry. Only fields actually consumed by
+                # scripts/search.js (Fuse keys + display). The previous version
+                # shipped `categories`/`tags`/`date` which were never read by
+                # the UI — ~24 KB / 12 % of payload for nothing.
                 entry = {
                     'title': title,
                     'url': f"{self.target_domain}{url_path}",
-                    'description': description[:200] if description else '',  # Limit description length
-                    'content': full_content[:1000],  # Limit content for searching
-                    'categories': categories,
-                    'tags': tags,
-                    'date': date
+                    'description': description[:200] if description else '',
+                    'content': full_content[:1000],
                 }
                 
                 search_index.append(entry)


### PR DESCRIPTION
## Summary

`search-index.json` was 238 KB raw / 217 KB minified for 170 entries (~1.4 KB / entry). Two improvements:

### 1. Drop fields the search UI never reads
[`scripts/search.js`](scripts/search.js) uses Fuse with `keys=['title', 'description', 'content']` and displays `title` + `description` + `url`. The index was also shipping `categories`, `tags`, and `date` — confirmed unused. **~24 KB / 12 % of payload removed.**

### 2. Scope content extraction to `<main>` / `<article>`

Previous code grabbed text from the whole document then stripped `script/style/nav/footer`. But Kadence's site header sits inside `<header>` with class wrappers — not `<nav>` — so "Skip to content James Kilby Toggle Menu..." bled into every entry. This polluted search matches *and* consumed the 1000-char content quota with chrome instead of actual post body.

Verified locally:

**Homepage `content`:**
- Before: `"James Kilby - James Kilby's technical blog covering VMware..."` (mostly title repeated)
- After: `"VMWARE VEXPERT · HOMELAB · INFRASTRUCTURE-AS-CODE Field notes from a homelab that costs real money to run..."`

**Post page `content`:**
- Before: started with site title + nav
- After: `"📅Published: April 11, 2025 • Updated: May 25, 2026 Warp is helping me run my homelab..."`

The 1000-char quota now buys real content, not navigation text.

## Expected impact

- File size: -24 KB (~12 %) just from dropped fields
- Search relevance: meaningfully better — the term "James Kilby" used to appear in *every* entry's content because of the site header
- Single 24 KB request shaved off pages that trigger search

## Test plan

- [x] `search.js` grep confirms removed fields are unused
- [x] Re-extraction against real homepage + a post produces clean post body
- [x] Generator script compiles
- [ ] After merge + deploy, confirm `curl https://jameskilby.co.uk/search-index.min.json | wc -c` is meaningfully smaller (was 217 KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)