### PR TITLE
fix(seo): wire fix_homepage_title into html_transformer orchestrator

### DIFF
--- a/scripts/html_transformer.py
+++ b/scripts/html_transformer.py
@@ -253,9 +253,17 @@ class HTMLTransformer:
         return html[:head_match.start()] + head_open + head_body + head_close + html[head_match.end():]
 
     def _apply_seo_fixes(self, soup, file_path):
-        """Apply all SEO transforms from SEOFixer on the soup object."""
+        """Apply all SEO transforms from SEOFixer on the soup object.
+
+        Mirrors SEOFixer.process_file's call order. When you add a fix method
+        to SEOFixer, you MUST also add it here — this orchestrator bypasses
+        process_file (which reads/writes the file itself) and drives the
+        SEOFixer methods on an already-parsed soup.
+        """
         modified = False
         if self.seo.fix_title_length(soup, file_path):
+            modified = True
+        if self.seo.fix_homepage_title(soup, file_path):
             modified = True
         if self.seo.fix_meta_description(soup, file_path):
             modified = True


### PR DESCRIPTION
## Summary

Follow-up to [#46](https://github.com/jameskilbynet/jkcoukblog/pull/46): the homepage title fix that PR added wasn't actually firing in production. Verified post-deploy that the live homepage still carries the 150-char Rank Math title.

**Root cause:** `SEOFixer.fix_homepage_title` was added in [#46](https://github.com/jameskilbynet/jkcoukblog/pull/46) and registered in `SEOFixer.process_file`, but the build pipeline runs `scripts/html_transformer.py` instead. That orchestrator hand-lists the SEOFixer methods to call in `_apply_seo_fixes` — new methods are silently skipped unless added there.

**Fix:** add `self.seo.fix_homepage_title(soup, file_path)` to `_apply_seo_fixes`, right after `fix_title_length` to keep title-related fixes together. Also documented the contract in the method docstring so the next person adding an SEOFixer method remembers to wire it in here.

## Test plan

- [x] `ast.parse` on `scripts/html_transformer.py` passes
- [x] Smoke test against current live homepage HTML — `<title>`, `og:title`, `twitter:title` all rewrite to the 58-char canonical form
- [ ] **Post-deploy**: `curl -s https://jameskilby.co.uk/ | grep -o '<title>[^<]*</title>'` shows the 58-char canonical title

🤖 Generated with [Claude Code](https://claude.com/claude-code)