### PR TITLE
fix(seo): strip wordpress.jameskilby.cloud leakage from generated HTML

### DIFF
--- a/scripts/fix_seo_issues.py
+++ b/scripts/fix_seo_issues.py
@@ -13,6 +13,13 @@ import re
 
 # Import config for target domain
 sys.path.insert(0, str(Path(__file__).parent))
+def _hostname(url):
+    """Strip scheme + trailing slash from a URL → bare hostname string."""
+    if not url:
+        return None
+    return url.replace('https://', '').replace('http://', '').rstrip('/').split('/')[0]
+
+
 try:
     from config import Config
     TARGET_DOMAIN = Config.TARGET_DOMAIN
@@ -26,6 +33,8 @@ try:
     PERSON_JOB_TITLE = getattr(Config, 'PERSON_JOB_TITLE', None)
     PERSON_KNOWS_ABOUT = tuple(getattr(Config, 'PERSON_KNOWS_ABOUT', ()))
     PERSON_AWARDS = tuple(getattr(Config, 'PERSON_AWARDS', ()))
+    WP_HOST = _hostname(getattr(Config, 'WP_URL', None))
+    TARGET_HOST = _hostname(TARGET_DOMAIN)
 except (ImportError, AttributeError):
     TARGET_DOMAIN = 'https://jameskilby.co.uk'
     HOMEPAGE_TITLE = None
@@ -36,6 +45,8 @@ except (ImportError, AttributeError):
     PERSON_JOB_TITLE = None
     PERSON_KNOWS_ABOUT = ()
     PERSON_AWARDS = ()
+    WP_HOST = None
+    TARGET_HOST = _hostname(TARGET_DOMAIN)
 
 
 class SEOFixer:
@@ -120,6 +131,9 @@ class SEOFixer:
                 modified = True
 
             if self.fix_twitter_attribution(soup, file_path):
+                modified = True
+
+            if self.fix_wordpress_host_leak(soup, file_path):
                 modified = True
 
             if self.fix_malformed_stylesheet_attr(soup, file_path):
@@ -1023,6 +1037,76 @@ class SEOFixer:
         if modified:
             self.issues_fixed += 1
             print(f"   🐦 Added twitter:site/twitter:creator ({TWITTER_HANDLE}): {file_path.name}")
+        return modified
+
+    def fix_wordpress_host_leak(self, soup, file_path):
+        """Strip vestigial references to the private WordPress host from the
+        generated HTML.
+
+        Three distinct leaks survive Rank Math + the pipeline's canonical-URL
+        rewriter:
+
+        1. oEmbed discovery <link> tags in <head>:
+              <link rel="alternate" type="application/json+oembed"
+                    href="/wp-json/oembed/1.0/embed?url=https%3A%2F%2F<wp>%2F...">
+              <link rel="alternate" type="application/xml+oembed"  href="...">
+           These point at /wp-json/oembed/... — a WordPress-only endpoint
+           that doesn't exist on the static site, so the links are broken
+           regardless. Strip them entirely.
+
+        2. Gutenberg block-editor internal-link metadata:
+              <a data-id="https://<wp>/2026/03/foo/" data-type="link"
+                 href="/2026/03/foo/">…</a>
+           Visible href is already the canonical jameskilby.co.uk URL; the
+           data-id is just internal block tracking. Rewrite host → target.
+
+        3. Defensive sweep: any other attribute containing the literal WP
+           hostname (raw or URL-encoded — dots aren't url-encoded, so the
+           literal string match catches both forms).
+
+        Single-pass over the soup, attributes only (text nodes left alone —
+        if a post mentions the host literally in prose, that's the author's
+        intent).
+
+        Idempotent.
+        """
+        if not WP_HOST or not TARGET_HOST or WP_HOST == TARGET_HOST:
+            return False
+
+        modified = False
+
+        # ── 1. Strip oEmbed discovery <link> tags ─────────────────────────
+        for link in list(soup.find_all('link', rel='alternate')):
+            link_type = (link.get('type') or '').lower()
+            if 'oembed' in link_type:
+                link.decompose()
+                modified = True
+
+        # ── 2 + 3. Rewrite WP_HOST → TARGET_HOST in all attribute values ─
+        # Fast-path gate: only walk the soup if the marker is present at all.
+        if WP_HOST in str(soup):
+            for tag in soup.find_all(True):
+                changed = False
+                for attr, value in list(tag.attrs.items()):
+                    if isinstance(value, str):
+                        if WP_HOST in value:
+                            tag[attr] = value.replace(WP_HOST, TARGET_HOST)
+                            changed = True
+                    elif isinstance(value, list):
+                        new_list = [
+                            (v.replace(WP_HOST, TARGET_HOST)
+                             if isinstance(v, str) and WP_HOST in v else v)
+                            for v in value
+                        ]
+                        if new_list != value:
+                            tag[attr] = new_list
+                            changed = True
+                if changed:
+                    modified = True
+
+        if modified:
+            self.issues_fixed += 1
+            print(f"   🧹 Stripped {WP_HOST} leakage: {file_path.name}")
         return modified
 
     def fix_malformed_stylesheet_attr(self, soup, file_path):

