### PR TITLE
fix(ci): skip interactive UI tests when chromium fails to launch

### DIFF
--- a/scripts/test_interactive_ui.py
+++ b/scripts/test_interactive_ui.py
@@ -57,6 +57,7 @@ from urllib.parse import urljoin
 
 try:
     from playwright.sync_api import sync_playwright, TimeoutError as PWTimeoutError
+    from playwright.sync_api import Error as PWError
     _PW_OK = True
     _PW_ERROR = None
 except ImportError as e:
@@ -99,6 +100,8 @@ class UISmokeTests:
     def __init__(self, base_url):
         self.base_url = base_url
         self.results = []
+        self.launch_failed = False
+        self.launch_error = None
 
     def record(self, name, ok, detail=""):
         self.results.append((name, ok, detail))
@@ -403,7 +406,17 @@ class UISmokeTests:
 
     def run_all(self):
         with sync_playwright() as p:
-            browser = p.chromium.launch(headless=True)
+            try:
+                browser = p.chromium.launch(headless=True)
+            except PWError as e:
+                # Chromium binary present but failed to launch — usually a
+                # missing system lib on the runner (e.g. libatk-1.0.so.0).
+                # Treat the same as "playwright unavailable": skip, exit 0,
+                # let the build proceed. The banner is grep-friendly so
+                # missing libs still surface in CI logs.
+                self.launch_failed = True
+                self.launch_error = str(e).splitlines()[0]
+                return
             try:
                 self.test_mobile_drawer_opens(browser)
                 self.test_splide_carousel_initializes(browser)
@@ -441,6 +454,15 @@ def main():
         print(f"   Serving from {base_url}\n")
         tests = UISmokeTests(base_url)
         tests.run_all()
+
+    if tests.launch_failed:
+        print("=" * 72)
+        print(f"⚠️  Interactive UI tests SKIPPED — chromium failed to launch")
+        print(f"    ({tests.launch_error})")
+        print(f"    Likely missing system libs (libatk-1.0.so.0 etc).")
+        print(f"    Install with: sudo playwright install-deps chromium")
+        print("=" * 72)
+        sys.exit(0)
 
     elapsed = time.time() - start
     passed = sum(1 for _, ok, _ in tests.results if ok)


### PR DESCRIPTION
## Summary

Follow-up to #56 — addresses the cosmetic-red smoke-test step on the self-hosted runner.

The Playwright step in [`deploy-static-site.yml:800-830`](.github/workflows/deploy-static-site.yml) is wrapped in `continue-on-error: true` with an inline comment that says: *"if [the libs] ever go missing, `test_interactive_ui.py` prints its SKIP banner and `continue-on-error: true` below still lets the build pass."* That wasn't actually true — only the **import-failure** path skipped cleanly; a **chromium-launch** failure (e.g. `libatk-1.0.so.0: cannot open shared object file`) propagated as a `playwright._impl._errors.TargetClosedError` and exited the step non-zero.

`continue-on-error: true` still let the overall workflow succeed, so this never blocked a deploy — but the step appeared red in the UI and made every other failure (including the org-move push permission issue in #56) harder to spot.

**Fix:** wrap `p.chromium.launch()` in a `try/except PWError`, flip a `launch_failed` flag, and print the same SKIP banner pattern `main()` already uses for the import-failure path.

```
========================================================================
⚠️  Interactive UI tests SKIPPED — chromium failed to launch
    (BrowserType.launch: ... libatk-1.0.so.0: cannot open shared object file)
    Likely missing system libs (libatk-1.0.so.0 etc).
    Install with: sudo playwright install-deps chromium
========================================================================
```

This is defence-in-depth — the *real* fix is to install the missing libs on the self-hosted runner. Run this once on the runner box:

```bash
sudo apt-get install -y \
  libatk1.0-0 libatk-bridge2.0-0 libcups2 libxkbcommon0 \
  libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 \
  libpango-1.0-0 libcairo2 libasound2t64
# or equivalently:
sudo playwright install-deps chromium
```

After that the smoke tests will actually run again, and the new skip path serves only as a safety net for future regressions.

## Test plan

- [ ] Confirm the next deploy workflow run shows the SKIP banner (not the traceback) in the smoke-test step until libs are installed
- [ ] After installing the libs on the runner, confirm the smoke tests pass (4/4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)