### PR TITLE
fix(deploy): purge fonts from CF cache when subset_fonts rewrites them

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -2,6 +2,21 @@ name: WordPress to Static Site Deploy
 
 on:
   workflow_dispatch:        # Manual trigger
+    inputs:
+      force_static_purge:
+        # When the build doesn't change a file under purge_static_cache.sh's
+        # URL list, the purge step is skipped — but the CF edge cache for
+        # those files may have been invalidated separately (e.g. subset_fonts
+        # rewrote a font in a prior deploy that didn't fire the purge gate).
+        # Setting this to "true" forces the purge to run on this dispatch
+        # regardless of the diff.
+        description: 'Force the static-asset CF purge even if nothing changed'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
   repository_dispatch:      # Webhook trigger
     types: [wordpress-update]
 
@@ -1224,13 +1239,22 @@ jobs:
       env:
         CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        FORCE_PURGE: ${{ github.event.inputs.force_static_purge }}
       run: |
-        # Only fire when one of the favicon / manifest files this script
-        # actually purges changed in this deploy. The script's URL list is
-        # hardcoded — keep this pattern in sync with scripts/purge_static_cache.sh.
-        STATIC_ASSET_PATTERN='^public/(favicon\.ico|favicon-16x16\.png|favicon-32x32\.png|apple-touch-icon\.png|site\.webmanifest)$'
+        # Only fire when one of the files purge_static_cache.sh actually
+        # purges changed in this deploy. Keep this pattern in sync with the
+        # URL list in scripts/purge_static_cache.sh.
+        #
+        # Fonts: subset_fonts.py rewrites them in-place on every build with
+        # the glyph set this build's HTML needs. The _headers rule on
+        # /assets/fonts/* says max-age=31536000 immutable, so without an
+        # explicit purge the CF edge serves the previous build's font forever.
+        STATIC_ASSET_PATTERN='^public/((favicon\.ico|favicon-16x16\.png|favicon-32x32\.png|apple-touch-icon\.png|site\.webmanifest)|assets/fonts/.*\.woff2)$'
 
-        if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+        if [ "$FORCE_PURGE" = "true" ]; then
+          # Manual dispatch override — see the workflow_dispatch input.
+          CHANGED="force-static-purge=true"
+        elif git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
           CHANGED=$(git diff --name-only HEAD~1 HEAD | grep -E "$STATIC_ASSET_PATTERN" || true)
         else
           # First commit on the branch — no previous deploy to diff against.
@@ -1239,7 +1263,7 @@ jobs:
         fi
 
         if [ -z "$CHANGED" ]; then
-          echo "ℹ️  No favicon / webmanifest files changed — skipping static asset purge"
+          echo "ℹ️  No favicon / webmanifest / font files changed — skipping static asset purge"
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## 🗑️ Static Asset Purge" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/scripts/purge_static_cache.sh
+++ b/scripts/purge_static_cache.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
-# Purge static asset cache from Cloudflare CDN
-# Used after deploying new favicon files or other static assets
+# Purge static asset cache from Cloudflare CDN.
+#
+# Covers files whose URL stays stable across deploys but whose content
+# may change — and whose `_headers` Cache-Control marks them as long-
+# lived, so the CF edge cache holds an old copy until manually purged:
+#
+#   - Favicon set / site.webmanifest (manual edits)
+#   - Self-hosted woff2 fonts (subset_fonts.py rewrites them on every
+#     build with the glyphs actually used in this build's HTML)
+#
+# Keep the URL list here in sync with the change-detection regex in
+# .github/workflows/deploy-static-site.yml (search for STATIC_ASSET_PATTERN).
 
 set -e
 
@@ -15,13 +25,20 @@ fi
 
 echo "🗑️  Purging static assets from Cloudflare cache..."
 
-# Files to purge
+# Files to purge. Keep in sync with STATIC_ASSET_PATTERN in
+# .github/workflows/deploy-static-site.yml.
 URLS_TO_PURGE='[
   "https://jameskilby.co.uk/favicon.ico",
   "https://jameskilby.co.uk/favicon-16x16.png",
   "https://jameskilby.co.uk/favicon-32x32.png",
   "https://jameskilby.co.uk/apple-touch-icon.png",
