### PR TITLE
fix: harden Slack workflow, pin Python deps, fix critical CSS truncation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Keeps the exact pins in requirements*.txt and the GitHub Action versions
+# current via weekly bump PRs.
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/issue-to-slack-improved.yml
+++ b/.github/workflows/issue-to-slack-improved.yml
@@ -14,7 +14,16 @@ jobs:
     steps:
       - name: Determine event details
         id: event_info
+        env:
+          # User-controlled text must enter the script via env vars, never via
+          # ${{ }} interpolation in the script body — a crafted issue/PR title
+          # would otherwise run as shell code (script injection).
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
+          # Strip CR/LF so a multi-line value can't inject extra step outputs.
+          ISSUE_TITLE=$(printf '%s' "$ISSUE_TITLE" | tr '\r\n' '  ')
+          PR_TITLE=$(printf '%s' "$PR_TITLE" | tr '\r\n' '  ')
           case "${{ github.event_name }}" in
             issues)
               if [ "${{ github.event.action }}" = "opened" ]; then
@@ -31,7 +40,7 @@ jobs:
                 echo "color=warning" >> $GITHUB_OUTPUT
               fi
               echo "url=${{ github.event.issue.html_url }}" >> $GITHUB_OUTPUT
-              echo "item_title=${{ github.event.issue.title }}" >> $GITHUB_OUTPUT
+              printf 'item_title=%s\n' "$ISSUE_TITLE" >> "$GITHUB_OUTPUT"
               echo "item_user=${{ github.event.issue.user.login }}" >> $GITHUB_OUTPUT
               echo "item_number=#${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
               ;;
@@ -40,7 +49,7 @@ jobs:
               echo "emoji=💬" >> $GITHUB_OUTPUT
               echo "color=#808080" >> $GITHUB_OUTPUT
               echo "url=${{ github.event.comment.html_url }}" >> $GITHUB_OUTPUT
-              echo "item_title=${{ github.event.issue.title }}" >> $GITHUB_OUTPUT
+              printf 'item_title=%s\n' "$ISSUE_TITLE" >> "$GITHUB_OUTPUT"
               echo "item_user=${{ github.event.comment.user.login }}" >> $GITHUB_OUTPUT
               echo "item_number=#${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
               ;;
@@ -65,7 +74,7 @@ jobs:
                 echo "color=warning" >> $GITHUB_OUTPUT
               fi
               echo "url=${{ github.event.pull_request.html_url }}" >> $GITHUB_OUTPUT
-              echo "item_title=${{ github.event.pull_request.title }}" >> $GITHUB_OUTPUT
+              printf 'item_title=%s\n' "$PR_TITLE" >> "$GITHUB_OUTPUT"
               echo "item_user=${{ github.event.pull_request.user.login }}" >> $GITHUB_OUTPUT
               echo "item_number=#${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
               ;;
@@ -86,7 +95,7 @@ jobs:
                   "color": "${{ steps.event_info.outputs.color }}",
                   "title": "${{ steps.event_info.outputs.emoji }} ${{ steps.event_info.outputs.title }}",
                   "title_link": "${{ steps.event_info.outputs.url }}",
