### PR TITLE
fix(search-script): dedupe per-page, regex-match across attribute orders

### DIFF
--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -4576,37 +4576,69 @@ document.addEventListener('DOMContentLoaded', function() {
         else:
             print(f"   ℹ️  No files to copy from {static_src}")
 
+    # Match any <script> tag whose src is /js/search.js, regardless of
+    # attribute order or whitespace. The previous literal-substring guard
+    # (`'<script src="/js/search.js"' in html_content`) only matched when
+    # `src` was the FIRST attribute on the tag — but html_transformer.py
+    # later adds `defer` and `data-cfasync` before `src`. As a result every
+    # rebuild's seeded HTML failed the duplicate check and got ANOTHER
+    # script tag appended. Older posts accumulated 10–20+ duplicates.
+    _SEARCH_SCRIPT_TAG_RE = re.compile(
+        r'<script\b[^>]*\bsrc=(["\'])/js/search\.js\1[^>]*>\s*</script>',
+        re.IGNORECASE,
+    )
+
     def inject_search_script(self):
-        """Inject search script into all HTML files"""
+        """Inject the search script into every HTML file exactly once.
+
+        Idempotent + self-healing: if existing duplicates are in the seeded
+        HTML (from the pre-fix bug above) we collapse them all to a single
+        canonical tag at the end of <body>.
+        """
         print("📝 Injecting search script into HTML files...")
-        
+
         injected_count = 0
-        
-        # Find all HTML files
+        deduped_count = 0
+        canonical_tag = (
+            '<script src="/js/search.js" data-cfasync="false"></script>'
+        )
+
         for html_file in self.output_dir.rglob('*.html'):
             try:
-                # Read HTML
                 with open(html_file, 'r', encoding='utf-8', errors='ignore') as f:
                     html_content = f.read()
-                
-                # Check if search script is already injected
-                if '<script src="/js/search.js"' in html_content:
+
+                # `findall` returns the capture group (quote char) per match,
+                # so its length is the count of <script ...src=/js/search.js>
+                # tags currently in the file.
+                existing_count = len(self._SEARCH_SCRIPT_TAG_RE.findall(html_content))
+
+                if existing_count > 1:
+                    # Strip every existing copy so we can re-add exactly one
+                    # at the canonical location below.
+                    html_content = self._SEARCH_SCRIPT_TAG_RE.sub('', html_content)
+                    existing_count = 0
+                    deduped_count += 1
+                elif existing_count == 1:
+                    # Exactly one tag — nothing to do; the existing tag's
+                    # attribute order may differ but it's already a working
+                    # reference to the same script.
                     continue
-                
-                # Find closing body tag and inject script before it
+
                 if '</body>' in html_content:
-                    search_script_tag = '<script src="/js/search.js" data-cfasync="false"></script>\n</body>'
-                    html_content = html_content.replace('</body>', search_script_tag)
-                    
-                    # Write back to file
+                    html_content = html_content.replace(
+                        '</body>',
+                        f'{canonical_tag}\n</body>',
+                    )
                     with open(html_file, 'w', encoding='utf-8') as f:
                         f.write(html_content)
-                    
                     injected_count += 1
             except Exception as e:
                 print(f"   ⚠️  Error injecting script into {html_file}: {str(e)}")
                 continue
-        
+
+        if deduped_count:
+            print(f"   🧹 Collapsed duplicate search scripts in {deduped_count} files")
         if injected_count > 0:
             print(f"   ✅ Injected search script into {injected_count} HTML files")
         else:


### PR DESCRIPTION
## What you reported

> performance dropped to 81

Same homepage, similar FCP / LCP (~2.9 / 3.8 s). **83 → 81 is Lighthouse run variance** — PSI mobile routinely fluctuates ±5 points on identical pages. No real regression on the homepage.

But while investigating I caught a genuine bug worth fixing now.

## The bug

Every deploy appends one more `<script src="/js/search.js">` tag to **seeded** post pages. Today's auto-update commit ([`587a40e7b3`](https://github.com/jameskilbycloud/jkcoukblog/commit/587a40e7b3)) added one line to every post for that reason. Counts on `origin/main`:

| Page | Duplicates |
|---|---|
| `public/index.html` (homepage — regenerated fresh) | 1 |
| `public/2026/04/packer-vsphere-golden-images/index.html` | 11 |
| `public/2017/05/money-saving-uk-version/index.html` | **21** |
| `public/about-james-kilby-solution-architect/index.html` | **21** |

## Why

[`inject_search_script`](scripts/wp_to_static_generator.py) (in `scripts/wp_to_static_generator.py`) guarded the inject with a literal substring:

```python
if '<script src="/js/search.js"' in html_content:
    continue
```

It emits `src` as the first attribute. But `html_transformer.py:add_async_defer_to_scripts` later adds `defer` and reorders attributes so the committed tag becomes:

```html
<script data-cfasync="false" defer="" src="/js/search.js"></script>
```

`src` isn't the first attribute anymore, so the next build's substring check misses the existing tag and injects another. The homepage stays clean because it's regenerated fresh each build; everything seeded accumulates +1 per deploy.

## What this PR does

1. **Regex match instead of substring** — accepts any attribute order:
   ```python
   _SEARCH_SCRIPT_TAG_RE = re.compile(
       r'<script\b[^>]*\bsrc=(["\'])/js/search\.js\1[^>]*>\s*</script>',
       re.IGNORECASE,
   )
   ```
   Future attribute additions by `html_transformer` can't reintroduce the same class of bug.

2. **Self-healing** — if >1 existing tag is found in the seeded HTML, strip them all and re-add exactly one canonical tag before `</body>`. The next deploy cleans up the accumulated duplicates (21 → 1 on the worst-affected posts) without any manual intervention.

## Test plan

- [x] `python3 -m py_compile scripts/wp_to_static_generator.py` — clean
- [x] Ran the regex/strip/re-inject sequence against the on-disk `2017/05/money-saving-uk-version/index.html`: 21 → 0 → 1
- [x] gitleaks clean
- [ ] After merge: next auto-update commit should show every seeded post page losing N-1 duplicate `<script>` tags
- [ ] Spot-check 2-3 post pages on the live site after deploy — only one `<script ... src="/js/search.js">` in the HTML

## Re: the 81 score

For the actual FCP 2.9 s / LCP 3.8 s on mobile — these are bound by the homepage's HTML payload (114 KB pre-brotli) + inline-critical-CSS parse time on Lighthouse's 4× CPU throttle, not anything we've added recently. The font subset + scrollbar-offset strip removed everything that was reachable in the short loop. Further improvements would need bigger surgery (split critical CSS, reduce homepage HTML weight, content-hash font URLs). Happy to explore those if you want to push the mobile score higher — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)