### PR TITLE
ci: Lighthouse PR gate against Cloudflare Pages preview URL

### DIFF
--- a/.github/lighthouse/README.md
+++ b/.github/lighthouse/README.md
@@ -1,0 +1,55 @@
+# Lighthouse CI configuration
+
+Two passes — desktop and mobile — share the same code paths in
+[`quality-checks.yml`](../workflows/quality-checks.yml) (scheduled +
+push, against production) and
+[`lighthouse-pr.yml`](../workflows/lighthouse-pr.yml) (every PR,
+against the CF Pages preview URL).
+
+| Pass | Config | Budget | Behaviour |
+|------|--------|--------|-----------|
+| Desktop | `lighthouse-config.json`        | `budget.json`        | Fast Wi-Fi (10 Mbps), no CPU throttle, 1350×940 viewport |
+| Mobile  | `lighthouse-config-mobile.json` | `budget-mobile.json` | Slow-4G (1.6 Mbps), 4× CPU slowdown, 360×640 viewport     |
+
+## Why these timing budgets
+
+After the May-2026 perf work the site lands at LCP ~530 ms / total
+transfer ~940 KB in GTmetrix terms — Lighthouse measures around
+800–1000 ms LCP under its desktop throttling profile.
+
+The desktop budget sits **~50 %** above current measured state so
+normal Lighthouse run-to-run variance stays green but a real
+regression (LCP +300 ms or bigger) fails the check. Bump down when
+measured performance improves; bump up only with a recorded reason
+in the commit message.
+
+The mobile budget is **2–3×** looser than desktop because slow-4G +
+4× CPU throttling roughly doubles real timings. The mobile targets
+align with Google's "Good" Core Web Vitals thresholds (LCP < 2500 ms,
+CLS < 0.1, TBT < 200 ms with tolerance).
+
+## Resource budgets
+
+Identical between desktop and mobile — assets don't change between
+form factors, only the timing of fetching/parsing them does.
+
+| Resource type | Budget (KB) |
+|--------------|-------------|
+| document     |  30 |
+| stylesheet   |  80 |
+| script       |  70 |
+| image        | 250 |
+| font         | 200 (intentionally loose, will tighten to ~80 once font subsetting has been live for a deploy or two) |
+| third-party  |  60 |
+| **total**    | **800** |
+
+## What NOT to put in these JSON files
+
+Lighthouse CI validates budget JSON strictly: `Budget has unrecognized
+properties: [...]`. Comments inside the JSON (`_comment_about_this_file`,
+`$schema`, etc.) cause the assertion step to crash silently — the
+workflow appears green but no budgets are actually enforced.
+
+Document changes here in this README. Recorded by PR #42 after a
+fixed silent-failure of the budget assertion that masked weeks of
+unenforced gates.

--- a/.github/lighthouse/budget-mobile.json
+++ b/.github/lighthouse/budget-mobile.json
@@ -1,0 +1,31 @@
+[
+  {
+    "_comment_about_this_file": "Lighthouse CI budget for the MOBILE pass. Slow-4G + 4× CPU throttling typically lands well-optimised sites at LCP 1500-2500 ms — significantly slower than desktop (which sits at ~530 ms for this site). These budgets target Google's 'Good' Core Web Vitals thresholds (LCP < 2500, CLS < 0.1, INP/TBT < 200) with headroom for Lighthouse's run-to-run variance under throttling. Resource sizes are shared with the desktop budget (assets don't change between form factors). See .github/lighthouse/budget.json for the desktop counterpart.",
+    "path": "/*",
+    "timings": [
+      { "metric": "first-contentful-paint",   "budget": 2000, "tolerance": 600 },
+      { "metric": "largest-contentful-paint", "budget": 2500, "tolerance": 800 },
+      { "metric": "interactive",              "budget": 3500, "tolerance": 1000 },
+      { "metric": "first-meaningful-paint",   "budget": 2000, "tolerance": 600 },
+      { "metric": "speed-index",              "budget": 3000, "tolerance": 800 },
+      { "metric": "total-blocking-time",      "budget":  500, "tolerance": 200 },
+      { "metric": "cumulative-layout-shift",  "budget": 0.05, "tolerance": 0.05 }
+    ],
+    "resourceSizes": [
+      { "resourceType": "document",    "budget":  30 },
+      { "resourceType": "stylesheet",  "budget":  80 },
+      { "resourceType": "script",      "budget":  70 },
+      { "resourceType": "image",       "budget": 250 },
+      { "resourceType": "font",        "budget": 200 },
+      { "resourceType": "third-party", "budget":  60 },
+      { "resourceType": "total",       "budget": 800 }
+    ],
+    "resourceCounts": [
+      { "resourceType": "stylesheet",  "budget":  8 },
+      { "resourceType": "script",      "budget": 10 },
+      { "resourceType": "image",       "budget": 20 },
+      { "resourceType": "font",        "budget":  6 },
+      { "resourceType": "third-party", "budget":  6 }
+    ]
+  }
+]

