### PR TITLE
fix(seo): align Person.sameAs and Organization.sameAs

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -70,9 +70,15 @@ class Config:
     # sameAs URLs — the canonical professional profile graph for entity linking.
     # Pre-existing JSON-LD links to wordpress.jameskilby.cloud (the private CMS),
     # which is wrong on a public schema; this list replaces that.
+    #
+    # The same list is applied to both Person AND Organization entities (by
+    # fix_person_enrichment and fix_organization_sameas respectively) — this
+    # is a single-author blog so Person.sameAs and Organization.sameAs should
+    # describe the same identity graph.
     PERSON_SAME_AS = (
         'https://github.com/jameskilbynet',
         'https://x.com/jameskilbynet',
+        'https://www.linkedin.com/in/james-kilby/',
     )
 
     PERSON_JOB_TITLE = 'Cloud / Infrastructure Architect'

--- a/scripts/fix_seo_issues.py
+++ b/scripts/fix_seo_issues.py
@@ -133,6 +133,9 @@ class SEOFixer:
             if self.fix_person_enrichment(soup, file_path):
                 modified = True
 
+            if self.fix_organization_sameas(soup, file_path):
+                modified = True
+
             if self.fix_og_site_name(soup, file_path):
                 modified = True
 
@@ -1145,6 +1148,95 @@ class SEOFixer:
         if blocks_modified:
             self.issues_fixed += 1
             print(f"   🪪 Enriched Person entity (sameAs+jobTitle+knowsAbout+award): {file_path.name}")
+        return blocks_modified > 0
+
+    def fix_organization_sameas(self, soup, file_path):
+        """Mirror Config.PERSON_SAME_AS onto Organization entities so that
+        Person.sameAs and Organization.sameAs describe the same identity
+        graph.
+
+        Single-author blog: the site (Organization) and the author (Person)
+        share the same professional profiles. Misaligned sameAs lists
+        (Person has GitHub+X, Organization has GitHub+LinkedIn — the
+        Rank Math default) weaken Google's entity reconciliation and
+        send mixed signals to AI engines doing author attribution.
+
+        Strategy:
+          - Find every Organization-family entity in JSON-LD @graph blocks
+          - Drop any sameAs entries pointing at WordPress (private CMS leak)
+          - Ensure every URL in PERSON_SAME_AS is present (case-insensitive)
+          - Preserve any other existing entries (e.g. company-specific
+            profiles a future contributor might add)
+
+        Idempotent.
+        """
+        if not PERSON_SAME_AS:
+            return False
+
+        def is_target_org(item):
+            if not isinstance(item, dict):
+                return False
+            t = item.get('@type')
+            types = t if isinstance(t, list) else [t]
+            return any(
+                isinstance(x, str) and x in ('Organization', 'NewsMediaOrganization')
+                for x in types
+            )
+
+        blocks_modified = 0
+        for script in soup.find_all('script', type='application/ld+json'):
+            raw = script.string or ''
+            if not raw.strip():
+                continue
+            try:
+                data = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            graph_items = (
+                data.get('@graph') if isinstance(data, dict) and isinstance(data.get('@graph'), list)
+                else ([data] if isinstance(data, dict) else None)
+            )
+            if not graph_items:
+                continue
+
+            block_changed = False
+            for item in graph_items:
+                if not is_target_org(item):
+                    continue
+
+                current = item.get('sameAs')
+                if isinstance(current, str):
+                    current = [current]
+                if not isinstance(current, list):
+                    current = []
+
+                # Reuse the Person leak-list — both entities should never
+                # link the private WordPress CMS.
+                filtered = [
+                    u for u in current
+                    if isinstance(u, str)
+                    and not any(leak in u for leak in self._PERSON_SAMEAS_LEAKS)
+                ]
+                lc = {u.lower() for u in filtered}
+                added = False
+                for canonical in PERSON_SAME_AS:
+                    if canonical.lower() not in lc:
+                        filtered.append(canonical)
+                        lc.add(canonical.lower())
+                        added = True
+                if added or filtered != current:
+                    item['sameAs'] = filtered
+                    block_changed = True
+
+            if block_changed:
+                script.string = json.dumps(
+                    data, separators=(',', ':'), ensure_ascii=False
+                )
+                blocks_modified += 1
+
+        if blocks_modified:
+            self.issues_fixed += 1
+            print(f"   🏢 Aligned Organization.sameAs with Person canonical list: {file_path.name}")
         return blocks_modified > 0
 
     def fix_og_site_name(self, soup, file_path):

--- a/scripts/html_transformer.py
+++ b/scripts/html_transformer.py
@@ -302,6 +302,8 @@ class HTMLTransformer:
             modified = True
         if self.seo.fix_person_enrichment(soup, file_path):
             modified = True
+        if self.seo.fix_organization_sameas(soup, file_path):
+            modified = True
         if self.seo.fix_twitter_attribution(soup, file_path):
             modified = True
         if self.seo.fix_wordpress_host_leak(soup, file_path):


### PR DESCRIPTION
## Summary

- Single canonical sameAs list (`github + x + linkedin`) applied to **both** `Person` and `Organization` JSON-LD entities.
- Closes audit action **H4**.

## Why

The audit found `Person.sameAs = [github, x]` and `Organization.sameAs = [github, linkedin]` site-wide. On a single-author blog these describe the same identity graph; the mismatch weakens Google's entity reconciliation and gives AI engines doing author attribution conflicting signals.

## Changes

| File | Change |
|---|---|
| `scripts/config.py` | `PERSON_SAME_AS` now includes LinkedIn → `[github, x, linkedin]`. Updated docstring to call out that the same list is applied to Organization. |
| `scripts/fix_seo_issues.py` | New `SEOFixer.fix_organization_sameas` mirrors `PERSON_SAME_AS` onto `Organization` (and `NewsMediaOrganization`) entities. Reuses the existing `_PERSON_SAMEAS_LEAKS` filter to strip `wordpress.jameskilby.cloud` from Organization too. |
| `scripts/html_transformer.py` | Wires `fix_organization_sameas` into the unified single-pass right after `fix_person_enrichment`. |

## Verified locally

| Surface | Before | After |
|---|---|---|
| Homepage `Person.sameAs` | `[github, x]` | `[github, x, linkedin]` |
| Homepage `Organization.sameAs` | `[github, linkedin]` | `[github, linkedin, x]` |
| Post `["Person","Organization"]` (dual-type entity) | `[github, x]` | `[github, x, linkedin]` |
| Post separate `Organization` | `[github, linkedin]` | `[github, linkedin, x]` |
| Second pass (idempotency) | — | both return `False` ✓ |

Order differs because the methods append new URLs after existing ones (preserves existing order, minimises build-diff churn). Order is semantically irrelevant for `sameAs` — Google compares as a set.

## Impact on `public/`

Next pipeline run rewrites the JSON-LD `@graph` on every page that has a `Person` or `Organization` entity (i.e. all pages). Expect the larger-than-usual auto-update diff on the next deploy.

## Test plan

- [x] Local verification on homepage + post fixture
- [x] Idempotency confirmed
- [ ] Post-deploy: spot-check homepage + 2 posts via the SEO audit JSON-LD inspector
- [ ] Post-deploy: rerun `claude-seo:seo-drift` against the 3 captured baselines and confirm only sameAs changes show up

🤖 Generated with [Claude Code](https://claude.com/claude-code)