### PR TITLE
fix(seo): dedupe TechArticle in @graph + inject dates + tighten title cap

### DIFF
--- a/scripts/fix_seo_issues.py
+++ b/scripts/fix_seo_issues.py
@@ -5,6 +5,8 @@ Fixes common SEO problems in generated HTML files
 """
 
 import sys
+import json
+from collections import defaultdict
 from pathlib import Path
 from bs4 import BeautifulSoup
 import re
@@ -91,6 +93,9 @@ class SEOFixer:
                 modified = True
 
             if self.fix_breadcrumb_positions(soup, file_path):
+                modified = True
+
+            if self.fix_techarticle_dedupe_and_dates(soup, file_path):
                 modified = True
 
             if self.fix_person_name(soup, file_path):
@@ -651,6 +656,123 @@ class SEOFixer:
             print(f"   🍞 Fixed BreadcrumbList position types: {file_path.name}")
 
         return modified
+
+    # Article-family types we consider for dedupe + date injection. Order
+    # matters when collapsing duplicates — earlier types are "more specific"
+    # and preferred over later ones in a tie.
+    _ARTICLE_TYPES = (
+        'TechArticle', 'NewsArticle', 'ScholarlyArticle', 'BlogPosting', 'Article',
+    )
+
+    def fix_techarticle_dedupe_and_dates(self, soup, file_path):
+        """Clean up duplicate Article-family entries in JSON-LD @graph and
+        inject missing datePublished + dateModified.
+
+        Rank Math sometimes emits two Article-family entries in the same
+        @graph with the same headline/articleBody but different @ids — one
+        complete (with dates), one a strict subset (no dates). The dateless
+        one fails Google's required-field validation for the Article rich
+        result.
+
+        Strategy:
+          1. Within each <script type="application/ld+json"> block:
+             a. Group Article-family entries by (@type, headline, articleBody).
+             b. For each group of duplicates, keep the most "complete" entry
+                (most populated key fields) and drop the rest.
+          2. For each surviving Article-family entry that's still missing
+             datePublished / dateModified, inject from <meta property=
+             "article:published_time" / "article:modified_time">.
+
+        Idempotent — re-running on a cleaned file is a no-op.
+        """
+        # Pull fallback dates from the article meta tags (always emitted by
+        # Rank Math for Article-type WordPress posts).
+        pub_meta = soup.find('meta', attrs={'property': 'article:published_time'})
+        mod_meta = soup.find('meta', attrs={'property': 'article:modified_time'})
+        fallback_published = (pub_meta.get('content') if pub_meta else None) or None
+        fallback_modified = (
+            (mod_meta.get('content') if mod_meta else None) or fallback_published
+        )
+
+        def is_article(item):
+            if not isinstance(item, dict):
+                return False
+            t = item.get('@type')
+            types = t if isinstance(t, list) else [t]
+            return any(tt in self._ARTICLE_TYPES for tt in types if isinstance(tt, str))
+
+        def completeness(item):
+            """Score by which key Article fields are populated."""
+            return sum(1 for f in (
+                'datePublished', 'dateModified', 'url', 'author',
+                'description', 'image', 'publisher', 'mainEntityOfPage',
+                'articleBody', 'articleSection',
+            ) if item.get(f))
+
+        blocks_modified = 0
+        for script in soup.find_all('script', type='application/ld+json'):
+            raw = script.string or ''
+            if not raw.strip():
+                continue
+            try:
+                data = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(data, dict) or not isinstance(data.get('@graph'), list):
+                continue
+
+            graph = data['@graph']
+            block_changed = False
+
+            # ── Step 1: dedupe Article-family entries within @graph ────────
+            groups = defaultdict(list)
+            for idx, item in enumerate(graph):
+                if not is_article(item):
+                    continue
+                t = item.get('@type')
+                sig = (
+                    str(t),
+                    str(item.get('headline', ''))[:120],
+                    str(item.get('articleBody', ''))[:200],
+                )
+                groups[sig].append(idx)
+
+            to_drop = set()
+            for indices in groups.values():
+                if len(indices) <= 1:
+                    continue
+                best = max(indices, key=lambda i: completeness(graph[i]))
+                to_drop.update(i for i in indices if i != best)
+
+            if to_drop:
+                graph = [item for i, item in enumerate(graph) if i not in to_drop]
+                data['@graph'] = graph
+                block_changed = True
+
+            # ── Step 2: inject missing dates into surviving entries ────────
+            if fallback_published:
+                for item in graph:
+                    if not is_article(item):
+                        continue
+                    if not item.get('datePublished'):
+                        item['datePublished'] = fallback_published
+                        block_changed = True
+                    if not item.get('dateModified'):
+                        item['dateModified'] = fallback_modified
+                        block_changed = True
+
+            if block_changed:
+                # Compact serialization — matches how Rank Math emits it,
+                # so the diff stays minimal on pages already clean.
+                script.string = json.dumps(
+                    data, separators=(',', ':'), ensure_ascii=False
+                )
+                blocks_modified += 1
+
+        if blocks_modified:
+            self.issues_fixed += 1
+            print(f"   🧬 Cleaned JSON-LD Article duplicates/dates: {file_path.name}")
+        return blocks_modified > 0
 
     def fix_person_name(self, soup, file_path):
         """Fix incorrect Person/Organization name 'Jameskilbycouk' → 'James Kilby'.