--- a/.github/lighthouse/budget-mobile.json
+++ b/.github/lighthouse/budget-mobile.json
@@ -1,6 +1,5 @@
 [
   {
-    "_comment_about_this_file": "Lighthouse CI budget for the MOBILE pass. Slow-4G + 4× CPU throttling typically lands well-optimised sites at LCP 1500-2500 ms — significantly slower than desktop (which sits at ~530 ms for this site). These budgets target Google's 'Good' Core Web Vitals thresholds (LCP < 2500, CLS < 0.1, INP/TBT < 200) with headroom for Lighthouse's run-to-run variance under throttling. Resource sizes are shared with the desktop budget (assets don't change between form factors). See .github/lighthouse/budget.json for the desktop counterpart.",
     "path": "/*",
     "timings": [
       { "metric": "first-contentful-paint",   "budget": 2000, "tolerance": 600 },

--- a/.github/lighthouse/budget.json
+++ b/.github/lighthouse/budget.json
@@ -1,6 +1,5 @@
 [
   {
-    "_comment_about_this_file": "Lighthouse CI budget. The previous values (LCP 2500 ms, total 1000 KB) were so loose they accepted nearly any regression. After the perf work in May 2026 the site lands at LCP ~530 ms / total ~940 KB in GTmetrix terms — Lighthouse measures around 800-1000 ms LCP under its own throttling profile. The values below sit ~50% above the current measured state so normal run-to-run variance stays green but a real regression (LCP +300 ms or bigger) fails the check. Bump these down when measured performance improves; bump up only with a recorded reason. See .github/workflows/quality-checks.yml for how this file gets consumed.",
     "path": "/*",
     "timings": [
       { "metric": "first-contentful-paint",   "budget": 1000, "tolerance": 300 },

--- a/.github/lighthouse/lighthouse-config-mobile.json
+++ b/.github/lighthouse/lighthouse-config-mobile.json
@@ -1,0 +1,30 @@
+{
+  "_comment_about_this_file": "Lighthouse CI config for the MOBILE pass. Companion to lighthouse-config.json (desktop). Uses Lighthouse's default mobile profile: 1.6 Mbps slow-4G + 750 Kbps up + 150 ms RTT + 4× CPU slowdown + 360×640 viewport. Real-world conditions for the ~50% of visitors who hit the site on a phone. Mobile measurements are 2-3× slower than desktop even for a well-optimised site, so the budget file (.github/lighthouse/budget-mobile.json) sets correspondingly looser thresholds.",
+  "ci": {
+    "collect": {
+      "settings": {
+        "onlyCategories": ["performance", "accessibility", "best-practices", "seo"],
+        "formFactor": "mobile",
+        "screenEmulation": {
+          "mobile": true,
+          "width": 360,
+          "height": 640,
+          "deviceScaleFactor": 2,
+          "disabled": false
+        },
+        "throttling": {
+          "rttMs": 150,
+          "throughputKbps": 1638.4,
+          "cpuSlowdownMultiplier": 4,
+          "requestLatencyMs": 0,
+          "downloadThroughputKbps": 1638.4,
+          "uploadThroughputKbps": 750
+        },
+        "skipAudits": [
+          "uses-http2",
+          "canonical"
+        ]
+      }
+    }
+  }
+}

--- a/.github/lighthouse/lighthouse-config-mobile.json
+++ b/.github/lighthouse/lighthouse-config-mobile.json
@@ -1,5 +1,4 @@
 {
-  "_comment_about_this_file": "Lighthouse CI config for the MOBILE pass. Companion to lighthouse-config.json (desktop). Uses Lighthouse's default mobile profile: 1.6 Mbps slow-4G + 750 Kbps up + 150 ms RTT + 4× CPU slowdown + 360×640 viewport. Real-world conditions for the ~50% of visitors who hit the site on a phone. Mobile measurements are 2-3× slower than desktop even for a well-optimised site, so the budget file (.github/lighthouse/budget-mobile.json) sets correspondingly looser thresholds.",
   "ci": {
     "collect": {
       "settings": {

--- a/.github/workflows/lighthouse-pr.yml
+++ b/.github/workflows/lighthouse-pr.yml
@@ -113,9 +113,13 @@ jobs:
             echo "preview_url=" >> $GITHUB_OUTPUT
           fi
 
-      - name: Run Lighthouse CI against preview
-        # No continue-on-error here — this step IS the gate. If the budget
-        # is exceeded, the PR check fails (which is the point).
+      # Two Lighthouse passes: desktop (fast Wi-Fi + no CPU throttle) and
+      # mobile (slow-4G + 4× CPU). Each has its own budget file because
+      # mobile measurements are 2-3× slower than desktop even for a
+      # well-optimised site. Both block the PR on regression — there's no
+      # continue-on-error here, this IS the gate.
+
+      - name: Lighthouse CI — DESKTOP pass against preview
         if: steps.pages_preview.outputs.preview_url != ''
         uses: treosh/lighthouse-ci-action@v11
         with:
@@ -125,6 +129,19 @@ jobs:
           temporaryPublicStorage: true
           budgetPath: .github/lighthouse/budget.json
           configPath: .github/lighthouse/lighthouse-config.json
+          artifactName: lighthouse-desktop-${{ github.event.pull_request.number }}
+
+      - name: Lighthouse CI — MOBILE pass against preview
+        if: steps.pages_preview.outputs.preview_url != ''
+        uses: treosh/lighthouse-ci-action@v11
+        with:
+          urls: ${{ steps.pages_preview.outputs.preview_url }}
+          runs: 3
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+          budgetPath: .github/lighthouse/budget-mobile.json
+          configPath: .github/lighthouse/lighthouse-config-mobile.json
+          artifactName: lighthouse-mobile-${{ github.event.pull_request.number }}
 
       - name: Step summary
         if: always()
@@ -135,11 +152,13 @@ jobs:
             if [ -n "${{ steps.pages_preview.outputs.preview_url }}" ]; then
               echo "**Tested URL:** ${{ steps.pages_preview.outputs.preview_url }}"
               echo ""
-              echo "**Budget:** \`.github/lighthouse/budget.json\` "
-              echo "(LCP ≤ 1200ms, FCP ≤ 1000ms, total transfer ≤ 800 KB, …)"
+              echo "Two passes, each runs Lighthouse 3 times and takes the median."
+              echo "A regression past either budget fails this check."
               echo ""
-              echo "Lighthouse runs 3 passes against the preview and takes the"
-              echo "median. A regression past the budget fails this check."
+              echo "| Pass | Profile | Budget | LCP target |"
+              echo "|------|---------|--------|------------|"
+              echo "| Desktop | Fast Wi-Fi, no CPU throttle | \`budget.json\`        | ≤ 1200 ms |"
+              echo "| Mobile  | Slow-4G, 4× CPU slowdown     | \`budget-mobile.json\` | ≤ 2500 ms |"
             else
               echo "⚠️  **Skipped** — no Cloudflare Pages preview was reachable."
               echo ""

--- a/.github/workflows/lighthouse-pr.yml
+++ b/.github/workflows/lighthouse-pr.yml
@@ -1,0 +1,153 @@
+name: Lighthouse PR Preview Gate
+
+# Why this exists
+# ----------------
+# .github/workflows/quality-checks.yml already runs Lighthouse, but against
+# the PRODUCTION URL — i.e. it only sees a regression *after* the PR has
+# merged and the auto-pipeline has shipped it. That's useful as a daily
+# trend signal but useless as a "block bad PRs" gate.
+#
+# This workflow targets the Cloudflare Pages PREVIEW deployment that CF
+# auto-builds for every PR. Each PR gets its own `https://<sha>.jkcoukblog
+# .pages.dev` URL. We poll the CF Pages API for the deployment matching
+# the PR head SHA, then run Lighthouse against it. A regression past the
+# budget in .github/lighthouse/budget.json fails this check, blocking the
+# PR before it can merge.
+#
+# Fork PRs (github.event.pull_request.head.repo.full_name !=
+# github.repository) don't have access to secrets — they're skipped
+# entirely. This codebase is single-author so that's the practical state.
+
+on:
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  contents: read
+  pull-requests: write  # so the step summary can be posted to the PR
+
+jobs:
+  lighthouse-pr:
+    name: Lighthouse (PR preview)
+    runs-on: ubuntu-latest
+    # Skip for fork PRs — they can't read the CLOUDFLARE_API_TOKEN secret.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Wait for Cloudflare Pages preview deployment
+        id: pages_preview
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ] || [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "ℹ️  Cloudflare API credentials not set — skipping Lighthouse PR gate."
+            echo "preview_url=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "⏳ Waiting for Cloudflare Pages preview of ${PR_SHA:0:7}..."
+          # 60 × 10 s = 10 min. CF Pages typically builds in 30-90 s but
+          # larger content updates can stretch it; we'd rather wait than
+          # spuriously skip the gate.
+          MAX_ATTEMPTS=60
+          ATTEMPT=0
+          DEPLOY_RAW=""
+          STATUS=""
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            RESP=$(curl -sS \
+              -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+              "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/jkcoukblog/deployments?per_page=25")
+            # Pull the first deployment whose commit_hash matches the PR
+            # head SHA. CF Pages returns deployments newest-first.
+            DEPLOY_RAW=$(printf '%s' "$RESP" \
+              | jq -c --arg sha "$PR_SHA" \
+                  '[.result[]? | select(.deployment_trigger.metadata.commit_hash == $sha)] | .[0] // empty' \
+              2>/dev/null || true)
+
+            if [ -n "$DEPLOY_RAW" ] && [ "$DEPLOY_RAW" != "null" ]; then
+              STATUS=$(printf '%s' "$DEPLOY_RAW" | jq -r '.latest_stage.status // "?"')
+              PREVIEW_URL=$(printf '%s' "$DEPLOY_RAW" | jq -r '.url // ""')
+              echo "   Status: $STATUS (attempt $((ATTEMPT+1))/$MAX_ATTEMPTS) — $PREVIEW_URL"
+              case "$STATUS" in
+                success)
+                  if [ -z "$PREVIEW_URL" ] || [ "$PREVIEW_URL" = "null" ]; then
+                    echo "❌ Deployment reached 'success' but URL field is empty — bailing."
+                    echo "preview_url=" >> $GITHUB_OUTPUT
+                    exit 0
+                  fi
+                  echo "✅ Preview ready: $PREVIEW_URL"
+                  # Small propagation buffer so the assets are guaranteed
+                  # to be reachable from the runner before Lighthouse hits.
+                  sleep 10
+                  echo "preview_url=$PREVIEW_URL" >> $GITHUB_OUTPUT
+                  break
+                  ;;
+                failure|canceled)
+                  echo "❌ Pages deployment $STATUS for ${PR_SHA:0:7} — Lighthouse skipped"
+                  echo "   (CF Pages check itself will block the merge)"
+                  echo "preview_url=" >> $GITHUB_OUTPUT
+                  exit 0
+                  ;;
+              esac
+            else
+              echo "   No deployment yet for ${PR_SHA:0:7} (attempt $((ATTEMPT+1))/$MAX_ATTEMPTS)"
+            fi
+            ATTEMPT=$((ATTEMPT+1))
+            sleep 10
+          done
+
+          if [ -z "$DEPLOY_RAW" ] || [ "$DEPLOY_RAW" = "null" ]; then
+            echo "⚠️  No CF Pages deployment found for ${PR_SHA:0:7} after 10 min."
+            echo "    Skipping Lighthouse gate — CF Pages may not be configured to"
+            echo "    build previews for this branch, or the build is stuck."
+            echo "preview_url=" >> $GITHUB_OUTPUT
+          elif [ "$STATUS" != "success" ]; then
+            echo "⚠️  CF Pages deployment for ${PR_SHA:0:7} stuck at '$STATUS' after 10 min."
+            echo "    Skipping Lighthouse gate."
+            echo "preview_url=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run Lighthouse CI against preview
+        # No continue-on-error here — this step IS the gate. If the budget
+        # is exceeded, the PR check fails (which is the point).
+        if: steps.pages_preview.outputs.preview_url != ''
+        uses: treosh/lighthouse-ci-action@v11
+        with:
+          urls: ${{ steps.pages_preview.outputs.preview_url }}
+          runs: 3
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+          budgetPath: .github/lighthouse/budget.json
+          configPath: .github/lighthouse/lighthouse-config.json
+
+      - name: Step summary
+        if: always()
+        run: |
+          {
+            echo "## 🚦 Lighthouse PR Preview Gate"
+            echo ""
+            if [ -n "${{ steps.pages_preview.outputs.preview_url }}" ]; then
+              echo "**Tested URL:** ${{ steps.pages_preview.outputs.preview_url }}"
+              echo ""
+              echo "**Budget:** \`.github/lighthouse/budget.json\` "
+              echo "(LCP ≤ 1200ms, FCP ≤ 1000ms, total transfer ≤ 800 KB, …)"
+              echo ""
+              echo "Lighthouse runs 3 passes against the preview and takes the"
+              echo "median. A regression past the budget fails this check."
+            else
+              echo "⚠️  **Skipped** — no Cloudflare Pages preview was reachable."
+              echo ""
+              echo "Possible reasons:"
+              echo "- This is a fork PR (no secret access)"
+              echo "- CF Pages is still building / building failed"
+              echo "- \`CLOUDFLARE_API_TOKEN\` / \`CLOUDFLARE_ACCOUNT_ID\` not configured"
+              echo ""
+              echo "The scheduled Lighthouse-on-production check still runs daily."
+            fi
+          } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -78,7 +78,11 @@ jobs:
             echo "⚠️  Lighthouse config not found, will use defaults"
           fi
 
-      - name: Run Lighthouse CI (with configs)
+      # Two Lighthouse passes when configs exist: desktop (fast Wi-Fi) +
+      # mobile (slow-4G + 4× CPU). Real-world coverage — desktop alone
+      # misses mobile-specific regressions like overweight JS or fonts
+      # blocking the main thread on lower-powered devices.
+      - name: Run Lighthouse CI — DESKTOP (with configs)
         if: steps.check_configs.outputs.budget_exists == 'true' && steps.check_configs.outputs.config_exists == 'true'
         uses: treosh/lighthouse-ci-action@v11
         with:
@@ -89,8 +93,26 @@ jobs:
           temporaryPublicStorage: true
           budgetPath: .github/lighthouse/budget.json
           configPath: .github/lighthouse/lighthouse-config.json
+          artifactName: lighthouse-desktop-prod
 
-      - name: Run Lighthouse CI (without configs)
+      - name: Run Lighthouse CI — MOBILE (with configs)
+        if: |
+          steps.check_configs.outputs.budget_exists == 'true' &&
+          steps.check_configs.outputs.config_exists == 'true' &&
+          hashFiles('.github/lighthouse/budget-mobile.json') != '' &&
+          hashFiles('.github/lighthouse/lighthouse-config-mobile.json') != ''
+        uses: treosh/lighthouse-ci-action@v11
+        with:
+          urls: |
+            https://jameskilby.co.uk
+          runs: 3
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+          budgetPath: .github/lighthouse/budget-mobile.json
+          configPath: .github/lighthouse/lighthouse-config-mobile.json
+          artifactName: lighthouse-mobile-prod
+
+      - name: Run Lighthouse CI (without configs — fallback)
         if: steps.check_configs.outputs.budget_exists == 'false' || steps.check_configs.outputs.config_exists == 'false'
         uses: treosh/lighthouse-ci-action@v11
         with:


### PR DESCRIPTION
## Why

[`.github/workflows/quality-checks.yml`](.github/workflows/quality-checks.yml) already runs Lighthouse, but against **production** — useful for daily trend monitoring, useless as a "block bad PRs" gate (the regression is already shipped by the time it fires). It also only runs on PRs that change `public/**`, which essentially never happens for human-authored PRs.

This PR introduces:
1. A new workflow that targets the **per-PR Cloudflare Pages preview** that CF auto-builds for every commit, so a perf regression fails the PR check *before* it can merge.
2. A **mobile Lighthouse pass alongside the desktop one** in both the new PR workflow AND the existing scheduled production workflow. Mobile measurements are 2-3× slower than desktop and catch a different class of regression (overweight JS, fonts blocking the main thread on lower-powered devices).

## Coverage matrix

| Workflow | Target | Trigger | Profile(s) | Behaviour on regression |
|---|---|---|---|---|
| `quality-checks.yml` (existing, updated) | Production | Schedule + push to main + PR-touching-`public/**` | Desktop + Mobile | Reports trend |
| **`lighthouse-pr.yml`** (new) | PR's CF Pages preview | **Every PR** | **Desktop + Mobile** | **Blocks merge** |

Both workflows share the same budget files so thresholds stay in sync.

## Per-profile budgets

| Pass | Profile | LCP target | Budget file |
|---|---|---|---|
| Desktop | Fast Wi-Fi (10 Mbps), no CPU throttle | ≤ 1200 ms (current ~530 ms) | `.github/lighthouse/budget.json` |
| Mobile | Slow-4G (1.6 Mbps), 4× CPU slowdown | ≤ 2500 ms (Google "Good" CWV) | `.github/lighthouse/budget-mobile.json` |

Mobile resource budgets are intentionally identical to desktop — assets don't change between form factors. Only the timing thresholds differ.

## How the PR-time gate works

```
PR opened/pushed
   │
   ▼
.github/workflows/lighthouse-pr.yml runs
   │
   ├─ Skip if fork PR (no secrets) ────────────────► done
   │
   ├─ Poll CF Pages API for deployment matching
   │  pull_request.head.sha (up to 10 min)
   │     │
   │     ├─ commit not yet seen → retry 10s, up to 60×
   │     ├─ status: failure/canceled → skip (CF check blocks merge anyway)
   │     └─ status: success → continue
   │
   ├─ Lighthouse DESKTOP pass (budget.json)
   ├─ Lighthouse MOBILE pass (budget-mobile.json)
   │
   └─ Either budget breach fails the PR check
```

Total run time: ~3-4 min desktop + ~3-4 min mobile + ~30 s CF poll/buffer ≈ 7-8 min. The job timeout is 20 min so there's headroom.

## Polling tactics

Same approach as [PR #33](https://github.com/jameskilbynet/jkcoukblog/pull/33)'s KV-purge fix:
- Pull last 25 deployments, filter by `deployment_trigger.metadata.commit_hash == pull_request.head.sha`
- Wait up to 10 min for matching deployment to reach `latest_stage.status == "success"`
- Bail early on `failure` / `canceled` (CF's own check already blocks the merge)
- Skip gracefully if no deployment ever appears

## Edge cases handled

- **Fork PRs**: skipped via `if: github.event.pull_request.head.repo.full_name == github.repository`. Secrets aren't accessible to fork workflows. This codebase is single-author so practical impact is nil.
- **Missing CF credentials**: skip with a clear log line, don't fail.
- **CF Pages preview build failed**: skip with a clear log line — the CF Pages check itself will block the merge.
- **Mobile files removed**: the existing `quality-checks.yml` gates the mobile step on `hashFiles('.github/lighthouse/budget-mobile.json') != ''`, so deleting the mobile config files cleanly disables the mobile pass without breaking the workflow.

## Test plan

- [x] All YAML files parse
- [x] jq filter logic verified against simulated CF API responses (match + no-match cases)
- [x] Mobile + desktop config JSON files validate
- [ ] **After merge, this PR's own lighthouse-pr workflow won't run** (the workflow is defined on `main`, doesn't exist on this branch's PR build). The first real test will be the *next* PR after this lands — should poll for the new PR's preview URL and pass/fail both desktop and mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)