### PR TITLE
fix(seo): enrich Person/E-E-A-T schema (sameAs + jobTitle + knowsAbout + award)

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -53,6 +53,51 @@ class Config:
     # — single-author blog, no per-post variance.
     TWITTER_HANDLE = "@jameskilbynet"
 
+    # ── Person / E-E-A-T schema enrichment ──────────────────────────────────
+    # Applied at build time by scripts/fix_seo_issues.py:fix_person_enrichment
+    # to every Person entity in JSON-LD whose name matches PERSON_CANONICAL_NAMES
+    # below (i.e. the site owner — single-author blog, so one Person identity).
+    # Google leans hard on E-E-A-T (Experience, Expertise, Authoritativeness,
+    # Trustworthiness) for technical content. Connecting the author's @id to
+    # their professional profiles via sameAs strengthens Google's entity graph
+    # association and improves trust signal for every page.
+
+    # Names treated as "the site owner" — Rank Math sometimes emits "James"
+    # (the WordPress display name) and sometimes "James Kilby" (the schema
+    # person name). Both refer to the same Person.
+    PERSON_CANONICAL_NAMES = ('James Kilby', 'James')
+
+    # sameAs URLs — the canonical professional profile graph for entity linking.
+    # Pre-existing JSON-LD links to wordpress.jameskilby.cloud (the private CMS),
+    # which is wrong on a public schema; this list replaces that.
+    PERSON_SAME_AS = (
+        'https://github.com/jameskilbynet',
+        'https://x.com/jameskilbynet',
+    )
+
+    PERSON_JOB_TITLE = 'Cloud / Infrastructure Architect'
+
+    # Topic-expertise array. Pulled from the actual category distribution
+    # on the site — only areas with multiple substantive posts.
+    PERSON_KNOWS_ABOUT = (
+        'VMware vSphere',
+        'VMware Cloud on AWS',
+        'Homelab Infrastructure',
+        'Cloudflare',
+        'AWS',
+        'Ansible',
+        'Kubernetes',
+        'Storage',
+        'Self-hosted AI',
+        'Network Automation',
+    )
+
+    # Professional awards — see the homepage tagline, vexpert category, and
+    # VEXPERT_START_YEAR above. vExpert is a public VMware MVP-style program.
+    PERSON_AWARDS = (
+        'VMware vExpert',
+    )
+
     # Paths that should carry <meta name="robots" content="noindex,follow">
     # at serve time AND be excluded from sitemap.xml. "follow" preserves
     # link discovery so Google still crawls posts linked from these pages;

--- a/scripts/fix_seo_issues.py
+++ b/scripts/fix_seo_issues.py
@@ -21,11 +21,21 @@ try:
     NOINDEX_PATH_PATTERNS = tuple(
         re.compile(p) for p in getattr(Config, 'NOINDEX_PATH_PATTERNS', ())
     )
+    PERSON_CANONICAL_NAMES = tuple(getattr(Config, 'PERSON_CANONICAL_NAMES', ()))
+    PERSON_SAME_AS = tuple(getattr(Config, 'PERSON_SAME_AS', ()))
+    PERSON_JOB_TITLE = getattr(Config, 'PERSON_JOB_TITLE', None)
+    PERSON_KNOWS_ABOUT = tuple(getattr(Config, 'PERSON_KNOWS_ABOUT', ()))
+    PERSON_AWARDS = tuple(getattr(Config, 'PERSON_AWARDS', ()))
 except (ImportError, AttributeError):
     TARGET_DOMAIN = 'https://jameskilby.co.uk'
     HOMEPAGE_TITLE = None
     TWITTER_HANDLE = None
     NOINDEX_PATH_PATTERNS = ()
+    PERSON_CANONICAL_NAMES = ()
+    PERSON_SAME_AS = ()
+    PERSON_JOB_TITLE = None
+    PERSON_KNOWS_ABOUT = ()
+    PERSON_AWARDS = ()
 
 
 class SEOFixer:
@@ -101,6 +111,9 @@ class SEOFixer:
                 modified = True
 
             if self.fix_person_name(soup, file_path):
+                modified = True
+
+            if self.fix_person_enrichment(soup, file_path):
                 modified = True
 
             if self.fix_og_site_name(soup, file_path):
