### PR TITLE
fix(ci): declare workflow GITHUB_TOKEN permissions for org defaults

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -5,6 +5,11 @@ on:
   repository_dispatch:      # Webhook trigger
     types: [wordpress-update]
 
+# Org defaults GITHUB_TOKEN to read-only; this workflow commits the generated
+# site back to main, so it must explicitly grant contents: write.
+permissions:
+  contents: write
+
 # Prevent concurrent runs of this workflow
 concurrency:
   group: wordpress-static-site-deploy

--- a/.github/workflows/rollback-site.yml
+++ b/.github/workflows/rollback-site.yml
@@ -3,6 +3,9 @@ name: Rollback Site to Previous Commit
 on:
   workflow_dispatch:        # Manual trigger only
 
+permissions:
+  contents: write
+
 jobs:
   rollback:
     runs-on: self-hosted

--- a/.github/workflows/spell-check-approval-handler.yml
+++ b/.github/workflows/spell-check-approval-handler.yml
@@ -4,6 +4,11 @@ on:
   issue_comment:
     types: [created]
 
+# createDispatchEvent needs contents: write; comment/label edits need issues: write.
+permissions:
+  contents: write
+  issues: write
+
 jobs:
   handle-approval:
     # Only run on issues with the spell-check label

--- a/.github/workflows/spell-check-consolidated.yml
+++ b/.github/workflows/spell-check-consolidated.yml
@@ -28,6 +28,13 @@ on:
   repository_dispatch:
     types: [apply-spell-corrections, verify-spell-corrections]
 
+# Needs contents: write (timestamp commit), issues: write (open/update report
+# issues), actions: read (download artifacts from the dispatching run).
+permissions:
+  contents: write
+  issues: write
+  actions: read
+
 jobs:
   spell-check:
     if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary

After the move to the `jameskilbycloud` org, `github-actions[bot]` started getting 403 on push from the deploy workflow:

```
remote: Permission to jameskilbycloud/jkcoukblog.git denied to github-actions[bot].
fatal: ... The requested URL returned error: 403
```

**Root cause:** GitHub orgs default `GITHUB_TOKEN` to read-only; personal accounts historically defaulted to read/write. None of these workflows declared a `permissions:` block, so they used to inherit read/write from the personal account and now inherit read-only from the org.

**Fix:** declare the needed scopes explicitly per workflow.

| Workflow | Scopes added | Why |
|---|---|---|
| `deploy-static-site.yml` | `contents: write` | Commits + pushes the generated static site to `main` |
| `rollback-site.yml` | `contents: write` | Push (incl. force-push) during manual rollback |
| `spell-check-consolidated.yml` | `contents: write`, `issues: write`, `actions: read` | Timestamp commit, open/update report issues, download artifacts from the dispatching run |
| `spell-check-approval-handler.yml` | `contents: write`, `issues: write` | `createDispatchEvent` needs contents write; comment/label edits need issues write |

Other workflows (`secret-scan`, `issue-to-slack-improved`, `lighthouse-pr`, `quality-checks`, `enable-cloudflare-indexing`) only do read ops or post to Slack via webhook — org-default read-only token is fine.

This does not touch anything inside `public/`, so no auto-build diff impact.

## Test plan

- [ ] After merge, trigger `deploy-static-site.yml` manually (`gh workflow run deploy-static-site.yml`) and confirm the commit/push step succeeds
- [ ] Spot-check a subsequent `repository_dispatch` (`wordpress-update`) run completes end-to-end
- [ ] On next spell-check report run, confirm the report issue is created and (if approved) the timestamp commit lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)