### PR TITLE
fix(seo): align og/twitter meta with canonical; dedupe BreadcrumbList

### DIFF
--- a/scripts/fix_seo_issues.py
+++ b/scripts/fix_seo_issues.py
@@ -118,6 +118,9 @@ class SEOFixer:
             if self.fix_breadcrumb_positions(soup, file_path):
                 modified = True
 
+            if self.fix_dedupe_breadcrumblist(soup, file_path):
+                modified = True
+
             if self.fix_techarticle_dedupe_and_dates(soup, file_path):
                 modified = True
 
@@ -134,6 +137,9 @@ class SEOFixer:
                 modified = True
 
             if self.fix_wordpress_host_leak(soup, file_path):
+                modified = True
+
+            if self.fix_og_meta_alignment(soup, file_path):
                 modified = True
 
             if self.fix_malformed_stylesheet_attr(soup, file_path):
@@ -231,6 +237,124 @@ class SEOFixer:
             self.issues_fixed += 1
             print(f"   🏷️  Locked homepage title to canonical form ({len(HOMEPAGE_TITLE)} chars)")
         return modified
+
+    # Brand suffixes we strip from social-share titles. The leading separator
+    # is intentional — only collapse the suffix when it appears at the END of
+    # the title (e.g. "Foo - James Kilby" → "Foo"), never mid-string.
+    _BRAND_SUFFIX_RE = re.compile(
+        r"\s+[-–—|]\s+James\s+Kilby\s*$",
+        re.IGNORECASE,
+    )
+
+    def fix_og_meta_alignment(self, soup, file_path):
+        """Force og:/twitter: title+description to mirror the canonical
+        <title> and meta description.
+
+        Rank Math (and similar plugins) sometimes emit LLM-generated
+        marketing copy in og:title/og:description that has no relationship
+        to the SEO-tuned <title>/meta description. Social previews then
+        carry clickbait the article never delivers — a brand-consistency
+        problem and a CTR drag.
+
+        Rule:
+          - og:title / twitter:title  ← <title> minus brand suffix
+          - og:description / twitter:description  ← meta[name=description]
+
+        Skipped for:
+          - The homepage (fix_homepage_title locks its own canonical title)
+          - Pages where the canonical source field is empty
+        """
+        # Homepage uses fix_homepage_title — leave it alone.
+        try:
+            rel = file_path.resolve().relative_to(self.public_dir.resolve())
+            if str(rel) == 'index.html':
+                return False
+        except (ValueError, AttributeError):
+            pass
+
+        modified = False
+
+        title_tag = soup.find('title')
+        title_text = (title_tag.get_text() or '').strip() if title_tag else ''
+        if title_text:
+            social_title = self._BRAND_SUFFIX_RE.sub('', title_text).strip()
+            for spec in (
+                {'property': 'og:title'},
+                {'name': 'twitter:title'},
+            ):
+                tag = soup.find('meta', attrs=spec)
+                if tag and (tag.get('content') or '') != social_title:
+                    tag['content'] = social_title
+                    modified = True
+
+        desc_tag = soup.find('meta', attrs={'name': 'description'})
+        desc_text = (desc_tag.get('content') or '').strip() if desc_tag else ''
+        if desc_text:
+            for spec in (
+                {'property': 'og:description'},
+                {'name': 'twitter:description'},
+            ):
+                tag = soup.find('meta', attrs=spec)
+                if tag and (tag.get('content') or '') != desc_text:
+                    tag['content'] = desc_text
+                    modified = True
+
+        if modified:
+            self.issues_fixed += 1
+            print(f"   🔗 Aligned og:/twitter: title+description with canonical: {file_path.name}")
+        return modified
+
+    def fix_dedupe_breadcrumblist(self, soup, file_path):
+        """Drop standalone BreadcrumbList JSON-LD blocks when an @graph
+        block on the same page already contains a BreadcrumbList.
+
+        Background: wp_to_static_generator.add_breadcrumb_navigation()
+        emits a standalone BreadcrumbList JSON-LD block as a safety net
+        for pages where Rank Math doesn't. On pages where Rank Math
+        DOES emit one inside the main @graph, we end up with two —
+        which Search Console flags as "Breadcrumbs item not specified"
+        and which dilutes the rich-result signal.
+
+        Strategy: if the page has at least one @graph-embedded
+        BreadcrumbList, drop every standalone (non-@graph) BreadcrumbList
+        block. The @graph entry is preferred because it is co-located
+        with the rest of the page's structured data and references the
+        same @id namespace.
+        """
+        import json as _json
+
+        graph_breadcrumbs = 0
+        standalone_scripts = []
+
+        for script in soup.find_all('script', type='application/ld+json'):
+            raw = script.string or ''
+            if not raw.strip():
+                continue
+            try:
+                data = _json.loads(raw)
+            except _json.JSONDecodeError:
+                continue
+            if isinstance(data, dict) and isinstance(data.get('@graph'), list):
+                if any(
+                    isinstance(n, dict) and n.get('@type') == 'BreadcrumbList'
+                    for n in data['@graph']
+                ):
+                    graph_breadcrumbs += 1
+            elif isinstance(data, dict) and data.get('@type') == 'BreadcrumbList':
+                standalone_scripts.append(script)
+
+        if graph_breadcrumbs == 0 or not standalone_scripts:
+            return False
+
+        for s in standalone_scripts:
+            s.decompose()
+
+        self.issues_fixed += 1
+        print(
+            f"   🍞 Removed {len(standalone_scripts)} duplicate standalone "
+            f"BreadcrumbList JSON-LD: {file_path.name}"
+        )
+        return True
 
     def fix_thin_archive_noindex(self, soup, file_path):
         """Inject <meta name="robots" content="noindex,follow"> on thin

--- a/scripts/html_transformer.py
+++ b/scripts/html_transformer.py
@@ -292,6 +292,8 @@ class HTMLTransformer:
             modified = True
         if self.seo.fix_breadcrumb_positions(soup, file_path):
             modified = True
+        if self.seo.fix_dedupe_breadcrumblist(soup, file_path):
+            modified = True
         if self.seo.fix_techarticle_dedupe_and_dates(soup, file_path):
             modified = True
         if self.seo.fix_person_name(soup, file_path):
@@ -301,6 +303,8 @@ class HTMLTransformer:
         if self.seo.fix_twitter_attribution(soup, file_path):
             modified = True
         if self.seo.fix_wordpress_host_leak(soup, file_path):
+            modified = True
+        if self.seo.fix_og_meta_alignment(soup, file_path):
             modified = True
         return modified
 

--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -3600,11 +3600,16 @@ document.addEventListener('DOMContentLoaded', function() {
             else:
                 main_wrap.insert(0, breadcrumb_nav)
             
-            # Add BreadcrumbList JSON-LD schema
-            if soup.head:
+            # Add BreadcrumbList JSON-LD schema — but only if the page
+            # doesn't already have one in an existing @graph block. Rank
+            # Math emits its own BreadcrumbList inside the main @graph on
+            # most posts; emitting a second standalone copy here triggers
+            # "Breadcrumbs item not specified" warnings in Search Console
+            # and dilutes the rich-result signal.
+            if soup.head and not self._has_existing_breadcrumblist(soup):
                 schema_script = soup.new_tag('script')
                 schema_script['type'] = 'application/ld+json'
-                
+
                 breadcrumb_list = {
                     "@context": "https://schema.org",
                     "@type": "BreadcrumbList",
@@ -3618,11 +3623,37 @@ document.addEventListener('DOMContentLoaded', function() {
                         for item in breadcrumb_items
                     ]
                 }
-                
+
                 schema_script.string = json.dumps(breadcrumb_list, ensure_ascii=False, separators=(',', ':'))
                 soup.head.append(schema_script)
-                
+
                 print(f"   🍞 Added breadcrumb navigation: {' > '.join([item['name'] for item in breadcrumb_items])}")
+            else:
+                print(f"   🍞 Added breadcrumb nav (HTML only — existing BreadcrumbList in @graph): {' > '.join([item['name'] for item in breadcrumb_items])}")
+
+    @staticmethod
+    def _has_existing_breadcrumblist(soup):
+        """Return True if any JSON-LD block on the page already declares a
+        BreadcrumbList (standalone or inside an @graph).
+        """
+        for script in soup.find_all('script', type='application/ld+json'):
+            raw = script.string or ''
+            if not raw.strip():
+                continue
+            try:
+                data = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(data, dict):
+                if data.get('@type') == 'BreadcrumbList':
+                    return True
+                graph = data.get('@graph')
+                if isinstance(graph, list) and any(
+                    isinstance(n, dict) and n.get('@type') == 'BreadcrumbList'
+                    for n in graph
+                ):
+                    return True
+        return False
     
     def build_post_index(self):
         """Bulk-fetch all published posts once and store in self.post_index.


