### PR TITLE
fix(seo): bundle small audit items — homepage h1, /llms*.txt cache, AI crawler policy doc

### DIFF
--- a/_headers
+++ b/_headers
@@ -129,6 +129,15 @@
   ! X-Frame-Options
   ! Permissions-Policy
 
+# llms.txt + llms-full.txt — built for AI ingestion crawlers; let them
+# soft-cache for an hour (CF Pages would otherwise default these to
+# max-age=0). Same rationale as the /markdown/* block above.
+/llms*.txt
+  Cache-Control: public, max-age=3600
+  ! Content-Security-Policy
+  ! X-Frame-Options
+  ! Permissions-Policy
+
 # API endpoints - JSON with CORS
 /api/*
   Content-Type: application/json; charset=utf-8

--- a/scripts/fix_seo_issues.py
+++ b/scripts/fix_seo_issues.py
@@ -91,6 +91,9 @@ class SEOFixer:
             if self.fix_homepage_title(soup, file_path):
                 modified = True
 
+            if self.fix_homepage_h1(soup, file_path):
+                modified = True
+
             if self.fix_title_drop_brand_suffix(soup, file_path):
                 modified = True
 
@@ -243,6 +246,43 @@ class SEOFixer:
             self.issues_fixed += 1
             print(f"   🏷️  Locked homepage title to canonical form ({len(HOMEPAGE_TITLE)} chars)")
         return modified
+
+    def fix_homepage_h1(self, soup, file_path):
+        """Replace the homepage <h1> with Config.HOMEPAGE_TITLE.
+
+        WordPress emits "James Kilby" (the site name) as the homepage h1
+        — fine for a personal home page but thin for a content-heavy
+        blog where the h1 is one of Google's strongest topic signals.
+        Lock it to the same canonical descriptive title we already use
+        for <title>/og:title so the heading conveys what the site is
+        actually about (VMware, homelab, cloud infrastructure).
+
+        Targets only the first/primary h1 in the document.
+        """
+        if not HOMEPAGE_TITLE:
+            return False
+        try:
+            rel = file_path.resolve().relative_to(self.public_dir.resolve())
+        except (ValueError, AttributeError):
+            return False
+        if str(rel) != 'index.html':
+            return False
+
+        h1 = soup.find('h1')
+        if not h1:
+            return False
+        current = h1.get_text(strip=True)
+        if current == HOMEPAGE_TITLE:
+            return False
+
+        # Replace inner content with a single text node; preserves any class
+        # / id attributes on the h1 element itself so styling doesn't break.
+        h1.clear()
+        h1.string = HOMEPAGE_TITLE
+
+        self.issues_fixed += 1
+        print(f"   🅷  Locked homepage <h1> to canonical form (was {current[:40]!r}, now {len(HOMEPAGE_TITLE)} chars)")
+        return True
 
     # Brand suffixes we strip from social-share titles. The leading separator
     # is intentional — only collapse the suffix when it appears at the END of

--- a/scripts/html_transformer.py
+++ b/scripts/html_transformer.py
@@ -274,6 +274,8 @@ class HTMLTransformer:
             modified = True
         if self.seo.fix_homepage_title(soup, file_path):
             modified = True
+        if self.seo.fix_homepage_h1(soup, file_path):
+            modified = True
         if self.seo.fix_title_drop_brand_suffix(soup, file_path):
             modified = True
         if self.seo.fix_thin_archive_noindex(soup, file_path):

--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -3978,6 +3978,16 @@ document.addEventListener('DOMContentLoaded', function() {
             "# in order to see the directive. Blocking crawl leaves the URLs in",
             "# the index as URL-only entries and prevents clean removal.",
             "",
+            "# AI crawler policy",
+            "# ────────────────────",
+            "# GPTBot, ClaudeBot, PerplexityBot, Google-Extended, Applebot-Extended,",
+            "# Bytespider and the rest of the LLM ingestion fleet are deliberately",
+            "# NOT Disallowed. This site publishes a markdown mirror at /markdown/,",
+            "# a JSON API mirror at /api/, an llmstxt.org index at /llms.txt and a",
+            "# full-content corpus at /llms-full.txt — all built for AI ingestion.",
+            "# Blocking the crawlers would defeat that on-purpose investment.",
+            "# Steering happens via /llms.txt, not robots.txt.",
+            "",
             f"Sitemap: {self.target_domain}/sitemap.xml",
             ""
         ]


### PR DESCRIPTION
## Summary

Three small audit items in one PR.

| Item | What | File |
|---|---|---|
| **M5** | Replace homepage `<h1>James Kilby</h1>` with the canonical descriptive title from `Config.HOMEPAGE_TITLE` (matches `<title>` / `og:title`) | `scripts/fix_seo_issues.py` (new `fix_homepage_h1`) + wiring in `process_file` + `html_transformer.apply_seo_fixes` |
| **MISC-1** | Add `Cache-Control: max-age=3600` for `/llms*.txt` (same gap M2 fixed for post pages) | `_headers` |
| **M3** | Document the deliberate "AI crawlers welcome" stance directly in the generated `robots.txt` so the lack of GPTBot/ClaudeBot/PerplexityBot Disallows isn't read as an oversight | `scripts/wp_to_static_generator.py:create_robots_txt` |

## Verified locally

- `fix_homepage_h1`: replaces `"James Kilby"` with `"James Kilby — VMware, Homelab & Cloud Infrastructure Notes"` on homepage; idempotent; post pages untouched.
- `scripts/test_csp.py`: all 3 CSP checks still pass against the updated root `_headers`.

## Impact on `public/`

- Next deploy will rewrite `<h1>` on `public/index.html` only.
- `public/_headers` gets one new block (`/llms*.txt`).
- `public/robots.txt` gets a new comment block. No directive changes.

## Test plan

- [x] Local: `fix_homepage_h1` test on homepage + post fixture
- [x] Local: `test_csp.py` clean
- [ ] Post-deploy: `curl -sI https://jameskilby.co.uk/llms.txt` returns `max-age=3600`
- [ ] Post-deploy: homepage `<h1>` text matches `Config.HOMEPAGE_TITLE`
- [ ] Post-deploy: `curl -s https://jameskilby.co.uk/robots.txt | grep -A 1 "AI crawler policy"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)