-                  "text": "*${{ steps.event_info.outputs.item_number }}:* ${{ steps.event_info.outputs.item_title }}",
+                  "text": ${{ toJSON(format('*{0}:* {1}', steps.event_info.outputs.item_number, steps.event_info.outputs.item_title)) }},
                   "fields": [
                     {
                       "title": "Repository",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,4 @@
 # Image optimisation extras are in requirements-images.txt
 
 # Spell checking (CI spell-check workflow only)
-pyspellchecker
+pyspellchecker==0.9.0

--- a/requirements-images.txt
+++ b/requirements-images.txt
@@ -1,11 +1,12 @@
 # Image Optimization Requirements
 # Install with: pip install -r requirements-images.txt
 
-# Core dependencies
-Pillow>=10.0.0
-pillow-avif-plugin>=1.4.0
-beautifulsoup4>=4.12.0
-requests>=2.31.0
+# Core dependencies — pinned exactly, kept current by Dependabot.
+# Versions must match requirements.txt where packages overlap.
+Pillow==12.2.0
+pillow-avif-plugin==1.5.5
+beautifulsoup4==4.15.0
+requests==2.34.2
 
 # Optional: For better performance
 # Pillow-SIMD  # Drop-in replacement for Pillow with SIMD optimizations

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,15 @@
 # Core dependencies for static site generation
-requests
-beautifulsoup4
-brotli
-cssutils
-Pillow
+# Pinned exactly — CI installs from this file on every run, so unpinned
+# entries float to whatever PyPI serves that day (supply-chain and
+# reproducibility risk). Dependabot (.github/dependabot.yml) raises bump PRs.
+requests==2.34.2
+beautifulsoup4==4.15.0
+brotli==1.2.0
+cssutils==2.15.0
+Pillow==12.2.0
 # fontTools is used by generate_og_images.py to unwrap woff2 → ttf
 # (PIL can't render woff2 directly). [woff] extra pulls brotli decompression.
-fonttools[woff]
+fonttools[woff]==4.63.0
 html2text==2020.1.16
 pyyaml==6.0.1
 

--- a/scripts/extract_critical_css.py
+++ b/scripts/extract_critical_css.py
@@ -23,6 +23,9 @@ class CriticalCSSExtractor:
         self.public_dir = Path(public_dir)
         self.files_processed = 0
         self.css_inlined = 0
+        self.css_truncated = 0
+        # Hard cap on critical CSS per page; rules beyond this are dropped.
+        self.max_critical_css = 15000
         # ~16 KB raw → ~5 KB on the wire after brotli. Below this we always
         # inline so the browser doesn't pay a render-blocking round-trip for
         # critical CSS. Measured: p90 page produces ~15 KB of critical CSS.
@@ -40,6 +43,9 @@ class CriticalCSSExtractor:
 
         print(f"\n✅ Processed {self.files_processed} files")
         print(f"   Inlined critical CSS in {self.css_inlined} files")
+        if self.css_truncated:
+            print(f"   ⚠️  Truncated critical CSS in {self.css_truncated} files "
+                  f"(over {self.max_critical_css} byte cap)")
 
     def process_file(self, file_path):
         """Process a single HTML file"""
@@ -54,7 +60,7 @@ class CriticalCSSExtractor:
             soup = BeautifulSoup(html, 'html.parser')
 
             # Extract critical CSS
-            critical_css = self._extract_critical_css(soup)
+            critical_css = self._extract_critical_css(soup, file_path)
 
             if not critical_css:
                 return False
@@ -77,7 +83,7 @@ class CriticalCSSExtractor:
             print(f"⚠️  Error processing {file_path}: {e}")
             return False
 
-    def _extract_critical_css(self, soup):
+    def _extract_critical_css(self, soup, file_path=None):
         """
         Extract critical above-the-fold CSS
         Uses a simple heuristic: CSS rules for elements in first ~800px of content
@@ -136,11 +142,11 @@ class CriticalCSSExtractor:
         critical_selectors.update(base_selectors)
 
         # Extract CSS rules that match critical selectors
-        critical_css = self._extract_matching_css_rules(soup, critical_selectors)
+        critical_css = self._extract_matching_css_rules(soup, critical_selectors, file_path)
 
         return critical_css
 
-    def _extract_matching_css_rules(self, soup, selectors):
+    def _extract_matching_css_rules(self, soup, selectors, file_path=None):
         """Extract CSS rules that match the given selectors"""
         critical_rules = []
 
@@ -166,19 +172,28 @@ class CriticalCSSExtractor:
                         # Silently skip if we can't read the file
                         pass
 
-        # Combine and minify
-        combined_css = '\n'.join(critical_rules)
-        minified_css = self._minify_css(combined_css)
+        # Minify each rule separately, then keep whole rules until the size
+        # cap is reached. Each entry in critical_rules is a complete,
+        # brace-balanced rule, so this can never cut inside a @media block —
+        # the old slice-at-15000-chars approach could, leaving an unbalanced
+        # brace that made the browser discard every rule after it.
+        minified_rules = [r for r in (self._minify_css(rule) for rule in critical_rules) if r]
 
-        # Limit to ~15KB of critical CSS
-        if len(minified_css) > 15000:
-            minified_css = minified_css[:15000]
-            # Find last complete rule
-            last_brace = minified_css.rfind('}')
-            if last_brace > 0:
-                minified_css = minified_css[:last_brace + 1]
+        kept = []
+        size = 0
+        for i, rule in enumerate(minified_rules):
+            if size + len(rule) > self.max_critical_css:
+                dropped_bytes = sum(len(r) for r in minified_rules[i:])
+                where = f" in {file_path}" if file_path else ""
+                print(f"   ⚠️  Critical CSS over {self.max_critical_css}B cap{where}: "
+                      f"dropped {len(minified_rules) - i}/{len(minified_rules)} rules "
+                      f"({dropped_bytes}B)")
+                self.css_truncated += 1
+                break
+            kept.append(rule)
+            size += len(rule)
 
-        return minified_css
+        return ''.join(kept)
 
     def _parse_css_rules(self, css_content, critical_selectors):
         """Parse CSS and extract rules matching critical selectors.


### PR DESCRIPTION
Fixes three findings from a full codebase review.

## 1. Script injection in the Slack notifier (security)

`issue-to-slack-improved.yml` interpolated `github.event.issue.title` / `pull_request.title` directly into a `run:` block — anyone opening an issue with a crafted title could execute shell code in the runner. Titles now enter via `env:`, CR/LF is stripped before writing step outputs (prevents output injection), and the Slack payload JSON-escapes the title with `toJSON()` so quotes can't break or inject into the payload.

## 2. Unpinned Python dependencies

`requirements.txt` left `requests`, `beautifulsoup4`, `brotli`, `cssutils`, `Pillow`, and `fonttools` unpinned, and `requirements-images.txt` used `>=` ranges — every CI run installed whatever PyPI served that day. All deps are now pinned to the versions CI was already resolving to (so this changes nothing functionally, just freezes the moving target), and a new `.github/dependabot.yml` raises weekly bump PRs for pip and GitHub Actions. Note: `html2text` was flagged as unused during review but is actually imported by `markdown_exporter.py`, so it stays.

## 3. Critical CSS truncation could corrupt output

`extract_critical_css.py` capped critical CSS by slicing the minified string at 15,000 chars and cutting back to the last `}`. If that landed inside a `@media` block, the result had an unbalanced brace and the browser discarded every rule after it — silently unstyled pages. It now minifies per-rule and keeps whole (brace-balanced) rules until the budget is spent, logs a per-file warning naming what was dropped, and reports a truncation count in the run summary. Verified with a test that reproduces the unbalanced-brace bug under the old logic and confirms balanced output under the new one.

## Impact on `public/`

Nothing in this PR writes to `public/` directly, but the critical-CSS change means the next pipeline run may regenerate inlined `<style>` blocks for pages whose critical CSS exceeds 15 KB (rule-boundary truncation instead of character-boundary). Expect a larger-than-usual auto-commit diff on those pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)