### PR DESCRIPTION
## Summary

- **Aligns `og:title` / `twitter:title`** with `<title>` (brand suffix stripped — `og:site_name` already supplies the brand), and **aligns `og:description` / `twitter:description`** with `meta[name=description]`. Fixes 44 / 72 posts (61%) with divergent OG descriptions and 13 / 72 (18%) with divergent OG titles surfaced by the 2026-06-03 SEO audit.
- **De-duplicates `BreadcrumbList` JSON-LD** at both source (`wp_to_static_generator.add_breadcrumb_navigation` no longer emits a standalone block when an `@graph` BreadcrumbList already exists) and as a defensive post-hoc fix in `SEOFixer`.

## Background

Rank Math emits LLM-generated marketing copy in `og:title` / `og:description` that has nothing to do with the SEO-tuned `<title>` / meta description — for example, the title "UK Money Saving Tips: Banking, Rewards & Travel Cards" had og:title "Maximize Your Savings with UK Banking Tips" and og:description "Unlock smart banking strategies to save more now!". Social shares were carrying clickbait the articles never delivered.

The duplicate BreadcrumbList issue was independent: `add_breadcrumb_navigation` emits a standalone BreadcrumbList JSON-LD as a safety net for pages without one, but Rank Math already provides one inside the main `@graph` on every post. Result: two BreadcrumbLists per page, "Breadcrumbs item not specified" warnings in Search Console.

