### PR TITLE
ci: drop --with-deps from playwright install

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -811,7 +811,14 @@ jobs:
         fi
         if [ ! -d "$HOME/.cache/ms-playwright" ] && [ ! -d "$HOME/Library/Caches/ms-playwright" ]; then
           echo "📦 Installing Chromium headless shell..."
-          python3 -m playwright install --with-deps chromium
+          # No --with-deps: that flag triggers `sudo apt install` to fetch
+          # Chromium's runtime libraries, which fails on the self-hosted
+          # runner because sudo requires a password. The libs are already
+          # present on the runner (this step worked before Playwright began
+          # auto-detecting the OS as unsupported); if they ever go missing,
+          # test_interactive_ui.py prints its SKIP banner and
+          # `continue-on-error: true` below still lets the build pass.
+          python3 -m playwright install chromium
         fi
 
         python3 scripts/test_interactive_ui.py ./static-output


### PR DESCRIPTION
## Summary
- The Playwright smoke-test step in `deploy-static-site.yml` has been silently failing every run. Its `continue-on-error: true` masks the failure, but it means the interactive-UI regression check hasn't actually run for some time.
- Root cause: `playwright install --with-deps chromium` falls through to `sudo apt install` to fetch Chromium runtime libs. The self-hosted runner's `sudo` requires a password — step exits 1.
- Fix: drop `--with-deps`. Just download the browser binary. The runtime libs are already present on the runner (this step worked before Playwright started classifying the OS as "unsupported"). If they ever genuinely go missing, `test_interactive_ui.py` already prints a SKIP banner and `continue-on-error: true` still applies.

## Test plan
- [ ] Manually dispatch `deploy-static-site.yml` after merge and confirm the "Interactive UI smoke tests (Playwright)" step succeeds (no red annotation).
- [ ] Confirm `test_interactive_ui.py` actually executes (look for its banner output in the step log, not the SKIP path).
- [ ] If Chromium dep is genuinely missing on the runner, expect the SKIP path — still no red annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)