### PR TITLE
fix(theme): split featured-image scaling between cards and single posts

### DIFF
--- a/scripts/brutalist-theme.css
+++ b/scripts/brutalist-theme.css
@@ -419,11 +419,14 @@ img {
   height: 100%;
 }
 
-/* Base thumbnail images - fill container with object-fit
-   Use two-class selector (0,2,1) to override Kadence's .post-thumbnail:not(...) img (0,2,1)
-   since brutalist-theme.css loads after Kadence CSS, same specificity = last wins */
-.post-thumbnail .post-thumbnail-inner img,
-.article-post-thumbnail .post-thumbnail-inner img {
+/* Grid/list card thumbnails - fill the fixed-ratio Kadence box with object-fit: cover
+   so card heights stay uniform. Decorative crop is acceptable for thumbnails.
+   Two-class selector (0,2,1) to match Kadence's .post-thumbnail:not(...) img (0,2,1)
+   so brutalist-theme.css wins via cascade order (it loads last). */
+.loop-entry .post-thumbnail .post-thumbnail-inner img,
+.loop-entry .article-post-thumbnail .post-thumbnail-inner img,
+.entry-list-item .post-thumbnail .post-thumbnail-inner img,
+.entry-list-item .article-post-thumbnail .post-thumbnail-inner img {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -437,9 +440,32 @@ img {
   background-color: rgba(255, 255, 255, 0.02);
 }
 
-/* Single post featured image - inherit from base rules */
+/* Single-post featured image - display at natural proportions.
+   Kadence's .post-thumbnail forces a fixed 3:2 box (padding-bottom:66.67%) which,
+   combined with object-fit:cover, savagely crops wide logos (4:1+) and square
+   portraits. On single posts we drop the forced ratio and let the image dictate
+   its own height. The .kadence-thumbnail-position-behind overlay still works
+   because .entry-content-wrap has its own solid dark background — the title
+   sits below the image as a banner. */
+.single .post-thumbnail.article-post-thumbnail,
+.single .article-post-thumbnail {
+  height: auto !important;
+  padding-bottom: 0 !important;
+}
+
 .single .article-post-thumbnail .post-thumbnail-inner {
-  /* Base rules handle positioning and image fit */
+  position: static;
+}
+
+.single .post-thumbnail .post-thumbnail-inner img,
+.single .article-post-thumbnail .post-thumbnail-inner img {
+  width: 100%;
+  height: auto;
+  max-width: 100%;
+  object-fit: contain;
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
 }
 
 /* Content images inside posts - maintain natural proportions */


### PR DESCRIPTION
## Summary
- Featured images on single posts were being hard-cropped by a unified `object-fit: cover` rule sitting inside Kadence's fixed 3:2 box (`.post-thumbnail { height:0; padding-bottom:66.67% }`). For non-3:2 images this zoom-crops aggressively — only the centre slice survives.
- Split the rule by context: **grid/list cards** keep `cover` (uniform tile heights, decorative crop is fine); **single-post featured image** drops the forced ratio and renders at natural proportions with `object-fit: contain`.
- Touches generated `public/` HTML on the next pipeline run via `extract_critical_css.py` re-reading the source CSS — no Python changes needed.

## Why prior fixes didn't stick

| Commit | What it did |
|---|---|
| `9774157190` | switched to `object-fit: contain` |
| `f824f4c869` | removed the forced 2:3 aspect ratio |
| `e05898598e` | reverted to `cover` with raised specificity to fix card thumbnails leaving white space — re-broke single posts |

This change keeps the e05898598e win for cards while restoring natural sizing on single posts.

## Affected posts (sample of the worst offenders)

| Post | Image ratio | Before | After |
|---|---|---|---|
| `how-to-take-a-wordpress-site-...-cloudflare-pages` (the post in the report) | 4.19:1 | ~36% of centre slice visible | full logo |
| `warp-the-intelligent-terminal` | 4.26:1 | tiny vertical band | full image |
| `truenas-scale-useful-commands` / `homelab-storage-refresh-part-1` | 3.88:1 | same | full logo |
| `new-nodes` | 5.16:1 | worst case | full image |
| `analytics-in-a-privacy-focused-world` (Plausible icon) | 1:1 | bottom half cropped | full icon |
| `managing-my-homelab-with-semaphoreui` | 1:1 | bottom cropped by `object-position: center top` | full icon |

## Why it's safe with `position-behind`
This theme already neutralises Kadence's `-4.3em` overlap via `.post-thumbnail { margin-bottom: 0 !important }` (line 523 of `brutalist-theme.css`), so the featured image is effectively a banner above the title — natural sizing is the right fit, no overlap to preserve.

## Test plan
- [ ] Run pipeline (`gh workflow run deploy-static-site.yml`) and let Pages deploy
- [ ] Open the report post: https://jameskilby.co.uk/2023/05/how-to-take-a-wordpress-site-and-publish-it-as-a-static-site-on-cloudflare-pages/ — full Simply Static logo visible, not a zoom-cropped slice
- [ ] Spot-check the wide-logo posts above (Warp, TrueNAS, new-nodes) — full image at natural proportions
- [ ] Spot-check a ~1:1 image post (Plausible / Semaphore) — whole icon visible, not just the top half
- [ ] Spot-check the homepage / category grids — card thumbnails still uniform height (`object-fit: cover` retained)
- [ ] Verify `make test-csp` still passes locally (no CSP-impacting changes, but the pipeline runs it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)