### PR TITLE
ci: --break-system-packages for the Playwright pip install

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -797,9 +797,17 @@ jobs:
         # Playwright + chromium aren't in requirements.txt because they
         # weigh ~150 MB and are only needed for this one step. Install
         # them here, idempotently (cached on the self-hosted runner).
+        #
+        # --break-system-packages is required on Ubuntu 24.04 (PEP 668).
+        # The runner Python is the system Python with EXTERNALLY-MANAGED
+        # set; pip refuses to install without an explicit override.
+        # Without the flag the step exits 1 immediately, the smoke tests
+        # never run, and the surrounding `continue-on-error: true` still
+        # lets the build succeed — which masks the regression-detection
+        # we added in #38.
         if ! python3 -c "import playwright" 2>/dev/null; then
           echo "📦 Installing Playwright Python..."
-          pip install playwright
+          pip install --break-system-packages playwright
         fi
         if [ ! -d "$HOME/.cache/ms-playwright" ] && [ ! -d "$HOME/Library/Caches/ms-playwright" ]; then
           echo "📦 Installing Chromium headless shell..."


### PR DESCRIPTION
## What

The Playwright smoke-tests step in `deploy-static-site.yml` (introduced in #38) has been failing on every deploy with PEP 668's externally-managed-environment error. Ubuntu 24.04 (the GitHub-hosted runner image) refuses `pip install` into the system Python without explicit opt-in.

From the latest deploy log:
```
note: If you believe this is a mistake, please contact your Python
      installation or OS distribution provider. You can override this,
      at the risk of breaking your Python installation or OS, by
      passing --break-system-packages.
##[error]Process completed with exit code 1.
```

The step has `continue-on-error: true` so the deploy itself isn't blocked, but **the smoke tests have never actually run** since #38 merged. The annotation we've all been ignoring on every deploy was masking it.

## Fix

Add `--break-system-packages` to the `pip install playwright` line. One-word change. We don't care about polluting the runner Python because each runner job is ephemeral.

```diff
-    pip install playwright
+    pip install --break-system-packages playwright
```

`playwright install --with-deps chromium` doesn't need the flag — it puts the browser under `~/.cache/ms-playwright`, not into Python's site-packages.

## Test plan

- [x] YAML still parses
- [ ] After merge + next deploy, look for `🧪 Interactive UI smoke tests against ./static-output` followed by `✅ Mobile menu drawer opens on tap` (and friends) in the Interactive UI smoke tests step. If the step still fails, the next layer to investigate is the chromium binary install.

## Note

Found while investigating PR [#42](https://github.com/jameskilbynet/jkcoukblog/pull/42), where the Lighthouse PR-gate also had a silent-failure issue (budget JSON comment field crashed assertion). Pattern worth noting: any CI step gated by `continue-on-error: true` that's never observed to actually succeed should be checked periodically — they accumulate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)