### PR TITLE
fix(seo): drop /404/ + /feed/ from sitemap, lock homepage title, add ETag/304

### DIFF
--- a/_worker.template.js
+++ b/_worker.template.js
@@ -205,15 +205,39 @@ async function handleKVCache(request, env, ctx, path, hostname) {
     }
 
     const cacheKey = `html:${path}`;
-    const cached = await env.HTML_CACHE.get(cacheKey, { type: 'text' });
+    const cachedRes = await env.HTML_CACHE.getWithMetadata(cacheKey, { type: 'text' });
+    const cached = cachedRes && cachedRes.value;
+    const cachedMeta = (cachedRes && cachedRes.metadata) || {};
 
     if (cached) {
       const ttl = getTTL(path);
+      const etag = await computeETag(cached);
+      const lastModified = cachedMeta.cached_at
+        ? new Date(cachedMeta.cached_at).toUTCString()
+        : new Date().toUTCString();
+
+      // 304 Not Modified — Googlebot honours this and skips downloading the
+      // body, which cuts our crawl-budget cost on pages that haven't changed.
+      if (matchesIfNoneMatch(request, etag)) {
+        return new Response(null, {
+          status: 304,
+          headers: {
+            'ETag': etag,
+            'Last-Modified': lastModified,
+            'Cache-Control': `public, max-age=${ttl}`,
+            'X-Cache-Status': 'HIT-304',
+            'X-Worker': 'advanced-worker-kv',
+            ...getSecurityHeaders(hostname)
+          }
+        });
+      }
 
       return new Response(cached, {
         headers: {
           'Content-Type': 'text/html; charset=utf-8',
           'Cache-Control': `public, max-age=${ttl}`,
+          'ETag': etag,
+          'Last-Modified': lastModified,
           'X-Cache-Status': 'HIT',
           'X-Worker': 'advanced-worker-kv',
           ...getSecurityHeaders(hostname)
@@ -254,12 +278,29 @@ async function handleKVCache(request, env, ctx, path, hostname) {
       }).catch(err => console.error('KV cache write failed:', err))
     );
 
-    // Return with our headers
+    // Return with our headers (plus ETag/Last-Modified for crawl efficiency).
+    const etag = await computeETag(html);
+    const lastModified = new Date(nowSec * 1000).toUTCString();
+    if (matchesIfNoneMatch(request, etag)) {
+      return new Response(null, {
+        status: 304,
+        headers: {
+          'ETag': etag,
+          'Last-Modified': lastModified,
+          'Cache-Control': `public, max-age=${ttl}`,
+          'X-Cache-Status': 'MISS-304',
+          'X-Worker': 'advanced-worker-kv',
+          ...getSecurityHeaders(hostname)
+        }
+      });
+    }
     return new Response(html, {
       status: response.status,
       headers: {
         'Content-Type': 'text/html; charset=utf-8',
         'Cache-Control': `public, max-age=${ttl}`,
+        'ETag': etag,
+        'Last-Modified': lastModified,
         'X-Cache-Status': 'MISS',
         'X-Cache-TTL': ttl.toString(),
         'X-Worker': 'advanced-worker-kv',
@@ -420,6 +461,33 @@ function getTTL(path) {
 
   // Older content - 1 hour
   return 3600;
+}
+
+/**
+ * Compute a weak ETag for an HTML body. SHA-1 hex of the bytes, prefixed
+ * with W/ — the response may be served from KV cache, so the byte-for-byte
+ * "strong" guarantee doesn't quite hold. Googlebot honours weak ETags for
+ * the If-None-Match flow we care about.
+ */
+async function computeETag(text) {
+  const buf = new TextEncoder().encode(text);
+  const hash = await crypto.subtle.digest('SHA-1', buf);
+  const hex = Array.from(new Uint8Array(hash))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+  return `W/"${hex}"`;
+}
+
+/**
+ * Return true iff the request's If-None-Match header matches the given ETag.
+ * Tolerates the weak-prefix and quoted/unquoted variants clients may send.
+ */
+function matchesIfNoneMatch(request, etag) {
+  const header = request.headers.get('if-none-match');
+  if (!header) return false;
+  const normalize = s => s.replace(/^W\//, '').replace(/^"|"$/g, '');
+  const wanted = normalize(etag);
+  return header.split(',').some(t => normalize(t.trim()) === wanted);
 }
 
 // ── Plausible proxy ────────────────────────────────────────────────────────

--- a/public/feed/index.html
+++ b/public/feed/index.html
@@ -1,8 +1,0 @@
-<!DOCTYPE html>
-<html lang="en"><head>
-<meta http-equiv="refresh" content="0; url=index.xml" />
-<link rel="alternate" type="application/rss+xml" href="index.xml" />
-</head><body>
-<p>Redirecting to <a href="index.xml">RSS feed</a>...</p>
-<script src="/js/search.js" data-cfasync="false"></script>
-</body></html>

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -38,6 +38,13 @@ class Config:
     # vExpert membership year used to compute years.vexpert; update if the
     # source-of-truth changes.
     VEXPERT_START_YEAR = 2015
+
+    # Canonical homepage <title>. Applied at build time by
+    # scripts/fix_seo_issues.py:fix_homepage_title so <title>, og:title,
+    # and twitter:title stay in lockstep regardless of what Rank Math /
+    # WordPress emits. Target ~50-60 chars so Google doesn't rewrite it
+    # in SERPs (pixel budget ≈ 580px ≈ 55-60 chars).
+    HOMEPAGE_TITLE = "James Kilby — VMware, Homelab & Cloud Infrastructure Notes"
     
     @classmethod
     def get_plausible_script_url(cls):

--- a/scripts/fix_seo_issues.py
+++ b/scripts/fix_seo_issues.py
@@ -14,8 +14,10 @@ sys.path.insert(0, str(Path(__file__).parent))
 try:
     from config import Config
     TARGET_DOMAIN = Config.TARGET_DOMAIN
+    HOMEPAGE_TITLE = getattr(Config, 'HOMEPAGE_TITLE', None)
 except (ImportError, AttributeError):
     TARGET_DOMAIN = 'https://jameskilby.co.uk'
+    HOMEPAGE_TITLE = None
 
 
 class SEOFixer:
@@ -55,6 +57,9 @@ class SEOFixer:
 
             # Apply fixes
             if self.fix_title_length(soup, file_path):
+                modified = True
+
+            if self.fix_homepage_title(soup, file_path):
                 modified = True
 
             if self.fix_meta_description(soup, file_path):
@@ -140,6 +145,48 @@ class SEOFixer:
         self.issues_fixed += 1
         print(f"   📏 Restored truncated title from JSON-LD: {file_path.name}")
         return True
+
+    def fix_homepage_title(self, soup, file_path):
+        """Replace the homepage <title>/og:title/twitter:title with the
+        canonical short title from Config.HOMEPAGE_TITLE.
+
+        Rank Math emits a 150-char title built by concatenating site
+        name + tagline + description. Google rewrites anything beyond
+        ~58 chars in SERPs, so the result is unpredictable. Lock it to
+        a tested ~60-char string so SERPs and social previews stay
+        consistent.
+        """
+        if not HOMEPAGE_TITLE:
+            return False
+        try:
+            rel = file_path.resolve().relative_to(self.public_dir.resolve())
+        except (ValueError, AttributeError):
+            return False
+        # Homepage is exactly public_dir/index.html
+        if str(rel) != 'index.html':
+            return False
+
+        modified = False
+
+        title_tag = soup.find('title')
+        if title_tag and (title_tag.get_text() or '').strip() != HOMEPAGE_TITLE:
+            title_tag.string = HOMEPAGE_TITLE
+            modified = True
+
+        og_title = soup.find('meta', attrs={'property': 'og:title'})
+        if og_title and og_title.get('content') != HOMEPAGE_TITLE:
+            og_title['content'] = HOMEPAGE_TITLE
+            modified = True
+
+        tw_title = soup.find('meta', attrs={'name': 'twitter:title'})
+        if tw_title and tw_title.get('content') != HOMEPAGE_TITLE:
+            tw_title['content'] = HOMEPAGE_TITLE
+            modified = True
+
+        if modified:
+            self.issues_fixed += 1
+            print(f"   🏷️  Locked homepage title to canonical form ({len(HOMEPAGE_TITLE)} chars)")
+        return modified
 
     @staticmethod
     def _extract_title_from_jsonld(soup):

--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -3724,6 +3724,14 @@ document.addEventListener('DOMContentLoaded', function() {
             "  Access-Control-Allow-Origin: *",
             "  Access-Control-Allow-Methods: GET, HEAD, OPTIONS",
             "",
+            "# RSS feed - explicit content-type. Cloudflare Pages defaults",
+            "# /feed/index.xml to application/xml; feed readers and validators",
+            "# (W3C feed validator, Feedly fetcher) prefer the RSS-specific",
+            "# media type.",
+            "/feed/index.xml",
+            "  Content-Type: application/rss+xml; charset=utf-8",
+            "  Cache-Control: public, max-age=3600",
+            "",
             "# API endpoints - JSON with CORS",
             "/api/*",
             "  Content-Type: application/json; charset=utf-8",
@@ -3765,7 +3773,14 @@ document.addEventListener('DOMContentLoaded', function() {
             "# Redirect www to non-www (canonical URL)",
             "# Note: Cloudflare's 'Always Use HTTPS' runs first, so HTTP www gets 2 hops",
             "# This is normal and acceptable for the rare HTTP www case",
-            "www.jameskilby.co.uk/* jameskilby.co.uk/:splat 301",
+            "# (NB: www must also be added as a Custom Domain in the Cloudflare",
+            "#  Pages dashboard for this rule to take effect — without that,",
+            "#  www doesn't route to Pages and the apex zone returns 522.)",
+            "www.jameskilby.co.uk/* https://jameskilby.co.uk/:splat 301!",
+            "",
+            "# /feed/ → RSS XML feed. Was previously a meta-refresh HTML shim,",
+            "# which Google treats as a soft redirect; a 301 is the canonical form.",
+            "/feed/ /feed/index.xml 301!",
             "",
             "# Automatic redirects for spelling corrections",
             "/2025/04/warp-the-inteligent-terminal/ /2025/04/warp-the-intelligent-terminal/ 301",
@@ -3783,15 +3798,18 @@ document.addEventListener('DOMContentLoaded', function() {
             "User-agent: *",
             "Allow: /",
             "",
-            "# Stop crawlers from wasting crawl budget on feed URLs and",
-            "# the JSON API directory — these are never indexed anyway.",
+            "# Stop crawlers from wasting crawl budget on per-archive feed URLs",
+            "# (e.g. /category/foo/feed/) and the JSON API directory — neither",
+            "# is indexable content. The root /feed/ is allowed because it 301s",
+            "# to /feed/index.xml which is the canonical RSS feed.",
             "Disallow: /*/feed/",
             "Disallow: /api/",
             "",
-            "# Tag pages carry <meta name=\"robots\" content=\"noindex, follow\">.",
-            "# Do NOT Disallow them: Google must be allowed to crawl the page",
-            "# in order to see the noindex directive. Blocking crawl leaves the",
-            "# URLs in the index as URL-only entries and prevents clean removal.",
+            "# The 404 page carries <meta name=\"robots\" content=\"noindex,follow\">",
+            "# and Cloudflare also sends X-Robots-Tag: noindex on it. We do NOT",
+            "# Disallow noindex pages here — Google must be allowed to crawl them",
+            "# in order to see the directive. Blocking crawl leaves the URLs in",
+            "# the index as URL-only entries and prevents clean removal.",
             "",
             f"Sitemap: {self.target_domain}/sitemap.xml",
             ""
@@ -3895,21 +3913,23 @@ document.addEventListener('DOMContentLoaded', function() {
                 'html_file': html_file,   # kept for image extraction below
             })
 
-        # Exclude noindex pages from sitemap (category/tag archives are
-        # marked noindex,follow — including them in the sitemap sends a
-        # mixed signal to search engines and wastes crawl budget)
+        # Exclude pages that should never appear in the sitemap. Three classes:
+        #   1. noindex pages — sending them as sitemap entries is a mixed
+        #      signal and triggers "Submitted URL marked 'noindex'" in GSC.
+        #   2. Non-canonical shims — pages whose only purpose is a meta
+        #      refresh (e.g. /feed/index.html → /feed/index.xml). Google treats
+        #      these as soft redirects when submitted via sitemap.
+        #   3. The 404 page itself — returns HTTP 404 + noindex, so listing
+        #      it triggers BOTH "Submitted URL returns 404" and "noindex".
+        SITEMAP_BLOCKED_PATHS = ('/404/', '/feed/')
         before_count = len(urls_for_sitemap)
         urls_for_sitemap = [
             item for item in urls_for_sitemap
-            if not self._is_noindex_page(
-                self.output_dir / item['url'].replace(self.target_domain, '').strip('/') / 'index.html'
-                if item['url'] != f'{self.target_domain}/'
-                else self.output_dir / 'index.html'
-            )
+            if not self._should_exclude_from_sitemap(item, SITEMAP_BLOCKED_PATHS)
         ]
         excluded = before_count - len(urls_for_sitemap)
         if excluded:
-            print(f"   🚫 Excluded {excluded} noindex pages from sitemap")
+            print(f"   🚫 Excluded {excluded} non-indexable pages from sitemap")
 
         # Fix lastmod for any remaining archive pages that aren't noindex:
         # Use the most recent post date linked from each archive page
@@ -4098,6 +4118,35 @@ document.addEventListener('DOMContentLoaded', function() {
         except Exception:
             return False
 
+    def _is_meta_refresh_shim(self, html_file):
+        """Check if a page is a meta-refresh redirect shim (non-canonical)."""
+        try:
+            if not html_file.exists():
+                return False
+            with open(html_file, 'r', encoding='utf-8', errors='ignore') as f:
+                head_content = f.read(2048)
+            return 'http-equiv="refresh"' in head_content.lower()
+        except Exception:
+            return False
+
+    def _should_exclude_from_sitemap(self, item, blocked_paths):
+        """Decide whether a sitemap candidate URL should be dropped.
+
+        Use the html_file already on the item dict (don't re-derive — paths
+        like /404/ map to public/404.html, not public/404/index.html).
+        """
+        url_path = item['url'].replace(self.target_domain, '') or '/'
+        if url_path in blocked_paths:
+            return True
+        html_file = item.get('html_file')
+        if html_file is None:
+            return False
+        if self._is_noindex_page(html_file):
+            return True
+        if self._is_meta_refresh_shim(html_file):
+            return True
+        return False
+
     def generate_rss_feed(self):
         """Generate RSS feed from posts"""
         print("📡 Generating RSS feed...")
@@ -4219,19 +4268,15 @@ document.addEventListener('DOMContentLoaded', function() {
         feed_file = feed_dir / 'index.xml'
         feed_file.write_text('\n'.join(rss_lines), encoding='utf-8')
         
-        # Also create a simple HTML redirect for /feed/
-        feed_html = feed_dir / 'index.html'
-        feed_html.write_text(
-            '<!DOCTYPE html>\n'
-            '<html lang="en"><head>\n'
-            '<meta http-equiv="refresh" content="0; url=index.xml" />\n'
-            '<link rel="alternate" type="application/rss+xml" href="index.xml" />\n'
-            '</head><body>\n'
-            '<p>Redirecting to <a href="index.xml">RSS feed</a>...</p>\n'
-            '</body></html>',
-            encoding='utf-8'
-        )
-        
+        # /feed/ → /feed/index.xml is handled by a 301 rule in _redirects
+        # (create_redirects_file). A previous meta-refresh HTML shim here
+        # was treated by Google as a soft redirect and triggered "Page with
+        # redirect" in GSC when listed in the sitemap. Drop any stale shim
+        # from earlier builds so Cloudflare honours the 301.
+        stale_shim = feed_dir / 'index.html'
+        if stale_shim.exists():
+            stale_shim.unlink()
+
         print(f"   ✅ Created RSS feed with {len(posts)} posts")
         print(f"   📡 Feed URL: {self.target_domain}/feed/index.xml")
     


### PR DESCRIPTION
## Summary

Comprehensive SEO audit against the live site surfaced three issues GSC would flag and a few smaller wins. All fixes ride through the build pipeline; the only direct change to `public/` is deleting one stale meta-refresh shim.

- **Sitemap excludes `/404/` and `/feed/`** — the existing `_is_noindex_page` check was looking at the wrong path (`public/404/index.html` vs the real `public/404.html`), so `/404/` slipped in with both `noindex` and HTTP 404. New helper `_should_exclude_from_sitemap` blocks by path *and* catches meta-refresh shims, fixing both `/404/` and `/feed/` regressions.
- **Feed shim → 301** — replaced the meta-refresh `feed/index.html` with `/feed/ → /feed/index.xml 301!` in `_redirects`. Google treats meta-refresh as a soft redirect; the 301 is the canonical form. Also set `Content-Type: application/rss+xml` on `/feed/index.xml`.
- **Homepage `<title>` locked** to a 58-char canonical string via `Config.HOMEPAGE_TITLE` + new `fix_homepage_title`. Rank Math was emitting 150 chars; Google rewrites SERP titles beyond ~58.
- **`ETag` + `Last-Modified` + 304 handling** added to the worker's KV cache HIT/MISS paths so Googlebot can skip downloading unchanged pages.
- **`www` redirect rule** improved (absolute `https://` + `301!`) so it fires correctly once www is bound to Pages.
- **`robots.txt` comment** reworded — referenced "tag pages" that don't actually exist on the static site.

## Touches `public/`

Yes — deletes `public/feed/index.html` (stale meta-refresh shim). The next auto-build regenerates `sitemap.xml` without `/404/` + `/feed/`, emits the new `_redirects` rules, and sets the new `_headers` entry.

## Manual step still required

`www.jameskilby.co.uk` returns HTTP 522 because Pages doesn't claim the hostname. The `_redirects` rule is now ready; **add `www.jameskilby.co.uk` as a Custom Domain in the Cloudflare Pages dashboard** (Settings → Custom domains). Until then `www` continues to 522.

## Test plan

- [x] `node --check _worker.template.js` passes
- [x] `ast.parse` on all modified Python files passes
- [x] Sitemap-exclusion smoke test — 5/5 cases pass (homepage allowed, `/404/` excluded, `/feed/` excluded, category page allowed, real post allowed)
- [x] `fix_homepage_title` smoke test against live HTML — `<title>`, `og:title`, `twitter:title` all rewrite to the 58-char canonical form
- [x] gitleaks pre-commit hook passes
- [ ] **Post-deploy**: confirm `https://jameskilby.co.uk/sitemap.xml` no longer contains `<loc>https://jameskilby.co.uk/404/</loc>` or `<loc>https://jameskilby.co.uk/feed/</loc>`
- [ ] **Post-deploy**: confirm `curl -sI https://jameskilby.co.uk/feed/` returns `301` to `/feed/index.xml`
- [ ] **Post-deploy**: confirm `curl -sI https://jameskilby.co.uk/feed/index.xml` returns `Content-Type: application/rss+xml`
- [ ] **Post-deploy**: confirm homepage `<title>` is the 58-char canonical form
- [ ] **Post-deploy**: confirm `curl -sI https://jameskilby.co.uk/` includes `ETag:` and `Last-Modified:` headers
- [ ] **Post-deploy**: confirm `curl -sI -H 'If-None-Match: <etag>' https://jameskilby.co.uk/` returns `304`
- [ ] **GSC follow-up (next reindex cycle)**: "Submitted URL marked 'noindex'" and "Page with redirect" warnings clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)