@@ -821,6 +834,125 @@ class SEOFixer:
             print(f"   👤 Fixed Person name (Jameskilbycouk → James Kilby): {file_path.name}")
 
         return modified
+
+    # URL substring → if any sameAs entry matches this, it gets replaced. The
+    # pre-existing JSON-LD linked wordpress.jameskilby.cloud (the private CMS),
+    # which is wrong for a public schema graph and leaks internal infrastructure.
+    _PERSON_SAMEAS_LEAKS = ('wordpress.jameskilby.cloud',)
+
+    def fix_person_enrichment(self, soup, file_path):
+        """Enrich Person entities in JSON-LD @graph with E-E-A-T signals.
+
+        Rank Math emits a bare Person entity (name + url + image) but no
+        professional identifiers. Google leans on the entity graph for E-E-A-T
+        scoring on technical content — linking the author to GitHub, X, and
+        their professional expertise makes them a recognized entity rather
+        than a string of text.
+
+        Applied to any Person entity whose name matches Config.PERSON_CANONICAL_NAMES
+        (i.e. the site owner — single-author blog). Other Person entries
+        (e.g. people mentioned in a quote) are left alone.
+
+        Adds (idempotently):
+          - sameAs   — Config.PERSON_SAME_AS (also replaces internal-only links)
+          - jobTitle — Config.PERSON_JOB_TITLE
+          - knowsAbout — Config.PERSON_KNOWS_ABOUT
+          - award      — Config.PERSON_AWARDS
+
+        Doesn't touch existing values that already match — re-run = no-op.
+        """
+        if not PERSON_CANONICAL_NAMES:
+            return False
+
+        canonical_set = {n.lower() for n in PERSON_CANONICAL_NAMES}
+
+        def is_target_person(item):
+            if not isinstance(item, dict):
+                return False
+            t = item.get('@type')
+            types = t if isinstance(t, list) else [t]
+            if not any('Person' in str(x) for x in types if x):
+                return False
+            name = (item.get('name') or '').strip().lower()
+            return name in canonical_set
+
+        blocks_modified = 0
+        for script in soup.find_all('script', type='application/ld+json'):
+            raw = script.string or ''
+            if not raw.strip():
+                continue
+            try:
+                data = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            graph_items = (
+                data.get('@graph') if isinstance(data, dict) and isinstance(data.get('@graph'), list)
+                else ([data] if isinstance(data, dict) else None)
+            )
+            if not graph_items:
+                continue
+
+            block_changed = False
+            for item in graph_items:
+                if not is_target_person(item):
+                    continue
+
+                # ── sameAs: replace any leaky entries, then ensure all canonical entries present ──
+                current = item.get('sameAs')
+                # Normalize: existing string or list of strings
+                if isinstance(current, str):
+                    current = [current]
+                if not isinstance(current, list):
+                    current = []
+                # Drop leak URLs
+                filtered = [
+                    u for u in current
+                    if isinstance(u, str)
+                    and not any(leak in u for leak in self._PERSON_SAMEAS_LEAKS)
+                ]
+                # Add any canonical URLs that aren't there yet (case-insensitive
+                # dedupe so we don't double up if the page already had github.com)
+                lc = {u.lower() for u in filtered}
+                added = False
+                for canonical in PERSON_SAME_AS:
+                    if canonical.lower() not in lc:
+                        filtered.append(canonical)
+                        lc.add(canonical.lower())
+                        added = True
+                if added or filtered != current:
+                    item['sameAs'] = filtered
+                    block_changed = True
+
+                # ── jobTitle ───────────────────────────────────────────────
+                if PERSON_JOB_TITLE and item.get('jobTitle') != PERSON_JOB_TITLE:
+                    if not item.get('jobTitle'):
+                        item['jobTitle'] = PERSON_JOB_TITLE
+                        block_changed = True
+
+                # ── knowsAbout ─────────────────────────────────────────────
+                if PERSON_KNOWS_ABOUT and not item.get('knowsAbout'):
+                    item['knowsAbout'] = list(PERSON_KNOWS_ABOUT)
+                    block_changed = True
+
+                # ── award ───────────────────────────────────────────────────
+                if PERSON_AWARDS and not item.get('award'):
+                    item['award'] = (
+                        PERSON_AWARDS[0] if len(PERSON_AWARDS) == 1
+                        else list(PERSON_AWARDS)
+                    )
+                    block_changed = True
+
+            if block_changed:
+                # Compact serialization — matches Rank Math's emission style.
+                script.string = json.dumps(
+                    data, separators=(',', ':'), ensure_ascii=False
+                )
+                blocks_modified += 1
+
+        if blocks_modified:
+            self.issues_fixed += 1
+            print(f"   🪪 Enriched Person entity (sameAs+jobTitle+knowsAbout+award): {file_path.name}")
+        return blocks_modified > 0
 
     def fix_og_site_name(self, soup, file_path):
         """Fix og:site_name when it contains the old concatenated slug 'Jameskilbycouk'.

--- a/scripts/html_transformer.py
+++ b/scripts/html_transformer.py
@@ -287,6 +287,8 @@ class HTMLTransformer:
             modified = True
         if self.seo.fix_person_name(soup, file_path):
             modified = True
+        if self.seo.fix_person_enrichment(soup, file_path):
+            modified = True
         if self.seo.fix_twitter_attribution(soup, file_path):
             modified = True
         return modified


### PR DESCRIPTION
## Why this is the highest-impact remaining SEO lever

After auditing what Google actually leverages for ranking in 2026: structural SEO is done (the 9 prior PRs covered it), and the next-biggest **code-shippable** lever is E-E-A-T (Experience, Expertise, Authoritativeness, Trustworthiness), which became the dominant ranking signal for technical content with the 2024–25 core updates.

Rank Math emits a bare `Person` entity (name + url + image) but no professional identifiers. Adding `sameAs` connects the author into Google's entity graph so they're a *recognized identity* rather than a name string. That's the difference between Google understanding "this person is the author of every page on this site, has X expertise, is identified across GitHub and X, and won the vExpert award" vs. "this is a name appearing on a blog."

## Side fix: privacy/SEO leak

The current `Person.sameAs` contains `https://wordpress.jameskilby.cloud` (the private CMS host). That URL is wrong for a public schema graph and leaks internal infrastructure. This PR removes it.

## Implementation

Single source of truth in `Config`:

```python
PERSON_CANONICAL_NAMES = ('James Kilby', 'James')  # both Rank Math emits
PERSON_SAME_AS = (
    'https://github.com/jameskilbynet',
    'https://x.com/jameskilbynet',
)
PERSON_JOB_TITLE = 'Cloud / Infrastructure Architect'
PERSON_KNOWS_ABOUT = (
    'VMware vSphere', 'VMware Cloud on AWS', 'Homelab Infrastructure',
    'Cloudflare', 'AWS', 'Ansible', 'Kubernetes', 'Storage',
    'Self-hosted AI', 'Network Automation',
)  # pulled from actual category distribution — only substantive areas
PERSON_AWARDS = ('VMware vExpert',)  # already in homepage tagline + VEXPERT_START_YEAR
```

New `SEOFixer.fix_person_enrichment`:
- Walks `@graph` for `Person` entities.
- Only targets persons whose `name` matches `PERSON_CANONICAL_NAMES` (the site owner) — leaves quoted/mentioned other-person entries untouched.
- `sameAs`: drops `wordpress.jameskilby.cloud`, appends canonical URLs (case-insensitive dedupe).
- `jobTitle` / `knowsAbout` / `award`: added only if missing — re-run = no-op.

Wired into `SEOFixer.process_file` and `html_transformer._apply_seo_fixes` (per the docstring contract from [#47](https://github.com/jameskilbynet/jkcoukblog/pull/47)).

## Test plan

- [x] Three Python files parse (`ast.parse`)
- [x] Smoke-tested against live post HTML — both Person entries (the `#person` publisher entity and the `/author/admin/` Person) get enriched correctly; `wordpress.jameskilby.cloud` leak removed
- [x] Idempotency: re-run returns `False`
- [ ] Post-deploy: Person entity in any post's JSON-LD shows `sameAs: [github..., x...]`, `jobTitle`, `knowsAbout` (10 items), `award: 'VMware vExpert'`
- [ ] Post-deploy: no `wordpress.jameskilby.cloud` anywhere in JSON-LD anymore
- [ ] Manual: validate one post in [Google Rich Results Test](https://search.google.com/test/rich-results) — Person schema parses without warnings
- [ ] GSC follow-up (next reindex cycle, ~1-2 weeks): "Person" entity status appears in GSC's Enhancement reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)