### PR TITLE
fix(worker): apply smart-TTL Cache-Control to pretty-URL post pages

### DIFF
--- a/_worker.template.js
+++ b/_worker.template.js
@@ -401,9 +401,17 @@ async function handleCacheAPI(request, env, ctx, path, hostname = '') {
     const responseToCache = response.clone();
     const newHeaders = new Headers(responseToCache.headers);
 
-    if (!newHeaders.has('Cache-Control')) {
-      newHeaders.set('Cache-Control', `public, max-age=${getTTL(path)}`);
-    }
+    // Always apply our smart TTL (Cache-Control) to HTML, overriding any
+    // upstream default. The previous `if (!has(...))` guard was meant to
+    // respect the `_headers /*.html` rule (max-age=300), but that rule only
+    // matches literal `.html` paths — pretty-URL post permalinks like
+    // `/2017/05/foo/` skipped it entirely and inherited Cloudflare Pages'
+    // `max-age=0, must-revalidate` default, leaving browsers unable to
+    // soft-cache repeat visits. Aligning the browser cache with the smart
+    // KV TTL gives readers proper local caching without violating the
+    // "absolute-expiry, view-counts don't reset the clock" invariant
+    // (browser cache is a separate clock from the KV cache).
+    newHeaders.set('Cache-Control', `public, max-age=${getTTL(path)}`);
 
     newHeaders.set('X-Cache-Status', 'MISS');
     newHeaders.set('X-Worker', 'advanced-worker-cache-api');


### PR DESCRIPTION
## Summary

Posts at pretty permalinks (`/2017/05/foo/`, `/2026/04/bar/`) currently respond with `cache-control: public, max-age=0, must-revalidate`, so browsers can't soft-cache repeat visits. Every reader navigation re-hits the edge even when nothing changed. Closes audit action **M2**.

## Root cause

`_headers /*.html  Cache-Control: public, max-age=300` only matches paths ending in `.html`. Pretty-URL posts skip that rule and inherit Cloudflare Pages' `max-age=0, must-revalidate` default. The worker's asset-miss HTML branch (line 404) then runs:

```js
if (!newHeaders.has('Cache-Control')) {
  newHeaders.set('Cache-Control', `public, max-age=${getTTL(path)}`);
}
```

The `has()` guard preserves CF Pages' bad default instead of applying the smart TTL the worker already computes.

## Fix

Remove the guard. Always apply `getTTL(path)` for HTML responses in this branch:

| URL pattern | New `max-age` |
|---|---|
| `/` | 300s (5 min) |
| `/YYYY/MM/<recent-post>/` (≤1 month) | 900s (15 min) |
| `/YYYY/MM/<older-post>/` (>1 month) | 3600s (1 hr) |

These are the same values the KV-cache-hit branches already use.

## Why this doesn't break the KV invariant

`CLAUDE.md` calls out that KV uses *absolute expiry* — view-count updates do not reset the clock. That invariant is about the KV cache. Browser cache is an independent clock; a `Cache-Control: max-age=N` only tells the browser when to revalidate locally, it doesn't touch KV state. The two clocks can drift up to one TTL apart with no correctness implications: a reader might see the previous KV version briefly after KV refreshes, which is already the worst-case behaviour of any cache hierarchy.

## Live state confirmed

```
$ curl -sI https://jameskilby.co.uk/
cache-control: public, max-age=300, must-revalidate        ← correct (from _headers /*.html)

$ curl -sI https://jameskilby.co.uk/2017/05/money-saving-uk-version/
cache-control: public, max-age=0, must-revalidate          ← BUG (this PR fixes)

$ curl -sI https://jameskilby.co.uk/2026/04/automated-vcf-9-offline-depot/
cache-control: public, max-age=0, must-revalidate          ← BUG (this PR fixes)
```

## Unchanged

- KV-cache-hit branches (lines 272/283/336/347) — already use `getTTL(path)` correctly
- 404 handler (`buildNotFoundResponse`) — explicit `max-age=60`
- Plausible script proxy — explicit `max-age=86400, stale-while-revalidate=3600`
- `_headers` file — left as-is

## Test plan

- [x] Static review: only the asset-miss HTML branch is touched
- [ ] Post-deploy: `curl -sI` an old post, a recent post, and the homepage; expect `max-age=3600`, `max-age=900`, `max-age=300` respectively
- [ ] PSI re-run after deploy — "Use efficient cache lifetimes" audit (currently flagging ~5 KiB savings) should resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)