### PR TITLE
fix(quality-checks,worker): match same-origin Plausible, ship CSP from worker

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -298,11 +298,11 @@ jobs:
     - name: Validate CSP configuration (Utterances, Plausible, Credly)
       run: |
         echo "🔒 Validating CSP allows all third-party services..."
-        echo "   (runs early — only reads _worker.template.js, no WP access needed)"
+        echo "   (runs early — only reads the repo-root _headers file, no WP access needed)"
         python3 scripts/test_csp.py || {
           echo ""
           echo "❌ CSP validation failed!"
-          echo "   Check _worker.template.js Content-Security-Policy header"
+          echo "   Check the Content-Security-Policy line in _headers (root)"
           echo ""
           exit 1
         }

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -391,10 +391,12 @@ jobs:
       run: |
         echo "🚀 Testing ${{ steps.url.outputs.url }}..."
 
-        # Run the test and capture output
+        # Run the test and capture output. Use `|| TEST_EXIT_CODE=$?` so that
+        # `set -e` (bash default) does not abort the step on a non-zero exit
+        # before we get a chance to cat the output and surface the failure.
         OUTPUT_FILE="test_output_main.txt"
-        python3 scripts/test_live_site_formatting.py --url "${{ steps.url.outputs.url }}" > "$OUTPUT_FILE" 2>&1
-        TEST_EXIT_CODE=$?
+        TEST_EXIT_CODE=0
+        python3 scripts/test_live_site_formatting.py --url "${{ steps.url.outputs.url }}" > "$OUTPUT_FILE" 2>&1 || TEST_EXIT_CODE=$?
 
         # Save output for later use
         cat "$OUTPUT_FILE"
@@ -423,10 +425,11 @@ jobs:
       run: |
         echo "🚀 Testing post page: ${{ steps.url.outputs.test_post }}..."
 
-        # Run the test and capture output
+        # Run the test and capture output. See test_main for the rationale on
+        # `|| TEST_EXIT_CODE=$?` — keeps `set -e` from skipping the cat below.
         OUTPUT_FILE="test_output_post.txt"
-        python3 scripts/test_live_site_formatting.py --url "${{ steps.url.outputs.test_post }}" > "$OUTPUT_FILE" 2>&1
-        TEST_EXIT_CODE=$?
+        TEST_EXIT_CODE=0
+        python3 scripts/test_live_site_formatting.py --url "${{ steps.url.outputs.test_post }}" > "$OUTPUT_FILE" 2>&1 || TEST_EXIT_CODE=$?
 
         # Save output for later use
         cat "$OUTPUT_FILE"

--- a/_worker.template.js
+++ b/_worker.template.js
@@ -23,6 +23,17 @@
 const PATH_MANIFEST_RAW = /*__PATH_MANIFEST_START__*/null/*__PATH_MANIFEST_END__*/;
 const PATH_MANIFEST = PATH_MANIFEST_RAW ? new Set(PATH_MANIFEST_RAW) : null;
 
