### PR TITLE
fix(seo): drop brand suffix from <title> on long posts

### DIFF
--- a/scripts/fix_seo_issues.py
+++ b/scripts/fix_seo_issues.py
@@ -91,6 +91,9 @@ class SEOFixer:
             if self.fix_homepage_title(soup, file_path):
                 modified = True
 
+            if self.fix_title_drop_brand_suffix(soup, file_path):
+                modified = True
+
             if self.fix_thin_archive_noindex(soup, file_path):
                 modified = True
 
@@ -245,6 +248,58 @@ class SEOFixer:
         r"\s+[-–—|]\s+James\s+Kilby\s*$",
         re.IGNORECASE,
     )
+
+    # Above this body length (chars, excluding the brand suffix), Google
+    # truncates the title in mobile SERP. Keep the suffix only when the body
+    # is short enough to leave room.
+    _TITLE_DROP_SUFFIX_BODY_THRESHOLD = 55
+
+    def fix_title_drop_brand_suffix(self, soup, file_path):
+        """Drop the " - James Kilby" suffix from <title> when the body
+        already exceeds the mobile-SERP truncation threshold.
+
+        Rank Math appends a site-name suffix to every post title. On long
+        titles (body > 55 chars) the suffix pushes total length past
+        Google's ~55–60 char mobile cutoff and the suffix gets clipped
+        anyway — so we shed it pre-emptively to give the body the full
+        width and remove the "…" tail. On short titles the suffix is
+        kept for brand recall.
+
+        Skipped for:
+          - The homepage (fix_homepage_title locks its own title)
+          - Pages where <title> has no recognisable brand suffix
+          - Pages where stripping the suffix would not actually shorten
+            the title (defensive — should never happen given the regex)
+        """
+        # Homepage uses fix_homepage_title — leave it alone.
+        try:
+            rel = file_path.resolve().relative_to(self.public_dir.resolve())
+            if str(rel) == 'index.html':
+                return False
+        except (ValueError, AttributeError):
+            pass
+
+        title_tag = soup.find('title')
+        if not title_tag:
+            return False
+        title_text = (title_tag.get_text() or '').strip()
+        if not title_text:
+            return False
+
+        body = self._BRAND_SUFFIX_RE.sub('', title_text).strip()
+        if body == title_text:
+            return False  # no recognisable brand suffix
+        if len(body) <= self._TITLE_DROP_SUFFIX_BODY_THRESHOLD:
+            return False  # short enough to keep the suffix
+
+        title_tag.string = body
+        self.issues_fixed += 1
+        print(
+            f"   ✂️  Dropped brand suffix from long <title> "
+            f"(body {len(body)}c > {self._TITLE_DROP_SUFFIX_BODY_THRESHOLD}c): "
+            f"{file_path.name}"
+        )
+        return True
 
     def fix_og_meta_alignment(self, soup, file_path):
         """Force og:/twitter: title+description to mirror the canonical

--- a/scripts/html_transformer.py
+++ b/scripts/html_transformer.py
@@ -274,6 +274,8 @@ class HTMLTransformer:
             modified = True
         if self.seo.fix_homepage_title(soup, file_path):
             modified = True
+        if self.seo.fix_title_drop_brand_suffix(soup, file_path):
+            modified = True
         if self.seo.fix_thin_archive_noindex(soup, file_path):
             modified = True
         if self.seo.fix_meta_description(soup, file_path):


### PR DESCRIPTION
## Summary

- New `SEOFixer.fix_title_drop_brand_suffix` strips `" - James Kilby"` from `<title>` when the body alone is > 55 chars (the mobile-SERP truncation threshold). Short titles keep the suffix for brand recall.
- Wires the method into `fix_seo_issues.process_file` and `html_transformer.apply_seo_fixes`.

## Why

Google truncates `<title>` at ~55–60 chars in mobile search results. Rank Math appends a fixed `" - James Kilby"` (14 chars) on every post, which pushes **32 / 72 posts (44%)** past the cutoff and leaves a `"…"` tail in SERP. The audit (`docs/seo-audit-2026-06/ACTION-PLAN.md`, item H1) called this out as the highest-leverage on-page fix after C1/C2.

`og:title` was already suffix-stripped unconditionally in PR #60 (since `og:site_name` already supplies the brand on social cards). This brings `<title>` into alignment with the same logic, but only when the suffix is actually hurting (long titles).

## Threshold choice

- `body length > 55` chars → drop suffix
- `body length ≤ 55` chars → keep suffix (full title with suffix stays ≤ ~70 chars; usually fine)

## Verified

| Case | Body length | Expected | Result |
|---|---|---|---|
| Real post: "AWS For Beginners: IAM Setup, Root Security & Billing Alerts - James Kilby" | 60c | drop | ✓ dropped |
| Real post: "Warp – The intelligent terminal - James Kilby" | 32c | keep | ✓ kept |
| Homepage | n/a | skip | ✓ skipped (locked by `fix_homepage_title`) |
| Idempotency (second pass) | — | no-op | ✓ |
| Boundary: body=55c | 55c | keep | ✓ kept |
| Boundary: body=56c | 56c | drop | ✓ dropped |

## Impact on `public/`

Next pipeline run rewrites ~32 post `<title>` tags. Expect a slightly larger auto-update diff on the next deploy.

## Test plan

- [x] Local unit verification (6 cases above)
- [ ] Pipeline build runs cleanly (`validate-html` + `validate-deployment`)
- [ ] Post-deploy sweep: `<title>` body length > 55 with suffix should be 0; total title > 70 chars count should drop from 32 to ≤ a small handful (only the few with body ≤ 55 chars but suffix pushes them just over).

Related: PR #60 (C1/C2 — OG alignment + BreadcrumbList dedupe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)