### PR TITLE
fix(headers): max-age=300 on pretty-URL post pages (proper M2 fix)

### DIFF
--- a/_headers
+++ b/_headers
@@ -87,3 +87,18 @@
 # Cache JSON files for 5 minutes
 /*.json
   Cache-Control: public, max-age=300, must-revalidate
+
+# Pretty-URL post pages: /YYYY/MM/<slug>/ — the `/*.html` rule above
+# only matches literal `.html` paths, so directory-style permalinks
+# inherited Cloudflare Pages' implicit `max-age=0, must-revalidate`
+# default and browsers couldn't soft-cache repeat visits.
+#
+# The _worker.template.js KV cache already serves these with a smart TTL
+# (15 min recent / 1 hr older), but Cloudflare Pages applies `_headers`
+# rules AFTER the worker response so the worker's Cache-Control is
+# silently overridden. This rule is the single source of truth for the
+# browser cache budget on post pages — set it conservatively to 5 min
+# (matching the homepage) so a fresh auto-deploy is visible to repeat
+# readers within a window comparable to the homepage TTL.
+/20*/*/*/
+  Cache-Control: public, max-age=300, must-revalidate


### PR DESCRIPTION
## Summary

Adds a `_headers` rule covering `/YYYY/MM/<slug>/` post permalinks with `max-age=300, must-revalidate`. **This is the actual fix for M2** — PR #64's worker change couldn't move the production header because Cloudflare Pages applies `_headers` rules *after* the worker response.

## Why PR #64 alone didn't work

Post-deploy verification on PR #64 still showed `cache-control: public, max-age=0, must-revalidate` on all post URLs. Tracing the worker code path proved the worker IS running and IS setting `max-age=${ttl}` — but Cloudflare Pages then silently overrode it with its implicit default.

This is in fact documented in the worker file itself, at the top of `getSecurityHeaders()`:

> Cloudflare Pages applies `_headers` rules AFTER worker responses, so any CSP set here would be silently overridden — `_headers` ... is the single source of truth for CSP.

That comment is about CSP, but the same behaviour applies to `Cache-Control`. `_headers` is the single source of truth.

## The hole in the existing rules

`_headers` already has:

```
/*.html
  Cache-Control: public, max-age=300, must-revalidate
```

This matches the homepage (`/` → `index.html`) but **not** pretty-URL posts at `/2026/04/foo/` — those don't end in `.html`. Without a rule, CF Pages applies its implicit `max-age=0, must-revalidate` default.

## Fix

```
/20*/*/*/
  Cache-Control: public, max-age=300, must-revalidate
```

Matches `/2017/05/foo/`, `/2026/04/bar/`, etc. — every post permalink. Sets the same conservative 5-minute browser cache budget the homepage already uses. Audit recommended 60–300s; 300s is the upper end and matches the homepage TTL for symmetry.

The PR #64 worker change stays merged — it correctly fixes the `handleCacheAPI` fallback path that activates only if the KV binding is missing, and is harmless otherwise.

## Test plan

- [ ] Post-deploy: `curl -sI` an old post and a recent post; both should now return `max-age=300, must-revalidate` instead of `max-age=0`
- [ ] Homepage unchanged (still served by `/*.html` rule at 300s)
- [ ] `/api/*`, `/markdown/*`, `/wp-content/uploads/*` unchanged (their existing prefix rules are more specific and win over `/20*/*/*/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)