### PR TITLE
fix(seo): add twitter:site + twitter:creator attribution

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -46,6 +46,13 @@ class Config:
     # in SERPs (pixel budget ≈ 580px ≈ 55-60 chars).
     HOMEPAGE_TITLE = "James Kilby — VMware, Homelab & Cloud Infrastructure Notes"
 
+    # X/Twitter handle for attribution meta tags. Applied at build time by
+    # scripts/fix_seo_issues.py:fix_twitter_attribution to every page that
+    # already emits a twitter:card. Both twitter:site (the site's handle)
+    # and twitter:creator (the post author's handle) are set to this value
+    # — single-author blog, no per-post variance.
+    TWITTER_HANDLE = "@jameskilbynet"
+
     # Paths that should carry <meta name="robots" content="noindex,follow">
     # at serve time AND be excluded from sitemap.xml. "follow" preserves
     # link discovery so Google still crawls posts linked from these pages;

--- a/scripts/fix_seo_issues.py
+++ b/scripts/fix_seo_issues.py
@@ -17,12 +17,14 @@ try:
     from config import Config
     TARGET_DOMAIN = Config.TARGET_DOMAIN
     HOMEPAGE_TITLE = getattr(Config, 'HOMEPAGE_TITLE', None)
+    TWITTER_HANDLE = getattr(Config, 'TWITTER_HANDLE', None)
     NOINDEX_PATH_PATTERNS = tuple(
         re.compile(p) for p in getattr(Config, 'NOINDEX_PATH_PATTERNS', ())
     )
 except (ImportError, AttributeError):
     TARGET_DOMAIN = 'https://jameskilby.co.uk'
     HOMEPAGE_TITLE = None
+    TWITTER_HANDLE = None
     NOINDEX_PATH_PATTERNS = ()
 
 
@@ -102,6 +104,9 @@ class SEOFixer:
                 modified = True
 
             if self.fix_og_site_name(soup, file_path):
+                modified = True
+
+            if self.fix_twitter_attribution(soup, file_path):
                 modified = True
 
             if self.fix_malformed_stylesheet_attr(soup, file_path):
@@ -838,6 +843,54 @@ class SEOFixer:
             self.issues_fixed += 1
             print(f"   🏷️  Fixed og:site_name (Jameskilbycouk → James Kilby): {file_path.name}")
 
+        return modified
+
+    def fix_twitter_attribution(self, soup, file_path):
+        """Ensure every page with a twitter:card also emits twitter:site and
+        twitter:creator pointing at Config.TWITTER_HANDLE.
+
+        Rank Math's default doesn't include twitter:site / twitter:creator,
+        which means X/Twitter previews show the link target text but no
+        attribution to the author. With these tags, the card shows the
+        author's @ handle and (where rendered) the author's avatar.
+
+        Single-author blog → site and creator are the same handle; no
+        per-post variance needed.
+
+        Only fires on pages that have twitter:card — pages without any
+        Twitter card meta aren't expected to render previews and we don't
+        want to introduce orphan tags.
+        """
+        if not TWITTER_HANDLE:
+            return False
+
+        twitter_card = soup.find('meta', attrs={'name': 'twitter:card'})
+        if not twitter_card:
+            return False
+
+        modified = False
+
+        for prop_name in ('twitter:site', 'twitter:creator'):
+            existing = soup.find('meta', attrs={'name': prop_name})
+            if existing:
+                # Already set to the right value? skip
+                if (existing.get('content') or '').strip() == TWITTER_HANDLE:
+                    continue
+                existing['content'] = TWITTER_HANDLE
+                modified = True
+            else:
+                # Insert right after twitter:card so all twitter:* tags
+                # stay grouped — easier to eyeball in view-source
+                new_tag = soup.new_tag(
+                    'meta',
+                    attrs={'name': prop_name, 'content': TWITTER_HANDLE},
+                )
+                twitter_card.insert_after(new_tag)
+                modified = True
+
+        if modified:
+            self.issues_fixed += 1
+            print(f"   🐦 Added twitter:site/twitter:creator ({TWITTER_HANDLE}): {file_path.name}")
         return modified
 
     def fix_malformed_stylesheet_attr(self, soup, file_path):

--- a/scripts/html_transformer.py
+++ b/scripts/html_transformer.py
@@ -287,6 +287,8 @@ class HTMLTransformer:
             modified = True
         if self.seo.fix_person_name(soup, file_path):
             modified = True
+        if self.seo.fix_twitter_attribution(soup, file_path):
+            modified = True
         return modified
 
     # Counters for the late-stage repair (Phase 4.8). We report these in the


### PR DESCRIPTION
## Summary

Rank Math's default doesn't include `twitter:site` or `twitter:creator`, so X/Twitter previews of shared posts/the homepage don't attribute to the author. Setting these makes the card show the author's @ handle and (where rendered) the author's avatar.

`Config.TWITTER_HANDLE = "@jameskilbynet"`. Single-author blog → both `twitter:site` and `twitter:creator` point at the same handle; no per-post variance needed.

## Implementation

New `SEOFixer.fix_twitter_attribution`:
- Only fires on pages that already emit a `twitter:card`. Pages without any Twitter card meta aren't expected to render previews and we don't want to introduce orphan tags.
- Updates existing `twitter:site` / `twitter:creator` if the value differs, or inserts new tags right after `twitter:card` so all `twitter:*` tags stay grouped in view-source.

Wired into both `SEOFixer.process_file` and `html_transformer._apply_seo_fixes` (per the docstring contract from [#47](https://github.com/jameskilbynet/jkcoukblog/pull/47)).

## Test plan

- [x] Three Python files parse (`ast.parse`)
- [x] Smoke-tested against live homepage HTML — `twitter:site` and `twitter:creator` injected after `twitter:card`
- [x] Smoke-tested against live post HTML — same
- [x] Idempotency: re-run returns `False`
- [x] Page without `twitter:card` (no preview expected) → no injection
- [ ] Post-deploy: `curl -s https://jameskilby.co.uk/2026/04/vsphere-power-management-driven-by-ansible/ | grep twitter:` includes `twitter:site` and `twitter:creator` both set to `@jameskilbynet`
- [ ] Manual: paste a post URL into [X's card validator](https://cards-dev.twitter.com/validator) — preview shows author attribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)