### PR TITLE
chore: site audit — security, perf and SEO fixes

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -830,7 +830,19 @@ jobs:
           # auto-detecting the OS as unsupported); if they ever go missing,
           # test_interactive_ui.py prints its SKIP banner and
           # `continue-on-error: true` below still lets the build pass.
-          python3 -m playwright install chromium
+          #
+          # We swallow a non-zero exit here because Playwright validates the
+          # host OS against a hardcoded allowlist and refuses to install on
+          # any release newer than what its pinned binaries support (e.g.
+          # "Playwright does not support chromium on ubuntu26.04-x64").
+          # test_interactive_ui.py catches the missing-chromium case and
+          # prints its own SKIP banner via the launch_failed path, so this
+          # step ends up green and the SKIP is visible in build logs.
+          # Bump the playwright pip package when a newer one adds support.
+          if ! python3 -m playwright install chromium; then
+            echo "::warning::Playwright refused to install chromium on this runner OS — smoke tests will SKIP."
+            echo "    Bump the playwright pip package once a release adds the new OS to its allowlist."
+          fi
         fi
 
         python3 scripts/test_interactive_ui.py ./static-output

--- a/_headers
+++ b/_headers
@@ -40,7 +40,49 @@
 # Security headers (all pages)
 /*
   X-Content-Type-Options: nosniff
-  X-XSS-Protection: 1; mode=block
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), microphone=(), camera=()
-  Content-Security-Policy: frame-ancestors 'self'; frame-src 'self' https://embed.acast.com https://www.youtube.com https://youtube.com https://utteranc.es https://www.credly.com https://www.youracclaim.com; script-src 'self' 'unsafe-inline' cdn.credly.com cdn.youracclaim.com;
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' plausible.jameskilby.cloud utteranc.es static.cloudflareinsights.com cdn.credly.com cdn.youracclaim.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' plausible.jameskilby.cloud cloudflareinsights.com; frame-src https://www.youtube.com https://player.vimeo.com https://embed.acast.com https://utteranc.es https://plausible.jameskilby.cloud https://www.credly.com https://www.youracclaim.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'
+
+# ── HTML-only headers — strip from non-document responses ────────────────────
+# CSP / X-Frame-Options / Permissions-Policy only govern HTML documents.
+# Stripping them from asset paths saves ~700 bytes per sub-resource response.
+/wp-content/*
+  ! Content-Security-Policy
+  ! X-Frame-Options
+  ! Permissions-Policy
+
+/assets/*
+  ! Content-Security-Policy
+  ! X-Frame-Options
+  ! Permissions-Policy
+
+/js/*
+  ! Content-Security-Policy
+  ! X-Frame-Options
+  ! Permissions-Policy
+
+/api/*
+  ! Content-Security-Policy
+  ! X-Frame-Options
+  ! Permissions-Policy
+
+/markdown/*
+  ! Content-Security-Policy
+  ! X-Frame-Options
+  ! Permissions-Policy
+
+/feed/index.xml
+  ! Content-Security-Policy
+  ! X-Frame-Options
+  ! Permissions-Policy
+
+/sitemap.xml
+  ! Content-Security-Policy
+  ! X-Frame-Options
+  ! Permissions-Policy
+
+/search-index*.json
+  ! Content-Security-Policy
+  ! X-Frame-Options
+  ! Permissions-Policy

--- a/_worker.template.js
+++ b/_worker.template.js
@@ -102,6 +102,23 @@ export default {
     }
     // ────────────────────────────────────────────────────────────────────────
 
+    // ── /YYYY/MM/DD/<slug>/ → /YYYY/MM/<slug>/ (301 permanent) ──────────────
+    // Legacy WordPress permalink format included the day. The static
+    // generator emits /YYYY/MM/<slug>/ only, so day-format URLs from old
+    // backlinks, archived snapshots and shared social-card links 404 with
+    // no recovery. Rewrite to the monthly canonical so link equity isn't
+    // lost. Matches /<4-digit>/<2-digit>/<2-digit>/<rest> only — won't
+    // collide with /wp-content/... or other top-level paths.
+    const dayPermalinkMatch = path.match(/^\/(\d{4})\/(\d{2})\/\d{2}\/(.+)$/);
+    if (dayPermalinkMatch) {
+      const [, year, month, rest] = dayPermalinkMatch;
+      return Response.redirect(
+        `https://jameskilby.co.uk/${year}/${month}/${rest}${url.search}`,
+        301
+      );
+    }
+    // ────────────────────────────────────────────────────────────────────────
+
     // ── Admin / diagnostic endpoints ────────────────────────────────────────
     // These must be checked BEFORE the GET-only guard so POST purges work,
     // and BEFORE shouldCache so they are never accidentally cached.
@@ -408,11 +425,17 @@ async function handleCacheAPI(request, env, ctx, path, hostname = '') {
 
 /**
  * Get security headers for all responses.
+ *
+ * Note: Content-Security-Policy is intentionally NOT set here. Cloudflare Pages
+ * applies `_headers` rules AFTER worker responses, so any CSP set here would be
+ * silently overridden — `_headers` (and `scripts/wp_to_static_generator.py`,
+ * which generates `public/_headers`) is the single source of truth for CSP.
+ * Validation lives in scripts/test_csp.py.
+ *
  * Pass hostname to automatically add X-Robots-Tag: noindex on the Pages preview domain.
  */
 function getSecurityHeaders(hostname = '') {
   const headers = {
-    'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' plausible.io plausible.jameskilby.cloud https://utteranc.es cdn.credly.com cdn.youracclaim.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' plausible.io plausible.jameskilby.cloud https://api.github.com https://cloudflareinsights.com; frame-src 'self' plausible.jameskilby.cloud https://utteranc.es https://www.youtube.com https://youtube.com https://embed.acast.com https://www.credly.com https://www.youracclaim.com;",
     'X-Frame-Options': 'SAMEORIGIN',
     'X-Content-Type-Options': 'nosniff',
     'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',

--- a/public/_headers
+++ b/public/_headers
@@ -60,10 +60,7 @@
 /*
   # Clickjacking Protection - prevents site from being embedded in iframes
   X-Frame-Options: SAMEORIGIN
-  
-  # XSS Protection for older browsers
-  X-XSS-Protection: 1; mode=block
-  
+
   # Prevent MIME type sniffing
   X-Content-Type-Options: nosniff
   
@@ -75,4 +72,51 @@
   Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=()
   
   # Content Security Policy - controls what resources can load
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https: cdn.jsdelivr.net plausible.jameskilby.cloud utteranc.es github.com static.cloudflareinsights.com cdn.credly.com cdn.youracclaim.com; style-src 'self' 'unsafe-inline' https: github.com; img-src 'self' data: https:; font-src 'self' data: https:; connect-src 'self' https: plausible.jameskilby.cloud; frame-src https://www.youtube.com https://player.vimeo.com https://embed.acast.com https://utteranc.es https://plausible.jameskilby.cloud https://www.credly.com https://www.youracclaim.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' plausible.jameskilby.cloud utteranc.es static.cloudflareinsights.com cdn.credly.com cdn.youracclaim.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' plausible.jameskilby.cloud cloudflareinsights.com; frame-src https://www.youtube.com https://player.vimeo.com https://embed.acast.com https://utteranc.es https://plausible.jameskilby.cloud https://www.credly.com https://www.youracclaim.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'
+
+# ── HTML-only headers — strip from non-document responses ────────────────────
+# Content-Security-Policy, X-Frame-Options and Permissions-Policy only govern
+# HTML documents; sending them on every image / font / JSON / markdown / feed
+# response is ~700 bytes of dead header weight per sub-resource. The `! Header`
+# syntax removes a header that an earlier matching block (above) set, so the
+# global `/*` rule still applies — just minus these three on asset paths.
+# X-Content-Type-Options (nosniff) and HSTS stay global on purpose.
+/wp-content/*
+  ! Content-Security-Policy
+  ! X-Frame-Options
+  ! Permissions-Policy
+
+/assets/*
+  ! Content-Security-Policy
+  ! X-Frame-Options
+  ! Permissions-Policy
+
+/js/*
+  ! Content-Security-Policy
+  ! X-Frame-Options
+  ! Permissions-Policy
+
+/api/*
+  ! Content-Security-Policy
+  ! X-Frame-Options
+  ! Permissions-Policy
+
+/markdown/*
+  ! Content-Security-Policy
+  ! X-Frame-Options
+  ! Permissions-Policy
+
+/feed/index.xml
+  ! Content-Security-Policy
+  ! X-Frame-Options
+  ! Permissions-Policy
+
+/sitemap.xml
+  ! Content-Security-Policy
+  ! X-Frame-Options
+  ! Permissions-Policy
+
+/search-index*.json
+  ! Content-Security-Policy
+  ! X-Frame-Options
+  ! Permissions-Policy

--- a/scripts/brutalist-theme.css
+++ b/scripts/brutalist-theme.css
@@ -2,16 +2,26 @@
 
 /* Self-hosted fonts — declared inline (not @imported) so the browser
    discovers @font-face URLs as soon as this stylesheet parses, instead
-   of waiting on a second render-blocking request for fonts.css. With
-   font-display: optional, fonts arriving after the swap window are
-   silently dropped. /assets/fonts/fonts.css is now a no-op kept on
-   disk for any external references; safe to remove later. */
+   of waiting on a second render-blocking request for fonts.css.
+
+   Two-tier strategy:
+     - font-display: optional  → preloaded by enhance_html_performance.py
+                                 so they arrive within the block window
+                                 and avoid being silently dropped. Reserve
+                                 for fonts used in initial above-the-fold
+                                 rendering only (body + h1/h2 headings).
+     - font-display: swap      → not preloaded. Renders with system
+                                 fallback first, swaps to the web font
+                                 when it loads. Use for everything else
+                                 (bold variants, code blocks).
+   Adding more `optional` fonts pushes them up the priority queue past
+   the LCP image, so think twice before promoting. */
 @font-face{font-family:"Anton";font-style:normal;font-weight:400;font-display:optional;src:url(/assets/fonts/anton-v27-latin-400.woff2) format("woff2")}
-@font-face{font-family:"JetBrains Mono";font-style:normal;font-weight:400;font-display:optional;src:url(/assets/fonts/jetbrainsmono-v24-latin-400.woff2) format("woff2")}
-@font-face{font-family:"JetBrains Mono";font-style:normal;font-weight:700;font-display:optional;src:url(/assets/fonts/jetbrainsmono-v24-latin-700.woff2) format("woff2")}
+@font-face{font-family:"JetBrains Mono";font-style:normal;font-weight:400;font-display:swap;src:url(/assets/fonts/jetbrainsmono-v24-latin-400.woff2) format("woff2")}
+@font-face{font-family:"JetBrains Mono";font-style:normal;font-weight:700;font-display:swap;src:url(/assets/fonts/jetbrainsmono-v24-latin-700.woff2) format("woff2")}
 @font-face{font-family:"Space Grotesk";font-style:normal;font-weight:400;font-display:optional;src:url(/assets/fonts/spacegrotesk-v22-latin-400.woff2) format("woff2")}
-@font-face{font-family:"Space Grotesk";font-style:normal;font-weight:500;font-display:optional;src:url(/assets/fonts/spacegrotesk-v22-latin-500.woff2) format("woff2")}
-@font-face{font-family:"Space Grotesk";font-style:normal;font-weight:700;font-display:optional;src:url(/assets/fonts/spacegrotesk-v22-latin-700.woff2) format("woff2")}
+@font-face{font-family:"Space Grotesk";font-style:normal;font-weight:500;font-display:swap;src:url(/assets/fonts/spacegrotesk-v22-latin-500.woff2) format("woff2")}
+@font-face{font-family:"Space Grotesk";font-style:normal;font-weight:700;font-display:swap;src:url(/assets/fonts/spacegrotesk-v22-latin-700.woff2) format("woff2")}
 
 /* Root variables and noise overlay */
 :root {

--- a/scripts/enhance_html_performance.py
+++ b/scripts/enhance_html_performance.py
@@ -47,6 +47,9 @@ class HTMLPerformanceEnhancer:
             if self.add_media_attributes_to_css(soup):
                 modified = True
 
+            if self.strip_http_equiv_meta(soup):
+                modified = True
+
             if self.optimize_external_scripts(soup):
                 modified = True
 
@@ -141,10 +144,19 @@ class HTMLPerformanceEnhancer:
         return modified
 
     def optimize_external_scripts(self, soup):
-        """Optimize external script loading"""
+        """Manage <link rel="dns-prefetch"> hints.
+
+        Three passes:
+          1. Collect the set of external hosts actually referenced by any
+             script/link/img on the page.
+          2. Walk every existing dns-prefetch tag: drop duplicates (by
+             normalized host) and drop hints whose host is no longer
+             referenced (e.g. cdn.jsdelivr.net after we vendored fuse/splide).
+          3. Add a dns-prefetch hint for any referenced external host that
+             doesn't already have one.
+        """
         modified = False
 
-        # Find head tag
         if not soup.head:
             return False
 
@@ -157,26 +169,76 @@ class HTMLPerformanceEnhancer:
         except Exception:
             same_origin_hosts = set()
 
-        # Add DNS prefetch for external domains
-        external_domains = set()
+        def _host(href):
+            """Extract the bare host from `//x`, `https://x/...`, or `x`."""
+            if not href:
+                return ''
+            h = href.strip()
+            if h.startswith('//'):
+                h = h[2:]
+            elif '://' in h:
+                h = h.split('://', 1)[1]
+            return h.split('/', 1)[0].lower()
 
-        for tag in soup.find_all(['script', 'link', 'img'], src=True):
-            src = tag.get('src') or tag.get('href', '')
-            if src.startswith('http'):
-                domain = src.split('/')[2]
-                if domain in same_origin_hosts:
+        # 1. External hosts the page actually uses. Resource hints
+        #    (dns-prefetch, preconnect, prefetch, preload to a remote host)
+        #    are hints, not real references — exclude them or stale hints
+        #    self-reference their own host and never get pruned.
+        hint_rels = {'dns-prefetch', 'preconnect', 'prefetch', 'preload'}
+        referenced_hosts = set()
+        for tag in soup.find_all(['script', 'link', 'img']):
+            if tag.name == 'link':
+                rels = tag.get('rel') or []
+                if isinstance(rels, str):
+                    rels = [rels]
+                if any(r.lower() in hint_rels for r in rels):
                     continue
-                external_domains.add(domain)
+            src = tag.get('src') or tag.get('href', '')
+            if not src or not (src.startswith('http') or src.startswith('//')):
+                continue
+            host = _host(src)
+            if host and host not in same_origin_hosts:
+                referenced_hosts.add(host)
 
-        # Add dns-prefetch for each external domain
-        for domain in external_domains:
-            # Check if dns-prefetch already exists
-            existing = soup.find('link', rel='dns-prefetch', href=f'//{domain}')
-            if not existing:
-                dns_prefetch = soup.new_tag('link')
-                dns_prefetch['rel'] = 'dns-prefetch'
-                dns_prefetch['href'] = f'//{domain}'
-                soup.head.insert(0, dns_prefetch)
+        # 2. Prune existing dns-prefetch tags: dedupe and drop stale hosts.
+        seen_hosts = set()
+        for link in soup.find_all('link', rel='dns-prefetch'):
+            host = _host(link.get('href', ''))
+            if not host or host not in referenced_hosts or host in seen_hosts:
+                link.decompose()
+                modified = True
+                self.optimizations_applied += 1
+                continue
+            seen_hosts.add(host)
+
+        # 3. Add dns-prefetch for any referenced host without one.
+        for host in referenced_hosts - seen_hosts:
+            dns_prefetch = soup.new_tag('link')
+            dns_prefetch['rel'] = 'dns-prefetch'
+            dns_prefetch['href'] = f'//{host}'
+            soup.head.insert(0, dns_prefetch)
+            modified = True
+            self.optimizations_applied += 1
+
+        return modified
+
+    def strip_http_equiv_meta(self, soup):
+        """Remove <meta http-equiv> tags for headers that must come from HTTP.
+
+        The HTML payload carries `<meta http-equiv="Cache-Control" ...>` etc.
+        from upstream WordPress; the real HTTP response from Cloudflare Pages
+        already sets these (often to different values). Some intermediaries
+        and audit tools honour the meta tag, producing confusing divergence.
+        Strip them so the HTTP headers are the only source of truth.
+        """
+        if not soup.head:
+            return False
+
+        stripped = {'cache-control', 'pragma', 'expires'}
+        modified = False
+        for meta in soup.find_all('meta', attrs={'http-equiv': True}):
+            if meta.get('http-equiv', '').lower() in stripped:
+                meta.decompose()
                 modified = True
                 self.optimizations_applied += 1
 
@@ -220,32 +282,55 @@ class HTMLPerformanceEnhancer:
         return modified
 
     def optimize_fonts(self, soup):
-        """Optimize web font loading"""
+        """Preload WOFF2 fonts that need to render in the first viewport.
+
+        Only fonts whose @font-face block declares `font-display: optional`
+        get a preload hint. Rationale:
+          - `optional` silently drops fonts that miss the short block
+            window, so they're only useful when preloaded.
+          - `swap` fonts render with a system fallback first and swap
+            in when loaded — preloading them just pushes them past the
+            LCP image in the priority queue for no visual win.
+        Promoting a font to `optional` in the CSS automatically opts it
+        into preloading; demoting to `swap` automatically opts out.
+        """
         if not soup.head:
             return False
 
         modified = False
 
-        # Find and preload WOFF2 fonts from @font-face declarations
-        for style in soup.find_all('style'):
-            if style.string and '@font-face' in style.string:
-                # Extract WOFF2 font URLs
-                font_urls = re.findall(r'url\(["\']?(.*?\.woff2)["\']?\)', style.string)
-                for font_url in font_urls:
-                    font_url = font_url.strip('\'"')
+        # Match each @font-face { ... } block and capture its body so we
+        # can inspect font-display and the src url() together.
+        font_face_re = re.compile(r'@font-face\s*\{([^}]*)\}', re.IGNORECASE)
+        url_re = re.compile(r'url\(["\']?([^"\')]+\.woff2)["\']?\)', re.IGNORECASE)
+        display_re = re.compile(r'font-display\s*:\s*([a-z]+)', re.IGNORECASE)
 
-                    # Check if preload already exists
+        for style in soup.find_all('style'):
+            if not style.string or '@font-face' not in style.string:
+                continue
+
+            for block in font_face_re.finditer(style.string):
+                body = block.group(1)
+                display_match = display_re.search(body)
+                if not display_match or display_match.group(1).lower() != 'optional':
+                    continue
+
+                for url_match in url_re.finditer(body):
+                    font_url = url_match.group(1).strip()
+
                     existing = soup.find('link', rel='preload', href=font_url)
-                    if not existing:
-                        preload = soup.new_tag('link')
-                        preload['rel'] = 'preload'
-                        preload['href'] = font_url
-                        preload['as'] = 'font'
-                        preload['type'] = 'font/woff2'
-                        preload['crossorigin'] = ''
-                        soup.head.insert(0, preload)
-                        modified = True
-                        self.optimizations_applied += 1
+                    if existing:
+                        continue
+
+                    preload = soup.new_tag('link')
+                    preload['rel'] = 'preload'
+                    preload['href'] = font_url
+                    preload['as'] = 'font'
+                    preload['type'] = 'font/woff2'
+                    preload['crossorigin'] = ''
+                    soup.head.insert(0, preload)
+                    modified = True
+                    self.optimizations_applied += 1
 
         return modified
 
@@ -320,12 +405,14 @@ class HTMLPerformanceEnhancer:
         return modified
 
     def optimize_images(self, soup):
-        """Add lazy loading, fetchpriority, and responsive attributes to images.
+        """Normalise image loading hints around a single LCP candidate.
 
-        fetchpriority="high" is applied only to the first image found inside
-        <main> or <article> — the most likely LCP candidate. Images outside
-        that scope (logos, nav icons, sidebar thumbnails) are never given high
-        priority and always receive loading="lazy" instead.
+        Exactly one image — the first inside <main>/<article> — gets
+        fetchpriority="high" and no lazy hint. Every other image is
+        force-set to loading="lazy" and any inherited fetchpriority="high"
+        is stripped. WordPress emits loading="eager" on every post
+        thumbnail in archive listings; without this, multiple eager
+        images compete with the real LCP and burn its priority slot.
         """
         if not soup.body:
             return False
@@ -338,15 +425,23 @@ class HTMLPerformanceEnhancer:
 
         for img in soup.find_all('img'):
             if img is lcp_img:
-                # Likely LCP element — hint the browser to fetch it early.
-                if not img.get('fetchpriority'):
+                # Likely LCP element — fetch early, never lazy.
+                if img.get('fetchpriority') != 'high':
                     img['fetchpriority'] = 'high'
                     modified = True
                     self.optimizations_applied += 1
+                if img.get('loading') == 'lazy':
+                    del img['loading']
+                    modified = True
+                    self.optimizations_applied += 1
             else:
-                # Everything else: defer loading until near the viewport.
-                if not img.get('loading'):
+                # Everything else: force lazy and drop any stray high priority.
+                if img.get('loading') != 'lazy':
                     img['loading'] = 'lazy'
+                    modified = True
+                    self.optimizations_applied += 1
+                if img.get('fetchpriority') == 'high':
+                    del img['fetchpriority']
                     modified = True
                     self.optimizations_applied += 1
 

--- a/scripts/minify_html.py
+++ b/scripts/minify_html.py
@@ -11,6 +11,15 @@ from pathlib import Path
 
 def minify_html(html):
     """Minify HTML while preserving pre/code/script/style content."""
+
+    # Drop a garbage attribute injected upstream by the WP Rocket / Kadence
+    # async-CSS pattern. The end of the <link> tag looks like:
+    #     ... rel="preload" stylesheet'"=""/>
+    # The literal `stylesheet'"=""` is parsed by browsers as an empty-valued
+    # attribute whose name is `stylesheet'"`. Strip it before minification.
+    # See https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
+    html = html.replace(' stylesheet\'"=""', '')
+
     placeholders = []
 
     def _stash(match):

--- a/scripts/test_csp.py
+++ b/scripts/test_csp.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 """
-Consolidated CSP test — validates that _worker.template.js CSP headers
-allow all required third-party services (Utterances, Credly, Plausible).
+Consolidated CSP test — validates that the deployed CSP allows all required
+third-party services (Utterances, Credly, Plausible).
+
+The CSP lives in _headers (Cloudflare Pages applies it after the worker, so
+that's the source of truth). Validation reads from _headers directly.
 
 Usage:
     python3 scripts/test_csp.py              # Test all providers
@@ -14,13 +17,15 @@ import re
 from pathlib import Path
 
 # Each provider defines which domains must appear in which CSP directives.
+# Only the *parent* page's requirements are enforced here — iframe content
+# (e.g. Utterances calling api.github.com from inside its own iframe) is
+# governed by the iframe's own CSP, not ours.
 PROVIDERS = {
     'utterances': {
         'label': 'Utterances comments',
         'checks': {
             'script-src': ['utteranc.es'],
             'frame-src': ['utteranc.es'],
-            'connect-src': ['api.github.com'],
         },
         'blocked_msg': 'Utterances will be blocked by CSP!',
         'success_msg': 'CSP correctly configured for Utterances!',
@@ -35,10 +40,12 @@ PROVIDERS = {
         'success_msg': 'CSP correctly configured for Credly badges!',
     },
     'plausible': {
+        # This site uses self-hosted Plausible at plausible.jameskilby.cloud
+        # (proxied via /js/script.js). plausible.io is not used.
         'label': 'Plausible Analytics',
         'checks': {
-            'script-src': ['plausible.io', 'plausible.jameskilby.cloud'],
-            'connect-src': ['plausible.io', 'plausible.jameskilby.cloud'],
+            'script-src': ['plausible.jameskilby.cloud'],
+            'connect-src': ['plausible.jameskilby.cloud'],
             'frame-src': ['plausible.jameskilby.cloud'],
         },
         'blocked_msg': 'Plausible Analytics will be blocked by CSP!',
@@ -48,19 +55,24 @@ PROVIDERS = {
 
 
 def read_csp():
-    """Read and return the CSP string from _worker.template.js."""
-    worker_file = Path('_worker.template.js')
-    if not worker_file.exists():
-        print("❌ _worker.template.js not found!")
+    """Read and return the CSP string from _headers (root)."""
+    headers_file = Path('_headers')
+    if not headers_file.exists():
+        print("❌ _headers not found!")
         return None
 
-    content = worker_file.read_text()
-    csp_match = re.search(r"'Content-Security-Policy':\s*\"([^\"]+)\"", content)
+    content = headers_file.read_text()
+    # _headers lines look like:  Content-Security-Policy: default-src 'self'; ...
+    csp_match = re.search(
+        r"^\s*Content-Security-Policy:\s*(.+)$",
+        content,
+        re.MULTILINE,
+    )
     if not csp_match:
-        print("❌ No CSP header found in Worker!")
+        print("❌ No Content-Security-Policy line found in _headers!")
         return None
 
-    return csp_match.group(1)
+    return csp_match.group(1).strip()
 
 
 def check_provider(csp, name):

--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -3757,9 +3757,6 @@ document.addEventListener('DOMContentLoaded', function() {
             "  # Clickjacking Protection - prevents site from being embedded in iframes",
             "  X-Frame-Options: SAMEORIGIN",
             "  ",
-            "  # XSS Protection for older browsers",
-            "  X-XSS-Protection: 1; mode=block",
-            "  ",
             "  # Prevent MIME type sniffing",
             "  X-Content-Type-Options: nosniff",
             "  ",
@@ -3771,9 +3768,30 @@ document.addEventListener('DOMContentLoaded', function() {
             "  Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=()",
             "  ",
             "  # Content Security Policy - controls what resources can load",
-            "  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https: cdn.jsdelivr.net plausible.jameskilby.cloud utteranc.es github.com static.cloudflareinsights.com cdn.credly.com cdn.youracclaim.com; style-src 'self' 'unsafe-inline' https: github.com; img-src 'self' data: https:; font-src 'self' data: https:; connect-src 'self' https: plausible.jameskilby.cloud; frame-src https://www.youtube.com https://player.vimeo.com https://embed.acast.com https://utteranc.es https://plausible.jameskilby.cloud https://www.credly.com https://www.youracclaim.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'",
+            "  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' plausible.jameskilby.cloud utteranc.es static.cloudflareinsights.com cdn.credly.com cdn.youracclaim.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' plausible.jameskilby.cloud cloudflareinsights.com; frame-src https://www.youtube.com https://player.vimeo.com https://embed.acast.com https://utteranc.es https://plausible.jameskilby.cloud https://www.credly.com https://www.youracclaim.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'",
+            "",
+            "# ── HTML-only headers — strip from non-document responses ────────────────────",
+            "# CSP / X-Frame-Options / Permissions-Policy only govern HTML documents.",
+            "# Stripping them from asset paths saves ~700 bytes per sub-resource response.",
         ]
-        
+        for asset_path in (
+            '/wp-content/*',
+            '/assets/*',
+            '/js/*',
+            '/api/*',
+            '/markdown/*',
+            '/feed/index.xml',
+            '/sitemap.xml',
+            '/search-index*.json',
+        ):
+            headers_content.extend([
+                asset_path,
+                "  ! Content-Security-Policy",
+                "  ! X-Frame-Options",
+                "  ! Permissions-Policy",
+                "",
+            ])
+
         headers_file = self.output_dir / '_headers'
         headers_file.write_text('\n'.join(headers_content))
         print("   ✅ Created _headers file with security headers")


### PR DESCRIPTION
## Summary

Implements ten recommendations from a live-site audit of jameskilby.co.uk against the build pipeline. Touches the worker, `_headers`, three pipeline scripts, the theme CSS, the CSP validator and one CI step.

### Security
- **#1 Tighten CSP** — drop `https:` wildcard from `script-src`/`style-src`/`font-src`/`connect-src` (it neutralised the named allowlists), remove dead `cdn.jsdelivr.net` (vendored away in 082819854c), add `cloudflareinsights.com` for the RUM beacon.
- **#2 Single CSP source of truth** — Pages applies `_headers` *after* the worker, so the worker's CSP was being silently overridden. Removed from `getSecurityHeaders()` in `_worker.template.js`. `scripts/test_csp.py` now validates `_headers` and reflects this site's setup (self-hosted Plausible, no parent-side `api.github.com`).
- **#3 Drop X-XSS-Protection** — MDN/OWASP recommend removal: no-op in modern browsers, DOM-XSS vector in legacy ones.
- **#8 Scope HTML-only headers** — CSP, X-Frame-Options and Permissions-Policy only govern HTML documents. Stripped from asset paths (`/wp-content/*`, `/assets/*`, `/js/*`, `/api/*`, `/markdown/*`, `/feed/index.xml`, `/sitemap.xml`, `/search-index*.json`) using `! Header-Name`. Saves ~700 bytes per sub-resource on cold loads. HSTS and X-Content-Type-Options stay global.

### Performance
- **#4 Strip malformed `stylesheet'"=""` attribute** — upstream WordPress emits this garbage attribute on every async-CSS preload `<link>`. Removed in `scripts/minify_html.py` before minification.
- **#5 LCP-only `loading="eager"`** — previously `loading` was only set if absent, so post listings shipped 3 eager images competing for the LCP slot. Now the LCP candidate keeps `fetchpriority="high"` and loses any `loading="lazy"`; every other image is force-set to `loading="lazy"` and any stray `fetchpriority="high"` stripped.
- **#6 Dedupe + prune dns-prefetch** — drop duplicate hints (by normalized host) and any hints to hosts no longer referenced by a script/link/img. Excludes hint-rel links from the "referenced hosts" scan so stale hints don't self-reference.
- **#7 Strip conflicting `<meta http-equiv>`** — `Cache-Control`/`Pragma`/`Expires` meta tags from upstream WP conflicted with the real HTTP response (5 min vs 24 h). New `strip_http_equiv_meta()` pass removes them so HTTP headers are the only source of truth.
- **#9 Trim font preloads 6 → 2** — tied preloading to `font-display`: only `optional` fonts (genuinely needed in first paint) get a preload hint; `swap` fonts load on demand. Demoted JetBrains Mono 400/700 and Space Grotesk 500/700 to `swap` in `brutalist-theme.css`.

### SEO
- **#10 301 day-permalink → month-permalink** — legacy WordPress day-format URLs (`/YYYY/MM/DD/<slug>/`) were 404-ing with no recovery; backlinks, social-card hits and archived snapshots now redirect to `/YYYY/MM/<slug>/` and preserve link equity. Regex scoped so `/wp-content/...` and other top-level paths can't collide.

### Build infra
- Make the Playwright chromium install resilient to a runner OS newer than Playwright's hardcoded allowlist (symptom: `Playwright does not support chromium on ubuntu26.04-x64`). Wrap the install in `if !` so a refusal becomes a `::warning::` instead of a red step. `test_interactive_ui.py` already prints its SKIP banner when chromium can't launch.

## Files touched

- `_headers`, `public/_headers`, `scripts/wp_to_static_generator.py` (CSP value + asset-path strip blocks)
- `_worker.template.js` (CSP removed, day-permalink redirect added)
- `scripts/enhance_html_performance.py` (image, dns-prefetch, font, meta-tag passes)
- `scripts/minify_html.py` (garbage-attribute strip)
- `scripts/brutalist-theme.css` (font-display strategy)
- `scripts/test_csp.py` (validator repointed at `_headers`)
- `.github/workflows/deploy-static-site.yml` (Playwright install resilience)

## PR landing notes for the next auto-commit

This PR changes script output. The first auto-pipeline run after merge will regenerate `public/` HTML with:
- 2 font preloads instead of 6 per post page
- Exactly 1 `loading="eager"` image per page (the LCP)
- No `stylesheet'"=""` garbage attributes
- No conflicting `<meta http-equiv>`
- Deduped dns-prefetch hints

That auto-commit diff will be large for the same reason — it's mechanical, not content.

## Test plan

- [x] `make test-csp` passes against new `_headers` (Utterances + Credly + Plausible all green)
- [x] `python3 -c "import ast; ast.parse(open('scripts/X').read())"` for every touched Python script
- [x] `node --check _worker.template.js` passes
- [x] Local smoke test against real post HTML: 7 garbage attrs → 0, 3 eager imgs → 1, 4 dns-prefetch hints → 1, 3 http-equiv metas → 0, 6 font preloads → 2 (body + heading only)
- [ ] Post-merge: re-run the verification commands below against the live site

## Live-site verification (post-merge)

```bash
H=https://jameskilby.co.uk
P=$H/2026/04/vsphere-power-management-driven-by-ansible/

# #1 — CSP tightened; no `https:` wildcard, no jsdelivr, has cloudflareinsights in connect-src
curl -sI $H/ | grep -i content-security-policy

# #3 — X-XSS-Protection gone (expect empty)
curl -sI $H/ | grep -i xss-protection

# #4 — garbage attribute gone (expect 0)
curl -s $P | grep -c "stylesheet'\"=\"\""

# #5 — exactly 1 eager / fetchpriority=high (LCP only)
curl -s $P | grep -c 'loading="eager"'
curl -s $P | grep -c 'fetchpriority="high"'

# #6 — deduped dns-prefetch, no jsdelivr
curl -s $P | grep -oE 'rel="dns-prefetch"[^>]*href="[^"]*"' | sort -u

# #7 — no http-equiv cache/pragma/expires (expect 0)
curl -s $H/ | grep -ciE 'http-equiv="(cache-control|pragma|expires)"'

# #8 — assets no longer carry HTML-only headers (expect empty)
curl -sI $H/wp-content/uploads/2026/04/vsphere-power-management-ansible-768x403.avif \
  | grep -iE 'content-security-policy|x-frame-options|permissions-policy'

# #9 — 2 font preloads (body + heading)
curl -s $P | grep -cE '<link[^>]*as="font"'

# #10 — day-permalink 301 (expect 301 + location to /YYYY/MM/<slug>/)
curl -sI $H/2026/04/01/vsphere-power-management-driven-by-ansible/ | head -3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)