--- a/scripts/html_transformer.py
+++ b/scripts/html_transformer.py
@@ -291,6 +291,8 @@ class HTMLTransformer:
             modified = True
         if self.seo.fix_twitter_attribution(soup, file_path):
             modified = True
+        if self.seo.fix_wordpress_host_leak(soup, file_path):
+            modified = True
         return modified
 
     # Counters for the late-stage repair (Phase 4.8). We report these in the


### PR DESCRIPTION
## Summary

Post-[#54](https://github.com/jameskilbynet/jkcoukblog/pull/54) verification found three residual references to the private WordPress host (`wordpress.jameskilby.cloud`) in the generated HTML, none of which the canonical-URL rewriter catches:

1. **oEmbed discovery `<link>` tags** in `<head>` (1 JSON + 1 XML per page):
   ```html
   <link rel="alternate" type="application/json+oembed"
         href="/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwordpress.jameskilby.cloud%2F...">
   ```
   `/wp-json/oembed/...` is a WordPress-only endpoint that doesn't exist on the static site — these links are dead regardless of host. **Stripped.**

2. **Gutenberg block-editor metadata** on internal-link `<a>` tags:
   ```html
   <a data-id="https://wordpress.jameskilby.cloud/2026/03/foo/"
      data-type="link"
      href="/2026/03/foo/">…</a>
   ```
   Visible `href` is already the canonical `jameskilby.co.uk` URL; the `data-id` is just block-editor internal tracking. **Rewritten** to target host.

3. **Defensive sweep** over every attribute on every element for any other stray reference (raw or URL-encoded — dots aren't url-encoded so the literal match catches both forms).

Doesn't touch text nodes — if a post mentions the host literally in prose, that's the author's intent.

## Why it matters

Two reasons, only one of which is SEO:
- **Privacy/infrastructure exposure** — the private CMS host shouldn't be discoverable by anyone inspecting view-source.
- **Tiny SEO win** — removes 2 broken `<link>` tags per page (saves ~280 bytes uncompressed per page, no semantic change).

Not a ranking factor, but the right hygiene.

## Implementation

`WP_HOST` and `TARGET_HOST` derived from `Config.WP_URL` / `Config.TARGET_DOMAIN` so the policy is single-sourced. Method:
- Strips `<link rel="alternate">` tags whose `type` contains `oembed`.
- Walks all elements once, rewriting any attribute value (string or list) that contains `WP_HOST`.
- Fast-path gate on `WP_HOST in str(soup)` so unchanged pages exit early.

Wired into both `SEOFixer.process_file` and `html_transformer._apply_seo_fixes`.

## Test plan

- [x] Two Python files parse (`ast.parse`)
- [x] Sample post: 3 leaks + 2 oEmbed links → 0; idempotent re-run returns `False`
- [x] 2019 post: 2 leaks + 2 oEmbed links → 0
- [x] `/about-me/`: 2 leaks + 2 oEmbed links → 0
- [x] Homepage: already 0 leaks — no-op (result=False)
- [x] `/category/aws/`: already 0 — no-op
- [x] Person.sameAs from [#54](https://github.com/jameskilbynet/jkcoukblog/pull/54) remains untouched (only `github.com/jameskilbynet` + `x.com/jameskilbynet`)
- [ ] Post-deploy: `curl -s https://jameskilby.co.uk/<any-post>/ | grep wordpress.jameskilby.cloud` returns nothing
- [ ] Post-deploy: no `<link>` with `type="application/json+oembed"` or `type="application/xml+oembed"` on any page

🤖 Generated with [Claude Code](https://claude.com/claude-code)