### PR TITLE
fix(seo): bake noindex,follow into changelog + stats templates

### DIFF
--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -218,7 +218,14 @@ def generate_changelog_html(lighthouse_scores, git_stats, changes):
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Changelog - James Kilby</title>
     <meta name="description" content="Site improvements, deployments, and performance metrics for James Kilby's technical blog.">
-    <meta name="robots" content="index, follow">
+    <!--
+        noindex,follow: /changelog/ is an auto-generated build artifact, not
+        content meant to rank. Follow keeps internal-link discovery alive.
+        Matches Config.NOINDEX_PATH_PATTERNS — this template runs AFTER
+        html_transformer (which would also have injected this), so baking it
+        in at source prevents the post-transform overwrite from undoing it.
+    -->
+    <meta name="robots" content="noindex, follow">
     <link rel="canonical" href="https://jameskilby.co.uk/changelog/">
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Anton&family=JetBrains+Mono:wght@400;700&family=Space+Grotesk:wght@400;500;700&display=swap');

--- a/scripts/generate_stats_page.py
+++ b/scripts/generate_stats_page.py
@@ -146,7 +146,14 @@ def generate_stats_html(lighthouse, build_metrics, git_stats):
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Site Statistics - James Kilby</title>
     <meta name="description" content="Public statistics and metrics for James Kilby's technical blog including performance scores, traffic data, and build information.">
-    <meta name="robots" content="index, follow">
+    <!--
+        noindex,follow: /stats/ is an auto-generated build artifact, not
+        content meant to rank. Follow keeps internal-link discovery alive.
+        Matches Config.NOINDEX_PATH_PATTERNS — this template runs AFTER
+        html_transformer (which would also have injected this), so baking it
+        in at source prevents the post-transform overwrite from undoing it.
+    -->
+    <meta name="robots" content="noindex, follow">
     <link rel="canonical" href="https://jameskilby.co.uk/stats/">
     
     <!-- Open Graph -->


### PR DESCRIPTION
## Summary

Post-[#50](https://github.com/jameskilbynet/jkcoukblog/pull/50) verification showed `/stats/` still serving `index, follow` despite `Config.NOINDEX_PATH_PATTERNS` including `^/stats/?$` and the sitemap correctly excluding it.

**Root cause:** `generate_changelog.py` and `generate_stats_page.py` write to `public/changelog/index.html` and `public/stats/index.html` directly, **after** `html_transformer.py` runs. So `fix_thin_archive_noindex` correctly injects the noindex on the static-output copies (build logs confirm "🚫 Added noindex,follow to thin archive: /stats/"), but the late-stage generators then overwrite those files with their own templates — both of which had `<meta name="robots" content="index, follow">` baked in.

`/changelog/` accidentally ended up correctly noindexed only because `generate_changelog.py` failed silently this build (non-blocking warning). When it succeeds it'll undo my fix the same way `/stats/` did. Fragile.

## Fix

Change both templates to bake `<meta name="robots" content="noindex, follow">` at source. The output now matches `Config.NOINDEX_PATH_PATTERNS` regardless of which step ran last and regardless of whether the generator succeeded.

Cross-reference comments at both sites point future readers at `Config.NOINDEX_PATH_PATTERNS` and the post-transform overwrite hazard.

## Test plan

- [x] `ast.parse` on both modified files passes
- [x] No other Python generator bakes `content="index, follow"` (grep confirmed)
- [ ] Post-deploy: `curl -s https://jameskilby.co.uk/stats/ | grep robots` returns `noindex, follow`
- [ ] Post-deploy: `curl -s https://jameskilby.co.uk/changelog/ | grep robots` returns `noindex, follow`
- [ ] Post-deploy: `sitemap.xml` continues to exclude both (already verified post-#50)

🤖 Generated with [Claude Code](https://claude.com/claude-code)