### PR TITLE
fix(homepage): trim grid to a multiple of 3 to remove orphan slot

### DIFF
--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -2712,6 +2712,12 @@ document.addEventListener('DOMContentLoaded', function() {
         # above the grid. Removed from the grid so it doesn't double-render.
         hero = self._build_homepage_hero(soup, posts_list)
 
+        # Hero extraction leaves the grid one short of a clean row in the
+        # 3-col layout (WP serves 12 → hero takes 1 → 11 cards = 3 full
+        # rows + 2 + an empty slot). Trim trailing cards down to the
+        # nearest multiple of 3 so the last row is always full.
+        self._trim_grid_to_columns(posts_list, columns=3)
+
         # ── 1. hero strap ───────────────────────────────────────────────
         strap = soup.new_tag('section', attrs={'class': 'jkr-strap'})
         strap_inner = soup.new_tag('div', attrs={'class': 'jkr-strap-inner'})
@@ -2976,6 +2982,23 @@ document.addEventListener('DOMContentLoaded', function() {
         to_remove.decompose()
 
         return hero
+
+    def _trim_grid_to_columns(self, posts_list, columns=3):
+        """Trim trailing grid items so the card count is a multiple of `columns`.
+
+        The post grid is a `columns`-wide CSS grid. Any orphan card on the
+        last row paints as an empty slot; drop them so the layout always
+        ends on a full row. No-ops when the count is already aligned.
+        """
+        items = posts_list.find_all('li', class_='entry-list-item', recursive=False)
+        if not items:
+            return
+        remainder = len(items) % columns
+        if remainder == 0:
+            return
+        for item in items[-remainder:]:
+            item.decompose()
+        print(f"   ✂️  Trimmed {remainder} orphan grid slot(s) to keep the {columns}-col layout balanced")
 
     def add_markdown_api_links(self, soup, current_url):
         """Add links to markdown and API versions in footer.


### PR DESCRIPTION
## Summary
- Hero promotion (`_build_homepage_hero`) pulls the newest post out of the grid, so WP's 12-post homepage paints as 11 cards = 3 full rows + 1 row of 2 + an empty slot in the 3-col CSS grid.
- Added `_trim_grid_to_columns()` called right after the hero is built. Drops trailing `count % columns` `<li class="entry-list-item">` children of `.kadence-posts-list` so the last row is always full.
- No-ops when the count is already aligned — stays correct if WP's posts-per-page setting changes (10 → trims to 9, 12 → trims to 12, 13 → trims to 12, etc.).
- This PR only touches `scripts/wp_to_static_generator.py`, so the next `🚀 Auto-update static site` commit on `main` will be the visible diff in `public/index.html` (one fewer row, no orphan slot).

## Test plan
- [ ] Verified locally against the current `public/index.html`: 11 grid `<li>` cards → trim drops 2 → 9 cards (clean 3×3).
- [ ] CI `deploy-static-site.yml` regenerates `public/index.html` from WP — confirm grid ends on a full row (no empty trailing slot).
- [ ] After merge, eyeball `https://jameskilby.co.uk/` once the auto-update commit lands.
- [ ] Confirm `/page/2/` still serves the trimmed posts (they're not deleted, just not on page 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)