## Changes

| File | Change |
|---|---|
| `scripts/fix_seo_issues.py` | New `fix_og_meta_alignment` and `fix_dedupe_breadcrumblist` methods on `SEOFixer`. Wired into `process_file`. |
| `scripts/html_transformer.py` | Wires both new methods into `apply_seo_fixes` so the unified single-pass picks them up. |
| `scripts/wp_to_static_generator.py` | `add_breadcrumb_navigation` now skips JSON-LD emission when the page already has a BreadcrumbList (HTML `<nav>` generation is unchanged). New `_has_existing_breadcrumblist` helper. |

## Impact on `public/`

Next pipeline run will rewrite `og:title` / `og:description` / `twitter:title` / `twitter:description` on roughly 60 posts, and remove one `<script type="application/ld+json">` block per post. **Expect a larger-than-usual auto-update diff on the next deploy** — this is the corrective sweep.

## Test plan

- [x] Local verification against live fixture (`/2017/05/money-saving-uk-version/`): og:* tags realigned to canonical; standalone BreadcrumbList removed; embedded BreadcrumbList preserved.
- [x] Idempotency: second pass returns `False`, no further changes.
- [x] Homepage skipped (homepage retains its `Config.HOMEPAGE_TITLE`-locked tags via existing `fix_homepage_title`).
- [x] Recent post (where og already matched `<title>` exactly): brand suffix correctly stripped from og:title, no other changes.
- [ ] Verify the next CI pipeline runs `validate-html` + `validate-deployment` cleanly.
- [ ] After deploy, re-run the bulk meta sweep from the audit and confirm OG-mismatch count drops to 0.
- [ ] Check Search Console after a few days for the "Breadcrumbs item not specified" warning count to fall.

Related: `docs/seo-audit-2026-06/ACTION-PLAN.md` (local, not in this PR) — items **C1** and **C2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)