+// Build-time substitution: scripts/stamp_worker_manifest.py reads the
+// Content-Security-Policy line from the repo-root `_headers` file and
+// replaces the placeholder below with that string literal. `_headers`
+// stays the single source of truth — the worker just consumes it so
+// CSP ships on every worker-built Response (Pages does NOT layer
+// `_headers` rules over Response objects returned by `_worker.js`;
+// only `env.ASSETS.fetch()` responses get them). If the placeholder
+// is still `null` (template unchanged, local dev) CSP is omitted —
+// same as before, fail-open.
+const CSP_FROM_HEADERS = /*__CSP_FROM_HEADERS_START__*/null/*__CSP_FROM_HEADERS_END__*/;
+
 /**
  * Is this path a known content URL?
  *
@@ -447,10 +458,12 @@ async function handleCacheAPI(request, env, ctx, path, hostname = '') {
 /**
  * Get security headers for all responses.
  *
- * Note: Content-Security-Policy is intentionally NOT set here. Cloudflare Pages
- * applies `_headers` rules AFTER worker responses, so any CSP set here would be
- * silently overridden — `_headers` (and `scripts/wp_to_static_generator.py`,
- * which generates `public/_headers`) is the single source of truth for CSP.
+ * Content-Security-Policy: stamped in from the repo-root `_headers` file at
+ * build time (see CSP_FROM_HEADERS above and scripts/stamp_worker_manifest.py).
+ * `_headers` remains the single source of truth — but Cloudflare Pages only
+ * applies its rules to responses fetched via `env.ASSETS.fetch()`. Brand-new
+ * `Response` objects returned by `_worker.js` (e.g. the KV-cached HTML path)
+ * don't get `_headers` layered on, so the worker must emit CSP itself.
  * Validation lives in scripts/test_csp.py.
  *
  * Pass hostname to automatically add X-Robots-Tag: noindex on the Pages preview domain.
@@ -463,6 +476,10 @@ function getSecurityHeaders(hostname = '') {
     'Referrer-Policy': 'strict-origin-when-cross-origin',
     'Permissions-Policy': 'geolocation=(), microphone=(), camera=()'
   };
+
+  if (CSP_FROM_HEADERS) {
+    headers['Content-Security-Policy'] = CSP_FROM_HEADERS;
+  }
 
   // Prevent the Cloudflare Pages preview domain from appearing in search results
   if (hostname === 'jkcoukblog.pages.dev') {

--- a/scripts/stamp_worker_manifest.py
+++ b/scripts/stamp_worker_manifest.py
@@ -1,15 +1,25 @@
 #!/usr/bin/env python3
 """
-Inline path-manifest.json into public/_worker.js at deploy time.
+Inline build-time data into public/_worker.js at deploy time.
 
-The Advanced Mode Worker template (_worker.template.js) contains the
-placeholder:
+The Advanced Mode Worker template (_worker.template.js) contains two
+placeholders that this script replaces:
 
     const PATH_MANIFEST_RAW = /*__PATH_MANIFEST_START__*/null/*__PATH_MANIFEST_END__*/;
+    const CSP_FROM_HEADERS = /*__CSP_FROM_HEADERS_START__*/null/*__CSP_FROM_HEADERS_END__*/;
 
-This script replaces `null` with a JS array literal of every legitimate
-content path, then writes the result to public/_worker.js.  That replaces
-the `cp _worker.template.js public/_worker.js` step in the deploy workflow.
+* PATH_MANIFEST_RAW gets a JS array literal of every legitimate content
+  path (read from <public>/path-manifest.json, produced by
+  scripts/generate_soft404_artefacts.py).
+* CSP_FROM_HEADERS gets a JS string literal of the Content-Security-Policy
+  line read from the repo-root `_headers` file. Cloudflare Pages only
+  applies `_headers` rules to responses fetched via env.ASSETS — `Response`
+  objects built inside _worker.js (e.g. the KV-cached HTML path) skip those
+  rules, so the worker must emit CSP itself. `_headers` stays the single
+  source of truth; the worker just consumes it at build time.
+
+This replaces the `cp _worker.template.js public/_worker.js` step in the
+deploy workflow.
 
 Usage:
     python3 scripts/stamp_worker_manifest.py