-  "https://jameskilby.co.uk/site.webmanifest"
+  "https://jameskilby.co.uk/site.webmanifest",
+  "https://jameskilby.co.uk/assets/fonts/anton-v27-latin-400.woff2",
+  "https://jameskilby.co.uk/assets/fonts/jetbrainsmono-v24-latin-400.woff2",
+  "https://jameskilby.co.uk/assets/fonts/jetbrainsmono-v24-latin-700.woff2",
+  "https://jameskilby.co.uk/assets/fonts/spacegrotesk-v22-latin-400.woff2",
+  "https://jameskilby.co.uk/assets/fonts/spacegrotesk-v22-latin-500.woff2",
+  "https://jameskilby.co.uk/assets/fonts/spacegrotesk-v22-latin-700.woff2"
 ]'
 
 # Purge using Cloudflare API


### PR DESCRIPTION
## What's happening

[PR #73 deployed](https://github.com/jameskilbycloud/jkcoukblog/pull/73) and `subset_fonts.py` correctly rewrote the four heavy fonts in `public/assets/fonts/` (auto-update commit `f10f75344a` shows JM 400 at 112 172 → 16 940 bytes). But mobile PSI still scores 83 with FCP 2.9 s / LCP 3.8 s.

Reason: Cloudflare's edge cache is still serving the **old** 112 KB JetBrains Mono:

```
$ curl -sI https://jameskilby.co.uk/assets/fonts/jetbrainsmono-v24-latin-400.woff2 | grep -iE 'content-length|cf-cache'
content-length: 112172
cf-cache-status: HIT
```

The `_headers` rule on `/assets/fonts/*` is `max-age=31536000, immutable`, so once a file is at the edge it stays there forever unless we explicitly purge.

`scripts/purge_static_cache.sh` already handles this pattern — for favicons. It just didn't know about fonts.

## What this PR does

1. **[scripts/purge_static_cache.sh](scripts/purge_static_cache.sh)** — extend the URL list with the six self-hosted woff2 paths so a purge call covers fonts in addition to favicons. Comments cross-reference the workflow regex.

2. **[.github/workflows/deploy-static-site.yml](.github/workflows/deploy-static-site.yml)** — the `STATIC_ASSET_PATTERN` regex that gates the purge step grows an `|assets/fonts/.*\.woff2` alternative, so any font change between `HEAD~1` and `HEAD` fires the same purge. Regex tested locally against a mixed set of paths.

3. **New `force_static_purge` workflow_dispatch input** — for one-off recoveries like the current state (subset deployed, cache not invalidated, no font diff in the next deploy to trigger the gate). Set it to `true` on the next manual "Run workflow" and the purge runs unconditionally.

## How to unblock the current cache state

Once this merges, **manually dispatch the deploy workflow with `force_static_purge=true`** — that runs the build (no-op since fonts are already correct) and forces the purge step. After ~30s the CF edge will serve the small fonts. Mobile PSI should drop the four font entries off the LCP critical chain.

Alternative if you don't want to wait for the merge: run `purge_static_cache.sh` directly from your machine with `CLOUDFLARE_ZONE_ID` and `CLOUDFLARE_API_TOKEN` set — same result.

## Test plan

- [x] Verified the regex matches `public/assets/fonts/jetbrainsmono-*.woff2` and the four other fonts, doesn't match `public/assets/css/brutalist-theme.css` or post HTML
- [x] gitleaks clean
- [ ] After merge + force-dispatch: verify `curl -sI .../jetbrainsmono-v24-latin-400.woff2` returns `content-length: 16940` and the new `cf-cache-status` reflects a re-fetch
- [ ] After cache replacement: re-run mobile PSI, confirm the four fonts drop out of the LCP critical chain and FCP/LCP improve

🤖 Generated with [Claude Code](https://claude.com/claude-code)