### PR TITLE
fix(seo): noindex,follow on thin category/tag/archive pages

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -45,6 +45,26 @@ class Config:
     # WordPress emits. Target ~50-60 chars so Google doesn't rewrite it
     # in SERPs (pixel budget ≈ 580px ≈ 55-60 chars).
     HOMEPAGE_TITLE = "James Kilby — VMware, Homelab & Cloud Infrastructure Notes"
+
+    # Paths that should carry <meta name="robots" content="noindex,follow">
+    # at serve time AND be excluded from sitemap.xml. "follow" preserves
+    # link discovery so Google still crawls posts linked from these pages;
+    # noindex stops the thin/utility pages themselves from competing in the
+    # index and inflating crawl budget. Each entry is a regex matched against
+    # the URL path (with trailing slash, e.g. "/category/aws/").
+    #
+    # See scripts/fix_seo_issues.py:fix_thin_archive_noindex (injects the
+    # meta tag) and wp_to_static_generator.py:_should_exclude_from_sitemap
+    # (drops them from sitemap). Both read this list — single source of truth.
+    NOINDEX_PATH_PATTERNS = (
+        r'^/category/.+',          # category archives (thin — list of post excerpts)
+        r'^/tag/.+',               # tag archives (currently 404 but future-proof)
+        r'^/page/\d+/?$',          # root pagination (no unique content)
+        r'^/changelog/?$',          # auto-generated changelog
+        r'^/evs/?$',               # raw event log (described as "non-content" in validate_seo)
+        r'^/stats/?$',             # auto-generated stats page
+        r'^/privacy-policy-2/?$',  # legal page — required, doesn't need to rank
+    )
     
     @classmethod
     def get_plausible_script_url(cls):

--- a/scripts/fix_seo_issues.py
+++ b/scripts/fix_seo_issues.py
@@ -15,9 +15,13 @@ try:
     from config import Config
     TARGET_DOMAIN = Config.TARGET_DOMAIN
     HOMEPAGE_TITLE = getattr(Config, 'HOMEPAGE_TITLE', None)
+    NOINDEX_PATH_PATTERNS = tuple(
+        re.compile(p) for p in getattr(Config, 'NOINDEX_PATH_PATTERNS', ())
+    )
 except (ImportError, AttributeError):
     TARGET_DOMAIN = 'https://jameskilby.co.uk'
     HOMEPAGE_TITLE = None
+    NOINDEX_PATH_PATTERNS = ()
 
 
 class SEOFixer:
@@ -60,6 +64,9 @@ class SEOFixer:
                 modified = True
 
             if self.fix_homepage_title(soup, file_path):
+                modified = True
+
+            if self.fix_thin_archive_noindex(soup, file_path):
                 modified = True
 
             if self.fix_meta_description(soup, file_path):
@@ -187,6 +194,59 @@ class SEOFixer:
             self.issues_fixed += 1
             print(f"   🏷️  Locked homepage title to canonical form ({len(HOMEPAGE_TITLE)} chars)")
         return modified
+
+    def fix_thin_archive_noindex(self, soup, file_path):
+        """Inject <meta name="robots" content="noindex,follow"> on thin
+        archive pages (categories, tags, pagination, auto-generated meta
+        pages) as defined by Config.NOINDEX_PATH_PATTERNS.
+
+        Why:
+          - /category/aws/ is 63 words of unique text → Google's "thin
+            content" zone. Categories add crawl cost without ranking value.
+          - /page/2/ etc. duplicate the homepage's post snippets.
+          - /changelog/, /stats/, /evs/, /privacy-policy-2/ are utility pages.
+
+        We keep `follow` so Google still discovers post links from these
+        pages, and we don't Disallow them in robots.txt (per the comment
+        there — Google has to crawl to see the noindex directive).
+
+        Pairs with wp_to_static_generator._matches_noindex_pattern which
+        drops these from sitemap.xml using the same Config list.
+        """
+        if not NOINDEX_PATH_PATTERNS:
+            return False
+        try:
+            rel = '/' + str(
+                file_path.resolve().relative_to(self.public_dir.resolve())
+            ).replace('\\', '/')
+        except (ValueError, AttributeError):
+            return False
+        # Convert /foo/bar/index.html → /foo/bar/ for matching
+        url_path = re.sub(r'/index\.html$', '/', rel)
+
+        if not any(p.match(url_path) for p in NOINDEX_PATH_PATTERNS):
+            return False
+
+        existing = soup.find('meta', attrs={'name': 'robots'})
+        existing_content = (existing.get('content') if existing else '') or ''
+        if 'noindex' in existing_content.lower():
+            return False  # already noindexed — nothing to do
+
+        if existing:
+            existing['content'] = 'noindex,follow'
+        else:
+            head = soup.find('head')
+            if not head:
+                return False
+            new_tag = soup.new_tag(
+                'meta',
+                attrs={'name': 'robots', 'content': 'noindex,follow'},
+            )
+            head.append(new_tag)
+
+        self.issues_fixed += 1
+        print(f"   🚫 Added noindex,follow to thin archive: {url_path}")
+        return True
 
     @staticmethod
     def _extract_title_from_jsonld(soup):

--- a/scripts/html_transformer.py
+++ b/scripts/html_transformer.py
@@ -265,6 +265,8 @@ class HTMLTransformer:
             modified = True
         if self.seo.fix_homepage_title(soup, file_path):
             modified = True
+        if self.seo.fix_thin_archive_noindex(soup, file_path):
+            modified = True
         if self.seo.fix_meta_description(soup, file_path):
             modified = True
         if self.seo.fix_multiple_h1(soup, file_path):