--- a/scripts/html_transformer.py
+++ b/scripts/html_transformer.py
@@ -283,6 +283,8 @@ class HTMLTransformer:
             modified = True
         if self.seo.fix_breadcrumb_positions(soup, file_path):
             modified = True
+        if self.seo.fix_techarticle_dedupe_and_dates(soup, file_path):
+            modified = True
         if self.seo.fix_person_name(soup, file_path):
             modified = True
         return modified

--- a/scripts/validate_seo.py
+++ b/scripts/validate_seo.py
@@ -34,7 +34,13 @@ from bs4 import BeautifulSoup
 # every threshold should map to a documented Google quality signal, not just
 # a personal preference.
 TITLE_MIN_LEN          = 15    # under this is suspicious (auto-generated?)
-TITLE_MAX_LEN          = 80    # over this gets truncated in search results
+# Google's SERP title pixel budget is ~580px, which works out to roughly
+# 55-65 characters depending on character mix (i, l vs M, W). 65 is the
+# pragmatic threshold — anything past gets display-truncated and Google
+# may rewrite the title in SERPs, so the declared title is not what users
+# actually see. Previous threshold (80) let titles slip through that were
+# guaranteed to be rewritten. Warnings here are non-failing.
+TITLE_MAX_LEN          = 65
 META_DESC_MIN_LEN      = 50
 META_DESC_MAX_LEN      = 200
 THIN_CONTENT_WORDS     = 150   # post pages under this are flagged warn


### PR DESCRIPTION
## Summary

Three follow-ups from the post-[#51](https://github.com/jameskilbynet/jkcoukblog/pull/51) audit. **#2 turned out to already be done** — keeping the original numbering for clarity:

### 1. Duplicate `TechArticle` in JSON-LD `@graph` + missing required dates

Rank Math emits two `TechArticle` entries inside the same `@graph` with identical `headline` and `articleBody` but different `@id` values. One is a strict subset of the other:

| Entry | Fields | `datePublished` | `dateModified` |
|---|---:|---|---|
| `#schema-10678` | 16 | **None** | **None** |
| `#schema-10680` | 19 | 2026-04-15T21:36:41 | 2026-04-17T06:40:14 |

The dateless entry **fails** Google's required-field validation for the Article rich result (datePublished and dateModified are both required per [Google's Article spec](https://developers.google.com/search/docs/appearance/structured-data/article)). And the duplication adds ~18 KB of JSON-LD per post.

New `SEOFixer.fix_techarticle_dedupe_and_dates`:
- Per `<script type="application/ld+json">` block, groups Article-family entries (`TechArticle`, `NewsArticle`, `ScholarlyArticle`, `BlogPosting`, `Article`) by `(@type, headline, articleBody)`.
- For each duplicate group, keeps the most "complete" entry (most populated key fields) and drops the rest.
- For each surviving entry still missing `datePublished` / `dateModified`, injects from `<meta property="article:published_time" / "article:modified_time">`.
- Re-serializes with `separators=(',',':')` to match Rank Math's compact form — diff stays minimal on already-clean files.

Idempotent: verified by re-run-returns-`False` smoke test.

Wired into both `SEOFixer.process_file` and `html_transformer._apply_seo_fixes` (per the docstring contract from [#47](https://github.com/jameskilbynet/jkcoukblog/pull/47)).

### 2. Visible "Updated: <date>" byline — already done

The Kadence theme + Rank Math already emit two `<time>` elements (`entry-date published` + `class="updated"`) plus a `content-freshness-indicator` widget showing both dates. My original audit misread because the inline regex only grabbed the first `<time>`. **No code change needed.**

### 3. Validator title threshold: 80 → 65

Google's SERP title pixel budget is ~580px ≈ 55–65 chars depending on character mix. The previous threshold (80) let titles slip through that were guaranteed to be rewritten by Google. 65 is the pragmatic threshold. Warnings here are non-failing — this doesn't break the build, just surfaces more actionable hits.

## Test plan

- [x] `ast.parse` on all three modified Python files passes
- [x] Smoke test against `/tmp/post4.html` (real live page with the duplicate): 2 Article entries → 1 entry with both dates; re-run returns `False` (idempotent)
- [x] Regression test on `/tmp/older_post.html` (single `TechArticle`, no duplicate) — no-op
- [x] Regression test on homepage (no Article-family entries) — no-op
- [ ] Post-deploy: `curl -s https://jameskilby.co.uk/2026/04/vsphere-power-management-driven-by-ansible/ | python3 -c '<jsonld script>'` shows exactly 1 `TechArticle` entry with both dates populated
- [ ] Post-deploy: build log shows "Cleaned JSON-LD Article duplicates/dates" for ~72 posts
- [ ] Post-deploy: SEO validator surfaces title-too-long warnings on more posts (expected — threshold tightened)
- [ ] Manual Google Rich Results Test on a sample post shows no "missing required field" warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)