@@ -30,11 +40,31 @@ PUBLIC_DIR = Path(
 TEMPLATE = REPO_ROOT / "_worker.template.js"
 OUTPUT = PUBLIC_DIR / "_worker.js"
 MANIFEST = PUBLIC_DIR / "path-manifest.json"
+HEADERS_FILE = REPO_ROOT / "_headers"
 
-PLACEHOLDER_RE = re.compile(
+PATH_PLACEHOLDER_RE = re.compile(
     r"/\*__PATH_MANIFEST_START__\*/.*?/\*__PATH_MANIFEST_END__\*/",
     re.DOTALL,
 )
+CSP_PLACEHOLDER_RE = re.compile(
+    r"/\*__CSP_FROM_HEADERS_START__\*/.*?/\*__CSP_FROM_HEADERS_END__\*/",
+    re.DOTALL,
+)
+# Matches the global `/*` block's Content-Security-Policy line in _headers.
+CSP_LINE_RE = re.compile(
+    r"^\s*Content-Security-Policy:\s*(.+)$",
+    re.MULTILINE,
+)
+
+
+def extract_csp() -> str | None:
+    """Read the Content-Security-Policy value from the repo-root _headers."""
+    if not HEADERS_FILE.exists():
+        return None
+    match = CSP_LINE_RE.search(HEADERS_FILE.read_text(encoding="utf-8"))
+    if not match:
+        return None
+    return match.group(1).strip()
 
 
 def main() -> int:
@@ -54,7 +84,7 @@ def main() -> int:
         return 1
 
     source = TEMPLATE.read_text(encoding="utf-8")
-    if not PLACEHOLDER_RE.search(source):
+    if not PATH_PLACEHOLDER_RE.search(source):
         print(
             "❌ placeholder /*__PATH_MANIFEST_START__*/…/*__PATH_MANIFEST_END__*/ "
             "not found in _worker.template.js — template was edited without "
@@ -62,18 +92,44 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
+    if not CSP_PLACEHOLDER_RE.search(source):
+        print(
+            "❌ placeholder /*__CSP_FROM_HEADERS_START__*/…/*__CSP_FROM_HEADERS_END__*/ "
+            "not found in _worker.template.js — template was edited without "
+            "preserving the injection point",
+            file=sys.stderr,
+        )
+        return 1
 
-    literal = json.dumps(paths, separators=(",", ":"))
-    stamped = PLACEHOLDER_RE.sub(
-        f"/*__PATH_MANIFEST_START__*/{literal}/*__PATH_MANIFEST_END__*/",
+    path_literal = json.dumps(paths, separators=(",", ":"))
+    stamped = PATH_PLACEHOLDER_RE.sub(
+        f"/*__PATH_MANIFEST_START__*/{path_literal}/*__PATH_MANIFEST_END__*/",
         source,
+        count=1,
+    )
+
+    csp = extract_csp()
+    if not csp:
+        print(
+            f"❌ Content-Security-Policy not found in {HEADERS_FILE} — "
+            "worker would ship without CSP",
+            file=sys.stderr,
+        )
+        return 1
+
+    # json.dumps gives us a JS-safe string literal with escapes and quoting.
+    csp_literal = json.dumps(csp)
+    stamped = CSP_PLACEHOLDER_RE.sub(
+        f"/*__CSP_FROM_HEADERS_START__*/{csp_literal}/*__CSP_FROM_HEADERS_END__*/",
+        stamped,
         count=1,
     )
 
     OUTPUT.write_text(stamped, encoding="utf-8")
     print(
         f"✅ _worker.js stamped: {len(paths)} paths baked in "
-        f"({len(literal)} bytes of manifest, {len(stamped)} bytes total) → {OUTPUT}"
+        f"({len(path_literal)} bytes of manifest), CSP "
+        f"({len(csp)} bytes) baked in, {len(stamped)} bytes total → {OUTPUT}"
     )
     return 0
 

--- a/scripts/test_live_site_formatting.py
+++ b/scripts/test_live_site_formatting.py
@@ -180,23 +180,28 @@ class LiveSiteFormattingTester:
         """Test that Plausible Analytics is properly configured."""
         print("\n🔍 Testing Plausible Analytics...")
         soup = BeautifulSoup(html, 'html.parser')
-        
-        # Find Plausible script
-        plausible_scripts = soup.find_all('script', src=lambda x: x and 'plausible' in x.lower())
-        
+
+        # Find Plausible script (same-origin proxy at /js/script.js or legacy upstream)
+        plausible_scripts = soup.find_all(
+            'script',
+            src=lambda x: x and 'script.js' in x and (
+                x == '/js/script.js' or 'plausible' in x.lower()
+            ),
+        )
+
         if not plausible_scripts:
             self.log_error("Plausible Analytics script not found")
             return False
-            
+
         if len(plausible_scripts) > 1:
             self.log_warning(f"Multiple Plausible scripts found ({len(plausible_scripts)})")
-            
+
         script = plausible_scripts[0]
         src = script.get('src', '')
         data_domain = script.get('data-domain', '')
-        
-        # Check script source
-        if 'plausible.jameskilby.cloud' not in src:
+
+        # Accept the same-origin proxy path or the legacy upstream URL.
+        if src != '/js/script.js' and 'plausible.jameskilby.cloud/js/script.js' not in src:
             self.log_error(f"Incorrect Plausible script source: {src}")
             return False
         else:


### PR DESCRIPTION
## Summary

Two related fixes, both surfaced while investigating why the **Quality Checks** workflow has been failing every day since the Plausible same-origin migration.

### 1. Quality Checks failing on the Plausible test
- `scripts/test_live_site_formatting.py` matched the Plausible tag by looking for `plausible` in the `src`. After the migration to a same-origin proxy (`<script src=\"/js/script.js\" data-domain=\"jameskilby.co.uk\" defer>`), the matcher returned nothing and the test logged an error → `exit 1` → Site Formatting Tests job red.
- Mirrored the dual-form match already in `validate_deployment.py` (accept `/js/script.js` OR the legacy `plausible.jameskilby.cloud` upstream).
- Also: the workflow step swallowed the python output. `set -e` (bash default) aborted at `python3 … > $OUTPUT_FILE 2>&1` on non-zero exit, so the subsequent `cat $OUTPUT_FILE` never ran — the log only showed `🚀 Testing https://jameskilby.co.uk...` and an unexplained `exit 1`. Added `|| TEST_EXIT_CODE=$?` to both `test_main` and `test_post` steps so failures are debuggable next time.

### 2. Production GET responses were shipping without CSP
- `_worker.template.js:getSecurityHeaders()` intentionally omitted CSP based on the assumption that Cloudflare Pages layers `_headers` rules over worker responses. Empirically that's wrong for Pages Advanced Mode: `_headers` rules only apply to responses fetched via `env.ASSETS.fetch()`. Brand-new `Response` objects built inside `_worker.js` (the KV-cached HTML path that serves real browser traffic) skip those rules.
- **Verified before this PR**: `curl -sI https://jameskilby.co.uk` (HEAD, bypasses worker) → CSP present. `curl -s -D - https://jameskilby.co.uk --compressed` (GET, hits worker) → no CSP, just `x-worker: advanced-worker-kv` and the worker's `getSecurityHeaders()` subset. This has been the live behaviour since the worker took over the cache path.
- Fix preserves `_headers` as the single source of truth and teaches `stamp_worker_manifest.py` to read the CSP line from the repo-root `_headers` and inline it into `public/_worker.js` alongside the existing path-manifest stamping. New placeholder `CSP_FROM_HEADERS` in the template, consumed by `getSecurityHeaders()`. Build fails loudly if either placeholder is missing or `_headers` has no CSP line.
- Updated the misleading log message in `deploy-static-site.yml` that pointed users at `_worker.template.js` for CSP edits — they belong in `_headers`.

## Why one PR

Both came out of the same investigation. The Plausible fix gets daily Quality Checks green again immediately; the CSP fix removes the warning that was about to become a recurring nag, and closes a real security gap.

## Files

- `scripts/test_live_site_formatting.py` — Plausible matcher accepts same-origin proxy.
- `.github/workflows/quality-checks.yml` — surface python output on test failure.
- `_worker.template.js` — `CSP_FROM_HEADERS` placeholder + `getSecurityHeaders()` emits CSP + corrected doc comment.
- `scripts/stamp_worker_manifest.py` — also stamp the CSP into `public/_worker.js`.
- `.github/workflows/deploy-static-site.yml` — fixed stale CSP-validation log message.

## Public/ impact

No `public/` changes in this PR. The auto-pipeline will regenerate `public/_worker.js` on the next run with the new stamper + template, baking CSP in.

## Test plan

- [ ] CI: \`Validate CSP configuration\` step still passes (reads `_headers`, unchanged content).
- [ ] CI: \`Stamp worker manifest\` step passes; produced `public/_worker.js` parses (`node --check`).
- [ ] After merge + auto-pipeline + Pages deploy: `curl -s -D - https://jameskilby.co.uk --compressed` returns `content-security-policy:` alongside `x-worker: advanced-worker-kv`.
- [ ] Next Quality Checks run (daily 03:00 UTC or manual dispatch) — Site Formatting Tests passes, Plausible Analytics test passes, no CSP warning.
- [ ] Spot-check Utterances comments, Plausible beacon, and Credly badge embeds still render on the live site (no CSP regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)