--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -23,6 +23,18 @@ from incremental_builder import IncrementalBuilder
 # calls can still pass an explicit `timeout=` to override this.
 DEFAULT_HTTP_TIMEOUT = 30
 
+# Pre-compiled url-path regexes for sitemap noindex policy. Single source of
+# truth is Config.NOINDEX_PATH_PATTERNS. Compiled once at import.
+# scripts/fix_seo_issues.py reads the same list to inject the meta tag.
+try:
+    from config import Config as _NIPathConfig
+    _NOINDEX_URL_PATH_PATTERNS = tuple(
+        re.compile(p) for p in _NIPathConfig.NOINDEX_PATH_PATTERNS
+    )
+    del _NIPathConfig
+except (ImportError, AttributeError):
+    _NOINDEX_URL_PATH_PATTERNS = ()
+
 class WordPressStaticGenerator:
     def __init__(self, wp_url, auth_token, output_dir, target_domain, use_incremental=True):
         self.wp_url = wp_url.rstrip('/')
@@ -4130,14 +4142,29 @@ document.addEventListener('DOMContentLoaded', function() {
         except Exception:
             return False
 
+    def _matches_noindex_pattern(self, url_path):
+        """Return True if url_path matches any Config.NOINDEX_PATH_PATTERNS."""
+        return any(p.match(url_path) for p in _NOINDEX_URL_PATH_PATTERNS)
+
     def _should_exclude_from_sitemap(self, item, blocked_paths):
         """Decide whether a sitemap candidate URL should be dropped.
 
         Use the html_file already on the item dict (don't re-derive — paths
         like /404/ map to public/404.html, not public/404/index.html).
+
+        Layered check:
+          1. Explicit path blocklist (blocked_paths) — /404/, /feed/.
+          2. Config.NOINDEX_PATH_PATTERNS — pattern-level noindex policy.
+             Runs even before fix_seo_issues injects the meta tag, so the
+             sitemap stays clean regardless of pipeline-step ordering.
+          3. _is_noindex_page (reads HTML head) — catches anything WordPress
+             or Rank Math has already marked noindex.
+          4. _is_meta_refresh_shim — non-canonical redirect pages.
         """
         url_path = item['url'].replace(self.target_domain, '') or '/'
         if url_path in blocked_paths:
+            return True
+        if self._matches_noindex_pattern(url_path):
             return True
         html_file = item.get('html_file')
         if html_file is None:


### PR DESCRIPTION
## Summary

Post-[#49](https://github.com/jameskilbynet/jkcoukblog/pull/49) audit showed multiple pages in `sitemap.xml` with very thin unique content:

| Path | Words |
|---|---:|
| `/category/aws/` | **63** |
| `/category/personal/` | 244 |
| `/category/vmware/` | 265 |
| `/page/2/` | 245 |
| `/changelog/` | 342 |
| `/evs/` | 275 |
| `/stats/` | 293 |

Anything under ~300 words on a non-post URL sits in Google's "thin content" risk zone — it doesn't break indexing on its own, but it pulls on the site's aggregate quality signal and burns crawl budget on low-yield pages. The `robots.txt` comment already documents the intent: "Tag/archive pages carry `noindex, follow`" — but in production the live HTML emitted `index, follow`. This PR closes that gap.

## Strategy

`noindex, follow` on thin archive/utility pages — Google still discovers post links from them, but doesn't index the pages themselves. **NOT** Disallowed in `robots.txt` (Google has to crawl to see the noindex directive).

Single source of truth: `Config.NOINDEX_PATH_PATTERNS` — regex list. Covered:
- `/category/.+`, `/tag/.+`, `/page/\d+/?$` (archives + pagination)
- `/changelog/?$`, `/evs/?$`, `/stats/?$`, `/privacy-policy-2/?$` (utility/legal pages)

**Deliberately NOT noindexed** (substantive unique content, kept indexable): `/about-me/`, `/lab/`, `/vmc/`, `/homelab-software/`, `/media/`.

## Two-side enforcement

So the policy is robust regardless of pipeline-step ordering:

1. **`fix_seo_issues.SEOFixer.fix_thin_archive_noindex`** injects/updates `<meta name="robots" content="noindex,follow">` at HTML-transform time. Wired into both `SEOFixer.process_file` and `html_transformer._apply_seo_fixes` (per the docstring contract I added in [#47](https://github.com/jameskilbynet/jkcoukblog/pull/47)).
2. **`wp_to_static_generator._matches_noindex_pattern`** auto-drops these from `sitemap.xml`. Reads the same `Config` list. Runs even before the meta tag is injected so the sitemap stays clean regardless of which step ran first.

## Test plan

- [x] All four Python files parse (`ast.parse`)
- [x] 15-case pattern test passes (homepage/posts/about-me/lab/vmc kept indexable; category/tag/page/changelog/evs/stats/privacy-policy-2 dropped)
- [x] 8-case smoke test against current `public/` files — archives correctly get `noindex,follow`; posts/homepage/about-me/lab untouched
- [ ] Post-deploy: `sitemap.xml` no longer contains `/category/`, `/page/N/`, `/changelog/`, `/evs/`, `/stats/`, `/privacy-policy-2/` URLs
- [ ] Post-deploy: `curl -s https://jameskilby.co.uk/category/aws/ | grep robots` shows `content="noindex,follow"`
- [ ] Post-deploy: `curl -s https://jameskilby.co.uk/about-me/ | grep robots` still shows `index, follow` (regression check)
- [ ] GSC follow-up (next reindex cycle): "Submitted URL marked 'noindex'" warnings clear once these URLs leave the sitemap

🤖 Generated with [Claude Code](https://claude.com/claude-code)