### PR TITLE
ci: close 4 loose ends from the deploy-log review (#2/#3/#6/#7)

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -180,7 +180,11 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: .build-cache.json
-        key: incremental-build-cache-${{ github.run_id }}
+        # Include run_attempt so re-runs of the same workflow (e.g. after a
+        # validation failure + retry) don't try to reserve a cache key that
+        # the failed attempt already owns. The restore-keys wildcard still
+        # finds the most recent previous build, so incrementality survives.
+        key: incremental-build-cache-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
           incremental-build-cache-
 
@@ -440,7 +444,10 @@ jobs:
       uses: actions/cache/save@v5
       with:
         path: .build-cache.json
-        key: incremental-build-cache-${{ github.run_id }}
+        # Must match the restore key above — include run_attempt so re-runs
+        # don't fail with "Unable to reserve cache with key ... — another
+        # job may be creating this cache" against their own prior attempt.
+        key: incremental-build-cache-${{ github.run_id }}-${{ github.run_attempt }}
 
     - name: Export to Markdown
       run: |

--- a/scripts/content_validator.py
+++ b/scripts/content_validator.py
@@ -152,13 +152,26 @@ class ContentValidator:
         # H1 tags (skip for RSS/Atom feed files — they have no H1 by design)
         rel = str(file_path)
         is_feed = 'feed' in rel.lower()
+        # Pagination archive pages (/page/2/, /page/3/, …) are WP-rendered
+        # list pages — WordPress doesn't emit an H1 because they're a
+        # listing of posts, not a content page. Downgrading these from a
+        # "critical error" to a warning matches reality. Real content
+        # pages still fail when missing H1.
+        is_pagination_archive = re.search(r'/page/\d+/index\.html$', rel) is not None
         h1_tags = soup.find_all('h1')
         if len(h1_tags) == 0 and not is_feed:
-            self.errors.append({
-                'type': 'seo_no_h1',
-                'file': str(file_path),
-                'message': 'Missing H1 tag'
-            })
+            if is_pagination_archive:
+                self.warnings.append({
+                    'type': 'seo_no_h1_archive',
+                    'file': str(file_path),
+                    'message': 'Missing H1 on paginated archive page (low priority)'
+                })
+            else:
+                self.errors.append({
+                    'type': 'seo_no_h1',
+                    'file': str(file_path),
+                    'message': 'Missing H1 tag'
+                })
         elif len(h1_tags) > 1:
             self.warnings.append({
                 'type': 'seo_multiple_h1',

--- a/scripts/ollama_spell_checker.py
+++ b/scripts/ollama_spell_checker.py
@@ -157,15 +157,20 @@ If no actual errors, return: {{"has_errors": false, "errors": []}}
                 
                 return {'has_errors': False, 'errors': []}
             else:
+                # API reachable but returned non-200. Distinguish from "no
+                # errors found" so the spell-check step can surface real
+                # connectivity failures rather than reporting "✅ All
+                # candidates were false positives" (the current behaviour
+                # silently masked an Ollama 404 for weeks).
                 print(f"❌ Ollama API error: {response.status_code}")
-                return {'has_errors': False, 'errors': []}
-                
+                return {'has_errors': False, 'errors': [], 'ollama_unreachable': True}
+
         except requests.exceptions.RequestException as e:
             print(f"⚠️  Ollama connection error: {str(e)}")
-            return {'has_errors': False, 'errors': []}
+            return {'has_errors': False, 'errors': [], 'ollama_unreachable': True}
         except Exception as e:
             print(f"⚠️  Unexpected error: {str(e)}")
-            return {'has_errors': False, 'errors': []}
+            return {'has_errors': False, 'errors': [], 'ollama_unreachable': True}
     
     def extract_text_from_html(self, html_content: str, post_title: str = '', post_excerpt: str = '') -> List[Tuple[str, str]]:
         """
@@ -305,7 +310,21 @@ If no actual errors, return: {{"has_errors": false, "errors": []}}
                 full_text += f"{text}\n\n"
             
             result = self.check_with_ollama_batched(full_text, all_candidate_errors)
-            
+
+            # Propagate "Ollama is down" up the call stack instead of
+            # masquerading as "no errors found". Without this, the calling
+            # script reports "✅ All candidates were false positives" when
+            # the API is actually 404'ing — a silent dependency failure.
+            if result.get('ollama_unreachable'):
+                return {
+                    'post_id': post_id,
+                    'title': post_title,
+                    'link': post_link,
+                    'ollama_unreachable': True,
+                    'errors': [],
+                    'has_errors': False,
+                }
+
             all_errors = []
             if result.get('has_errors'):
                 errors_found = result.get('errors', [])
@@ -487,24 +506,46 @@ def main():
     
     # Check posts
     results = checker.check_recent_posts(count=post_count, since=since_timestamp)
-    
+
     # Generate report
     if results:
         report = checker.generate_report(results)
-        
+
         # Save report
         report_file = Path('spelling_check_report.md')
         report_file.write_text(report)
-        
+
         print("\n" + "=" * 60)
         print(f"📊 Report saved to: {report_file}")
         print()
         print(report)
-        
-        # Exit with error code if errors found
+
+        # Differentiate three end-states so the surrounding CI step can
+        # tell "Ollama is down" apart from "Ollama checked and found
+        # nothing". Previously both ended on `sys.exit(0)` with a green
+        # "✅ No spelling errors found!" — masking weeks-long upstream
+        # outages.
+        ollama_down_count = sum(1 for r in results if r.get('ollama_unreachable'))
         if any(r.get('has_errors') for r in results):
             print("\n⚠️  Spelling errors found! Please review the report.")
             sys.exit(1)
+        elif ollama_down_count == len(results):
+            # Every post failed for the same upstream reason — Ollama is
+            # off the network. Non-fatal (we don't want to block deploys
+            # just because the LLM host is unreachable), but loud.
+            print(
+                f"\n⚠️  Ollama API was unreachable for all {len(results)} posts — "
+                "spell-check did NOT run. Check OLLAMA_URL / OLLAMA_API_CREDENTIALS."
+            )
+            sys.exit(2)
+        elif ollama_down_count:
+            # Partial outage — flag it but report what we got.
+            print(
+                f"\n⚠️  Ollama API was unreachable for {ollama_down_count}/"
+                f"{len(results)} posts. Remaining {len(results) - ollama_down_count} "
+                "checked successfully — no errors found."
+            )
+            sys.exit(0)
         else:
             print("\n✅ No spelling errors found!")
             sys.exit(0)

--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -71,8 +71,13 @@ class WordPressStaticGenerator:
             # Check if we need to rebuild archives
             if changed_posts or changed_pages or self.incremental_builder.should_rebuild_archives():
                 print("   🔄 Rebuilding archive pages...")
-                # Add essential pages and archives
-                urls.update(['/', '/category/', '/tag/'])
+                # Add essential pages and archives. Per-category/per-tag URLs
+                # are added below from the taxonomy listing; the bare
+                # `/category/` and `/tag/` paths used to be in here too but
+                # WordPress 404s them (they're not real pages, just taxonomy
+                # roots), producing two failures per build that obscured
+                # real errors.
+                urls.add('/')
                 
                 # Get all categories and tags (archives need full list)
                 categories_response = self.session.get(f'{self.wp_url}/wp-json/wp/v2/categories?per_page=100')
@@ -204,9 +209,12 @@ class WordPressStaticGenerator:
                     urls.add(relative_url)
                     print(f"   🏷️  Tag: {tag['name']}")
         
-        # Add essential pages
-        essential_urls = ['/', '/category/', '/tag/']
-        urls.update(essential_urls)
+        # Add essential pages. `/category/` and `/tag/` used to be in here
+        # too but WordPress 404s those bare taxonomy roots (only the
+        # individual `/category/<slug>/` and `/tag/<slug>/` URLs are real),
+        # producing two ❌ Failed entries on every build that masked real
+        # download errors.
+        urls.add('/')
 
         # Discover homepage pagination pages (/page/2/, /page/3/, etc.)
         print("   🔍 Discovering homepage pagination pages...")


### PR DESCRIPTION
## Summary

Four small, independent fixes from the original deploy-log audit. One PR for housekeeping.

### #2 — Incremental cache key collides on workflow re-runs

[`.github/workflows/deploy-static-site.yml`](.github/workflows/deploy-static-site.yml)

Restore/save steps keyed on `incremental-build-cache-${{ github.run_id }}`. When GitHub re-runs a failed workflow (e.g. after the validation-failure retry earlier in this session), `run_id` is constant and the second attempt can't reserve the key the first attempt already owns:

```
Failed to save: Unable to reserve cache with key
incremental-build-cache-26440728316, another job may be creating this cache.
##[warning]Cache save failed.
```

Append `${{ github.run_attempt }}`. The `restore-keys` wildcard still matches older builds, so incrementality survives across attempts.

### #6 — `/category/` and `/tag/` 404 every build

[`scripts/wp_to_static_generator.py`](scripts/wp_to_static_generator.py)

Two paths were hardcoded into the URLs-to-fetch list (lines 75 + 213). WordPress doesn't render the bare taxonomy roots — only `/category/<slug>/` and `/tag/<slug>/` URLs are real pages. Result: two `❌ Failed:` entries on every deploy log, polluting the signal:

```
📊 Processing Results:
   ✅ Success: 100
   ❌ Failed: 2
      ⚠️  /category/ (404 - skipped)
      ⚠️  /tag/ (404 - skipped)
```

Individual category and tag URLs come from the taxonomy listing loop just above, so no archive content is lost.

### #3 — Paginated archive pages flagged "Missing H1" critical

[`scripts/content_validator.py`](scripts/content_validator.py)

The validator treated `<h1>` absence as critical, but `/page/2/`…`/page/6/` are list pages that legitimately don't have an H1 (just a stream of post excerpts). Five "critical errors" per build, all on pages that don't need an H1, on a non-blocking step:

```
📋 Content Validation Report
==================================================
Status: ❌ FAIL
Errors: 5
…
❌ Critical Errors (5):
   1. Missing H1 tag — static-output/page/6/index.html
   2. Missing H1 tag — static-output/page/3/index.html
   …
⚠️  Content validation found issues (non-blocking)
```

i.e. the report status was a lie. Downgrade missing-H1 specifically for `/page/N/index.html` paths to a warning (new type `seo_no_h1_archive`). Regular content pages still error as before.

### #7 — Ollama spell-check silently masquerades as success

[`scripts/ollama_spell_checker.py`](scripts/ollama_spell_checker.py)

The script returned `{'has_errors': False}` for BOTH "Ollama unreachable" and "Ollama reachable but found nothing." CI reported the same `✅ All candidates were false positives` for both, so a real 404 from the LLM host went undetected:

```
❌ Ollama API error: 404
   ✅ All candidates were false positives
```

Add an `ollama_unreachable` flag in the API wrapper, propagate up to `main()`, and exit with code 2 + a clear banner when ALL posts failed for that reason. Partial outages stay non-blocking but get surfaced in the summary.

## Test plan

- [x] All 4 Python files compile
- [x] Workflow YAML parses
- [x] Unit-fixture: `/page/3/index.html` with no H1 → 0 errors, 1 `seo_no_h1_archive` warning
- [x] Unit-fixture: regular `/2025/04/foo/index.html` with no H1 → still errors with `seo_no_h1`
- [ ] After merge + next deploy: confirm
  - `Cache restored` step uses new key with run_attempt suffix
  - Deploy log shows `❌ Failed: 0` (not 2) in the generator results
  - Content validator status is `✅ PASS` instead of `❌ FAIL` (the 5 paginated false-positives now sit in warnings)
  - Spell-check step distinguishes "Ollama unreachable" from "no errors"

🤖 Generated with [Claude Code](https://claude.com/claude-code)