### PR TITLE
fix: surface non-blocking CI failures, thread-safe caches, config-aware cache invalidation

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -493,6 +493,7 @@ jobs:
           --with-full
 
     - name: Content quality validation
+      id: content_validation
       timeout-minutes: 5
       continue-on-error: true  # Non-blocking: warnings won't fail the build
       run: |
@@ -639,6 +640,7 @@ jobs:
         fi
 
     - name: Optimize CSS files (unused removal + minify)
+      id: optimize_css
       run: |
         echo "🎨 Optimizing CSS files..."
 
@@ -653,6 +655,7 @@ jobs:
       continue-on-error: true
 
     - name: Single-pass HTML transformer (SEO + pictures + perf + critical CSS + minify)
+      id: html_transformer
       timeout-minutes: 15
       run: |
         echo "🔄 Running single-pass HTML transformer..."
@@ -689,6 +692,7 @@ jobs:
         fi
 
     - name: Generate per-post Open Graph images
+      id: og_images
       # Replace the shared fallback og:image with a branded, title-specific
       # PNG so social shares of different posts look different. 60% of posts
       # currently ship the same generic image. Must run BEFORE Brotli so
@@ -700,6 +704,7 @@ jobs:
       continue-on-error: true
 
     - name: Subset Anton font to chars used in headings
+      id: font_subset
       # Anton ships at ~130 KB and is preloaded (LCP critical path), but
       # only ~90 of its glyphs are actually used across the site. Subset
       # to ~12 KB. Must run BEFORE Brotli so the .br/.gz sidecars get
@@ -720,6 +725,7 @@ jobs:
       run: python3 scripts/rewrite_vendored_urls.py ./static-output
 
     - name: Brotli + Gzip compress static files
+      id: compress
       timeout-minutes: 10
       run: |
         echo "🗜️  Compressing final optimized files with Brotli (primary) + Gzip (fallback)..."
@@ -817,6 +823,7 @@ jobs:
       continue-on-error: true
 
     - name: Interactive UI smoke tests (Playwright)
+      id: smoke_tests
       # Headless-Chromium walkthrough that exercises the JS-driven UI
       # (mobile drawer, Splide carousel layout, sticky-header behaviour
       # when configured). Specifically guards against the optimize_css
@@ -984,6 +991,7 @@ jobs:
         python3 scripts/convert_to_staging.py
 
     - name: Generate changelog, stats, and recompress
+      id: changelog_stats
       run: |
         echo "📋 Generating changelog page..."
         python3 scripts/generate_changelog.py || echo "⚠️  Changelog generation failed (non-blocking)"
@@ -1070,6 +1078,7 @@ jobs:
         node-version: '20'
 
     - name: Upload search index to Workers KV
+      id: search_index
       if: success()
       run: |
         echo "🔍 Uploading search index to Workers KV..."
@@ -1121,6 +1130,7 @@ jobs:
     # in the repo for emergency ad-hoc use.
 
     - name: Purge all HTML from KV cache
+      id: kv_purge
       if: success()
       env:
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -1235,6 +1245,7 @@ jobs:
     # cache" step above is the actual cache invalidation for HTML.
 
     - name: Purge static assets from Cloudflare cache
+      id: static_purge
       if: success()
       env:
         CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
@@ -1277,6 +1288,7 @@ jobs:
       continue-on-error: true
 
     - name: Submit URLs to IndexNow
+      id: indexnow
       if: success()
       run: |
         echo "🔔 Submitting URLs to IndexNow..."
@@ -1315,6 +1327,7 @@ jobs:
       continue-on-error: true
 
     - name: Ping Google sitemap on new post
+      id: google_ping
       if: success()
       run: |
         # Only ping Google when a genuinely new post page was added this build.
@@ -1352,6 +1365,49 @@ jobs:
         echo "- **Triggered by:** $(echo "$NEW_POSTS" | wc -l | tr -d ' ') new post(s)" >> $GITHUB_STEP_SUMMARY
       continue-on-error: true
 
+    - name: Report non-blocking step failures
+      id: nonblocking_report
+      if: always()
+      run: |
+        # The steps below are continue-on-error so a degraded build still
+        # deploys, but their failures must not be invisible: collect every
+        # outcome, write a summary, and feed the Slack notification.
+        FAILED=()
+        check() {
+          if [ "$2" = "failure" ]; then FAILED+=("$1"); fi
+        }
+        check "Content quality validation"  "${{ steps.content_validation.outcome }}"
+        check "CSS optimization"            "${{ steps.optimize_css.outcome }}"
+        check "HTML transformer"            "${{ steps.html_transformer.outcome }}"
+        check "OG image generation"         "${{ steps.og_images.outcome }}"
+        check "Font subsetting"             "${{ steps.font_subset.outcome }}"
+        check "Brotli/Gzip compression"     "${{ steps.compress.outcome }}"
+        check "Playwright smoke tests"      "${{ steps.smoke_tests.outcome }}"
+        check "Changelog/stats generation"  "${{ steps.changelog_stats.outcome }}"
+        check "Search index KV upload"      "${{ steps.search_index.outcome }}"
+        check "KV HTML cache purge"         "${{ steps.kv_purge.outcome }}"
+        check "Static asset cache purge"    "${{ steps.static_purge.outcome }}"
+        check "IndexNow submission"         "${{ steps.indexnow.outcome }}"
+        check "Google sitemap ping"         "${{ steps.google_ping.outcome }}"
+
+        COUNT=${#FAILED[@]}
+        echo "failed_count=$COUNT" >> "$GITHUB_OUTPUT"
+        if [ "$COUNT" -eq 0 ]; then
+          echo "failed_list=" >> "$GITHUB_OUTPUT"
+          echo "✅ All non-blocking steps succeeded"
+        else
+          LIST=$(printf '%s, ' "${FAILED[@]}"); LIST=${LIST%, }
+          echo "failed_list=$LIST" >> "$GITHUB_OUTPUT"
+          {
+            echo "## ⚠️ Non-blocking steps failed ($COUNT)"
+            echo ""
+            for s in "${FAILED[@]}"; do echo "- $s"; done
+            echo ""
+            echo "The deploy proceeded anyway (these steps are continue-on-error), but the failures need a look."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "⚠️ $COUNT non-blocking step(s) failed: $LIST"
+        fi
+
     - name: Notify Slack on Success
       if: success()
       uses: slackapi/slack-github-action@v3.0.3
@@ -1365,10 +1421,15 @@ jobs:
             "icon_emoji": ":github:",
             "attachments": [
               {
-                "color": "good",
-                "title": "✅ jkcoukblog Build Success",
+                "color": "${{ steps.nonblocking_report.outputs.failed_count == '0' && 'good' || 'warning' }}",
+                "title": "${{ steps.nonblocking_report.outputs.failed_count == '0' && '✅ jkcoukblog Build Success' || '⚠️ jkcoukblog Build Success (with warnings)' }}",
                 "text": "jkcoukblog static site built and pushed successfully!",
                 "fields": [
+                  {
+                    "title": "Non-blocking step failures",
+                    "value": "${{ steps.nonblocking_report.outputs.failed_count == '0' && 'None' || steps.nonblocking_report.outputs.failed_list }}",
+                    "short": false
+                  },
                   {
                     "title": "HTML Pages",
                     "value": "${{ env.HTML_COUNT }}",

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ This repository contains a complete automation pipeline that:
 - ✅ **Generates a static site** with all content, assets, and metadata — **incrementally** (only posts modified since last build are re-fetched)
 - ✅ **Applies AI spell-checking** via Ollama (non-blocking, incremental)
 - ✅ **Optimises images** to AVIF/WebP with `<picture>` elements and intelligent caching
+- ✅ **Transforms HTML in a single pass** — SEO fixes, `<picture>` conversion, performance hints, critical CSS inlining, and minification in one parse cycle per file
 - ✅ **Compresses assets** with Brotli (primary) + Gzip (fallback), pre-encoded at build time
-- ✅ **Inlines critical CSS** for faster first paint
-- ✅ **Validates content** — SEO, accessibility, JSON-LD, og:image, security headers
-- ✅ **Deploys to Cloudflare Pages** via git commit, with selective KV cache purge
-- ✅ **Submits to IndexNow** after deployment so crawlers see fresh content immediately
+- ✅ **Generates extras** — per-post Open Graph images, `llms.txt`, Markdown export + JSON API, subsetted heading font
+- ✅ **Validates content** — SEO, accessibility, JSON-LD, og:image, security headers, plus Playwright UI smoke tests
+- ✅ **Deploys to Cloudflare Pages** via git commit, with KV HTML cache purge after deploy
+- ✅ **Submits to IndexNow** (and pings Google on new posts) so crawlers see fresh content immediately
 
 ## 🏗️ Architecture
 
@@ -36,10 +37,15 @@ wordpress.jameskilby.cloud  |                         |                      jam
 ├── .github/
 │   ├── workflows/
 │   │   ├── deploy-static-site.yml         # Main build + deploy pipeline
-│   │   ├── quality-checks.yml             # Lighthouse + live site formatting tests
+│   │   ├── force-full-deploy.yml          # Full (non-incremental) rebuild trigger
+│   │   ├── quality-checks.yml             # Lighthouse + live site formatting tests (daily)
+│   │   ├── lighthouse-pr.yml              # Lighthouse audit on pull requests
 │   │   ├── spell-check-consolidated.yml   # AI spell checking (Ollama/Llama)
 │   │   ├── spell-check-approval-handler.yml # Spell check approval flow
-│   │   ├── secret-scan.yml                # Gitleaks secret scanning
+│   │   ├── apply-typo-patches.yml         # Apply approved typo fixes to WordPress
+│   │   ├── apply-alt-patches.yml          # Apply approved image alt-text fixes
+│   │   ├── wordpress-backup.yml           # WordPress backup (1st + 15th of month)
+│   │   ├── secret-scan.yml                # Gitleaks secret scanning (weekly)
 │   │   ├── rollback-site.yml              # Deployment rollback
 │   │   ├── issue-to-slack-improved.yml    # GitHub issue → Slack notifications
 │   │   └── enable-cloudflare-indexing.yml # Cloudflare indexing setup
@@ -49,18 +55,28 @@ wordpress.jameskilby.cloud  |                         |                      jam
 │   ├── incremental_builder.py             # BLAKE2b incremental build cache
 │   ├── config.py                          # Centralised configuration
 │   ├── optimize_images.py                 # AVIF/WebP generation (parallel, cached)
-│   ├── convert_images_to_picture.py       # Wraps <img> in <picture> elements
-│   ├── extract_critical_css.py            # Extracts and inlines above-fold CSS
-│   ├── optimize_css.py                    # CSS optimisation and minification
-│   ├── enhance_html_performance.py        # fetchpriority, lazy loading, preconnect
-│   ├── fix_seo_issues.py                  # SEO auto-fixer (title, meta, H1)
-│   ├── minify_html.py                     # HTML minification
+│   ├── optimize_css.py                    # CSS unused-selector removal + minification
+│   ├── html_transformer.py                # Single-pass HTML transformer (SEO, <picture>,
+│   │                                      #   perf hints, critical CSS, minify)
+│   ├── convert_images_to_picture.py       # <picture> conversion (used by transformer)
+│   ├── extract_critical_css.py            # Critical CSS extraction (used by transformer)
+│   ├── enhance_html_performance.py        # Performance hints (used by transformer)
+│   ├── fix_seo_issues.py                  # SEO auto-fixer (used by transformer)
+│   ├── minify_html.py                     # HTML minification (used by transformer)
 │   ├── brotli_compress.py                 # Brotli + Gzip pre-encoding
+│   ├── generate_og_images.py              # Per-post Open Graph image generation
+│   ├── generate_llms_txt.py               # llms.txt generation for AI crawlers
+│   ├── generate_soft404_artefacts.py      # Soft-404 detection artefacts
+│   ├── stamp_worker_manifest.py           # Stamps Advanced Mode Worker manifest
+│   ├── subset_fonts.py                    # Subsets heading font to used characters
+│   ├── rewrite_vendored_urls.py           # Rewrites stale vendored-CDN URLs
 │   ├── content_validator.py               # SEO, JSON-LD, accessibility, security
 │   ├── validate_html.py                   # HTML structural validation
 │   ├── validate_deployment.py             # Post-optimisation deployment checks
+│   ├── validate_seo.py                    # SEO validation
 │   ├── validate_wordpress_source.py       # Pre-build WordPress health check
 │   ├── test_csp.py                        # CSP validation (Utterances, Credly, Plausible)
+│   ├── test_interactive_ui.py             # Playwright interactive UI smoke tests
 │   ├── test_live_site_formatting.py       # Live site formatting + performance tests
 │   ├── markdown_exporter.py               # Exports content as Markdown
 │   ├── markdown_api.py                    # Generates /api/ JSON endpoints
@@ -71,19 +87,20 @@ wordpress.jameskilby.cloud  |                         |                      jam
 │   ├── convert_to_staging.py              # Converts URLs for staging deployment
 │   ├── ollama_spell_checker.py            # AI spell checker (Ollama/Llama)
 │   ├── wp_spell_check_and_fix.py          # WordPress spell check + auto-fix
+│   ├── apply_typo_patches.py              # Applies approved typo patches to WordPress
+│   ├── apply_alt_patches.py               # Applies approved alt-text patches
 │   ├── manage_build_cache.py              # Build cache management tool
 │   ├── purge_html_kv_cache.py             # Bulk-delete html:* entries from KV
+│   ├── purge_soft404_kv_cache.py          # Ad-hoc soft-404 KV purge
 │   ├── restore_seeded_urls.py             # Restore seeded URLs after build
 │   ├── fix_duplicate_resource_hints.py    # Deduplicate preconnect/prefetch hints
 │   ├── purge_static_cache.sh              # Cloudflare edge cache purge
-│   ├── streamdeck-deploy.sh               # Stream Deck deployment trigger
-│   └── archive/                           # Archived one-time setup scripts
+│   └── streamdeck-deploy.sh               # Stream Deck deployment trigger
 ├── _worker.template.js                    # Cloudflare Pages Advanced Mode Worker
 │                                          #   → copied to public/_worker.js at deploy
 │                                          #   KV cache, smart TTL, view tracking,
-│                                          #   selective purge, security headers,
-│                                          #   /diagnostic, /trace, /test endpoints
-├── docs/                                  # Documentation hub (20+ files)
+│                                          #   security headers, /markdown/ + /api/ routing
+├── docs/                                  # Documentation hub
 │   ├── README.md                          # Documentation index
 │   ├── DEPLOYMENT.md                      # Deployment guide
 │   ├── OPTIMIZATION.md                    # Performance optimisation reference
@@ -98,13 +115,11 @@ wordpress.jameskilby.cloud  |                         |                      jam
 │   ├── STREAMDECK_DEPLOY_SETUP.md         # Stream Deck integration
 │   ├── STREAMDECK_QUICK_REFERENCE.md      # Stream Deck quick reference card
 │   ├── STREAMDECK_README.md               # Stream Deck overview
-│   ├── ADDITIONAL_PERFORMANCE_RECOMMENDATIONS.md  # Extra performance tips
-│   └── archive/                           # Historical docs
+│   └── ADDITIONAL_PERFORMANCE_RECOMMENDATIONS.md  # Extra performance tips
 ├── public/                                # Generated static site (Cloudflare Pages)
 ├── workers/                               # Cloudflare Workers (deployed independently)
 │   ├── search-api.js                      # Search API endpoint
-│   ├── slack-notification-handler.js      # Slack webhook handler
-│   └── archive/                           # Superseded worker versions
+│   └── slack-notification-handler.js      # Slack webhook handler
 ├── assets/fonts/                          # Font assets
 ├── Makefile                               # Build pipeline targets (make help)
 ├── CONTRIBUTING.md                        # Contribution guidelines
@@ -128,6 +143,7 @@ wordpress.jameskilby.cloud  |                         |                      jam
    - `OLLAMA_API_CREDENTIALS` — AI spell check (optional)
    - `CACHE_PURGE_TOKEN` — KV cache purge (optional)
    - `CLOUDFLARE_API_TOKEN` — Cloudflare API (optional, for cache purge + KV)
+   - `CLOUDFLARE_ACCOUNT_ID` — Account ID for KV operations (optional)
    - `CLOUDFLARE_ZONE_ID` — Zone ID for static asset purge (optional)
    - `KV_SEARCH_INDEX_ID` — KV namespace for search index (optional)
    - `PLAUSIBLE_SHARE_LINK` — Plausible stats page (optional)
@@ -153,36 +169,37 @@ python3 scripts/wp_to_static_generator.py ./static-output
 
 ## 🔄 Build Pipeline
 
-The `deploy-static-site.yml` workflow runs these steps in order:
+The `deploy-static-site.yml` workflow runs a non-blocking spell-check job, then the main build job:
 
 | # | Step | Notes |
 |---|------|-------|
+| 0 | AI spell check | Separate job, Ollama/Llama, `continue-on-error` — never blocks the build |
 | 1 | Validate environment variables | Fails fast on missing secrets |
-| 2 | Restore build caches | `actions/cache@v4` — image cache + incremental build cache + spell-check timestamp |
-| 3 | Install system dependencies | apt packages: `avifenc`, `optipng`, `jpegoptim`, `jq`, `bc` |
-| 4 | Install Python dependencies | `pip install -r requirements.txt` |
+| 2 | Restore build caches | `actions/cache` — image cache + incremental build cache + spell-check timestamp |
+| 3 | Install system + Python dependencies | apt packages (`avifenc`, `optipng`, `jpegoptim`, `jq`, `bc`) + `pip install -r requirements.txt` |
+| 4 | Validate CSP (Utterances, Plausible, Credly) | `test_csp.py` — fails build if the CSP would block them |
 | 5 | Validate WordPress source health | Pre-flight check before generation |
 | 6 | Generate static site | `wp_to_static_generator.py` — incremental (WP `modified_after`) or full build; HTML, assets, sitemap, search index |
-| 7 | Export to Markdown | `markdown_exporter.py` |
-| 8 | Generate Markdown API | `markdown_api.py` |
-| 9 | Validate CSP (Utterances, Plausible, Credly) | `test_csp.py` — fails build if CSP would block them |
-| 10 | Content quality validation | `content_validator.py` — non-blocking |
-| 11 | Optimise images | AVIF + WebP, 4 parallel workers, BLAKE2b cache |
-| 12 | Convert `<img>` → `<picture>` | Adds AVIF/WebP sources with fallbacks |
-| 13 | Optimise CSS | Remove unused selectors |
-| 14 | Apply SEO fixes | Title length, meta description scoped to article, H1 deduplication |
-| 15 | Extract and inline critical CSS | Above-fold CSS inlined in `<head>` |
-| 16 | Apply performance enhancements | `fetchpriority` for LCP image, lazy loading, preconnect, CSS preload |
-| 17 | Minify CSS | Minification pass |
-| 18 | Minify HTML | `minify_html.py` |
-| 19 | Brotli + Gzip compression | `.br` (primary) + `.gz` (fallback) for all text assets |
-| 20 | Validate final HTML | Structural validation |
-| 21 | Comprehensive deployment validation | Brotli integrity, AVIF/WebP presence, picture structure |
-| 22 | Commit and push to git | Triggers Cloudflare Pages auto-deploy |
-| 23 | Upload search index to Workers KV | `wrangler kv:key put` |
-| 24 | Selective KV cache purge | Purges only changed HTML pages |
-| 25 | Purge static assets from Cloudflare | Edge cache purge via Cloudflare API |
-| 26 | Submit URLs to IndexNow | Runs after deployment so crawlers see fresh content |
+| 7 | Export to Markdown + Markdown API | `markdown_exporter.py`, `markdown_api.py` — `/markdown/` and `/api/` paths |
+| 8 | Generate llms.txt | `generate_llms_txt.py` |
+| 9 | Content quality validation | `content_validator.py` — non-blocking |
+| 10 | Optimise images | AVIF + WebP, 4 parallel workers, BLAKE2b cache |
+| 11 | Optimise CSS | Remove unused selectors + minify |
+| 12 | Single-pass HTML transformer | `html_transformer.py` — SEO fixes, `<img>` → `<picture>`, performance hints, critical CSS inlining, and HTML minification in one parse cycle per file |
+| 13 | Soft-404 artefacts + worker stamp | `generate_soft404_artefacts.py`, `stamp_worker_manifest.py` |
+| 14 | Generate per-post Open Graph images | `generate_og_images.py` |
+| 15 | Subset heading font | `subset_fonts.py` — Anton subset to characters used in headings |
+| 16 | Rewrite stale vendored-CDN URLs | `rewrite_vendored_urls.py` |
+| 17 | Brotli + Gzip compression | `.br` (primary) + `.gz` (fallback) for all text assets |
+| 18 | Interactive UI smoke tests | Playwright (`test_interactive_ui.py`) |
+| 19 | Validate HTML + deployment | `validate_html.py` + `validate_deployment.py` in parallel — Brotli integrity, AVIF/WebP presence, picture structure |
+| 20 | Prepare output + changelog/stats | Copies to `public/`, generates changelog and stats pages, recompresses |
+| 21 | Commit and push to git | Triggers Cloudflare Pages auto-deploy |
+| 22 | Upload search index to Workers KV | `wrangler kv key put` |
+| 23 | Purge all HTML from KV cache | Waits for the Pages deploy of the pushed commit, then wipes `html:*` entries |
+| 24 | Purge static assets from Cloudflare | Edge cache purge via Cloudflare API |
+| 25 | Submit URLs to IndexNow | Runs after deployment so crawlers see fresh content |
+| 26 | Ping Google sitemap | Only when a new post was published |
 | 27 | Notify Slack | Success or failure notification |
 | 28 | Clean up on failure | Removes `./static-output` if build failed |
 
@@ -194,6 +211,7 @@ The `deploy-static-site.yml` workflow runs these steps in order:
 - 4 parallel workers for fast processing
 - `fetchpriority="high"` on the first `<main>`/`<article>` image (LCP candidate)
 - `loading="lazy"` + `decoding="async"` on all other images
+- Per-post Open Graph images generated at build time
 
 ### 🗜️ Compression
 - **Brotli** (quality 11, `MODE_TEXT` for HTML/CSS/JS, `MODE_GENERIC` for JSON/SVG/XML)
@@ -202,8 +220,9 @@ The `deploy-static-site.yml` workflow runs these steps in order:
 - Minimum 5% size reduction threshold before writing compressed file
 
 ### ⚡ Performance
+- Single-pass HTML transformer — one BeautifulSoup parse/serialise cycle per file instead of 5–6 separate passes
 - Critical CSS extracted and inlined for zero render-blocking on first paint
-- CSS preload hints for primary stylesheet (exact filename match: `critical.css`, `main.css`, `styles.css`)
+- Heading font subsetted to only the characters actually used
 - DNS prefetch + preconnect for Plausible Analytics
 - Cloudflare KV HTML cache with smart TTL (5 min homepage, 15 min recent posts, 1 hr older)
 - KV TTL uses absolute expiry — view-count updates do not reset the cache clock
@@ -214,19 +233,21 @@ The `deploy-static-site.yml` workflow runs these steps in order:
 - Meta description expansion scoped to `<article>`/`<main>` (not nav or footer)
 - Canonical URL warnings
 - H1 deduplication
-- IndexNow submission after deployment
+- `llms.txt` for AI crawlers
+- IndexNow submission after deployment + Google sitemap ping on new posts
 
 ### 🔒 Security
 - Content Security Policy headers (via `_worker.template.js`)
 - Inline script detection in content validator
 - Mixed content detection
-- `/markdown/` and `/api/` path handling in the worker
+- Gitleaks secret scanning (pre-commit hook + weekly workflow)
 
 ### 📊 Analytics & Monitoring
 - **Plausible Analytics** auto-injected on every page
 - **Utterances** comments (GitHub Issues backed, dark theme)
 - **Slack notifications** on success and failure
 - **GitHub Actions summary** with per-step metrics
+- **Playwright UI smoke tests** before every deploy
 
 ## ⚙️ Configuration
 
@@ -251,17 +272,22 @@ Secrets (tokens, credentials) remain in environment variables and GitHub Secrets
 
 ### Workflow Status Badges
 
-[![Deploy Static Site](https://github.com/jameskilbynet/jkcoukblog/actions/workflows/deploy-static-site.yml/badge.svg)](https://github.com/jameskilbynet/jkcoukblog/actions/workflows/deploy-static-site.yml)
-[![Quality Checks](https://github.com/jameskilbynet/jkcoukblog/actions/workflows/quality-checks.yml/badge.svg)](https://github.com/jameskilbynet/jkcoukblog/actions/workflows/quality-checks.yml)
-[![Secret Scan](https://github.com/jameskilbynet/jkcoukblog/actions/workflows/secret-scan.yml/badge.svg)](https://github.com/jameskilbynet/jkcoukblog/actions/workflows/secret-scan.yml)
+[![Deploy Static Site](https://github.com/jameskilbycloud/jkcoukblog/actions/workflows/deploy-static-site.yml/badge.svg)](https://github.com/jameskilbycloud/jkcoukblog/actions/workflows/deploy-static-site.yml)
+[![Quality Checks](https://github.com/jameskilbycloud/jkcoukblog/actions/workflows/quality-checks.yml/badge.svg)](https://github.com/jameskilbycloud/jkcoukblog/actions/workflows/quality-checks.yml)
+[![Secret Scan](https://github.com/jameskilbycloud/jkcoukblog/actions/workflows/secret-scan.yml/badge.svg)](https://github.com/jameskilbycloud/jkcoukblog/actions/workflows/secret-scan.yml)
 
 | Workflow | Purpose |
 |----------|---------|
-| `deploy-static-site.yml` | Main 28-step build + deploy pipeline |
-| `quality-checks.yml` | Lighthouse audits + live site formatting tests (daily) |
+| `deploy-static-site.yml` | Main build + deploy pipeline |
+| `force-full-deploy.yml` | Force a full (non-incremental) rebuild |
+| `quality-checks.yml` | Lighthouse audits + live site formatting tests (daily, 03:00 UTC) |
+| `lighthouse-pr.yml` | Lighthouse audit on pull requests |
 | `spell-check-consolidated.yml` | AI spell checking via Ollama/Llama |
 | `spell-check-approval-handler.yml` | PR-based spell correction approval |
-| `secret-scan.yml` | Gitleaks secret scanning |
+| `apply-typo-patches.yml` | Apply approved typo fixes back to WordPress |
+| `apply-alt-patches.yml` | Apply approved image alt-text fixes |
+| `wordpress-backup.yml` | WordPress backup (1st + 15th of month) |
+| `secret-scan.yml` | Gitleaks secret scanning (weekly) |
 | `rollback-site.yml` | Deployment rollback |
 | `issue-to-slack-improved.yml` | GitHub issue → Slack notifications |
 

--- a/scripts/incremental_builder.py
+++ b/scripts/incremental_builder.py
@@ -7,6 +7,7 @@ Massive time savings by tracking what's already been built
 import json
 import hashlib
 import re
+import threading
 from pathlib import Path
 from datetime import datetime
 
@@ -16,10 +17,44 @@ from datetime import datetime
 _POST_URL_RE = re.compile(r'^/\d{4}/\d{2}/[^/]+')
 
 class IncrementalBuilder:
+    # Files whose contents determine the generated HTML. The cache only says
+    # "this WordPress content was already rendered" — if the code that renders
+    # it changes, every cached page is potentially stale, so any change here
+    # invalidates the whole cache and forces a full rebuild.
+    FINGERPRINT_FILES = ('config.py', 'wp_to_static_generator.py')
+
     def __init__(self, cache_file='.build-cache.json'):
         self.cache_file = Path(cache_file)
+        # mark_processed() is called from ThreadPoolExecutor workers in
+        # wp_to_static_generator.py — guard all cache mutation/serialisation.
+        self._lock = threading.Lock()
         self.cache = self._load_cache()
-    
+        self._check_environment_fingerprint()
+
+    def _environment_fingerprint(self):
+        """Hash the generator code + config that shape the rendered output."""
+        h = hashlib.blake2b(digest_size=16)
+        script_dir = Path(__file__).resolve().parent
+        for name in self.FINGERPRINT_FILES:
+            try:
+                h.update((script_dir / name).read_bytes())
+            except OSError:
+                h.update(f'missing:{name}'.encode())
+        return h.hexdigest()
+
+    def _check_environment_fingerprint(self):
+        """Invalidate the cache when config.py or the generator changed."""
+        fingerprint = self._environment_fingerprint()
+        cached = self.cache.get('environment_fingerprint')
+        if cached != fingerprint:
+            had_entries = bool(self.cache['posts'] or self.cache['pages'])
+            if cached is not None or had_entries:
+                print("♻️  config.py / generator changed since last build — "
+                      "clearing build cache, this build will be full")
+                self.cache = self._empty_cache()
+        self.cache['environment_fingerprint'] = fingerprint
+
+
     def _load_cache(self):
         """Load build cache from disk"""
         if self.cache_file.exists():
@@ -43,7 +78,9 @@ class IncrementalBuilder:
     def _save_cache(self):
         """Save build cache to disk"""
         try:
-            self.cache_file.write_text(json.dumps(self.cache, indent=2))
+            with self._lock:
+                serialized = json.dumps(self.cache, indent=2)
+            self.cache_file.write_text(serialized)
         except IOError as e:
             print(f"⚠️  Failed to save cache: {e}")
     
@@ -245,14 +282,15 @@ class IncrementalBuilder:
         return all_pages
     
     def mark_processed(self, url, content_hash, modified_date):
-        """Mark content as processed"""
+        """Mark content as processed (thread-safe — called from worker threads)"""
         cache_type = self._get_cache_type(url)
-        
-        self.cache[cache_type][url] = {
-            'hash': content_hash,
-            'modified': modified_date,
-            'processed': datetime.now().isoformat()
-        }
+
+        with self._lock:
+            self.cache[cache_type][url] = {
+                'hash': content_hash,
+                'modified': modified_date,
+                'processed': datetime.now().isoformat()
+            }
     
     def should_rebuild_archives(self):
         """Determine if archive pages (categories, tags, home) need rebuild"""
@@ -299,13 +337,14 @@ class IncrementalBuilder:
     def remove_stale_entries(self, current_urls):
         """Remove cache entries for URLs that no longer exist"""
         removed = 0
-        
-        for cache_type in ['posts', 'pages']:
-            cached_urls = list(self.cache[cache_type].keys())
-            for url in cached_urls:
-                if url not in current_urls:
-                    del self.cache[cache_type][url]
-                    removed += 1
+
+        with self._lock:
+            for cache_type in ['posts', 'pages']:
+                cached_urls = list(self.cache[cache_type].keys())
+                for url in cached_urls:
+                    if url not in current_urls:
+                        del self.cache[cache_type][url]
+                        removed += 1
         
         if removed > 0:
             print(f"🧹 Removed {removed} stale cache entries")

--- a/scripts/optimize_images.py
+++ b/scripts/optimize_images.py
@@ -22,6 +22,7 @@ import json
 import time
 import requests
 from pathlib import Path
+import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Dict, List, Tuple, Optional
 import hashlib
@@ -82,6 +83,9 @@ class ImageOptimizer:
         }
         self.optimization_results = []  # For JSON output
         self.optimization_cache = {}
+        # optimize_image() runs in ThreadPoolExecutor workers — guard every
+        # mutation of the shared cache/stats/results structures.
+        self._lock = threading.Lock()
         self.load_optimization_cache()
 
     def load_optimization_cache(self):
@@ -131,7 +135,7 @@ class ImageOptimizer:
             # Populate cache if missing so future runs are fast
             cache_key = str(image_path.relative_to(self.public_dir))
             if cache_key not in self.optimization_cache:
-                self.optimization_cache[cache_key] = {
+                entry = {
                     'hash': self.get_image_hash(image_path),
                     'optimized_at': '',
                     'optimized_size': 0,
@@ -141,6 +145,8 @@ class ImageOptimizer:
                     'webp': str(webp_path.relative_to(self.public_dir)),
                     'avif': str(avif_path.relative_to(self.public_dir))
                 }
+                with self._lock:
+                    self.optimization_cache.setdefault(cache_key, entry)
             return False
 
         # Check cache for unchanged images that need AVIF/WebP created
@@ -200,16 +206,18 @@ class ImageOptimizer:
 
             # Check if should optimize
             if not self.should_optimize_image(image_path):
-                self.stats['skipped'] += 1
                 result['was_cached'] = True
                 result['duration_ms'] = int((time.time() - start_time) * 1000)
-                self.optimization_results.append(result)
+                with self._lock:
+                    self.stats['skipped'] += 1
+                    self.optimization_results.append(result)
                 return result
 
             # Get original size
             original_size = image_path.stat().st_size
             result['original_size'] = original_size
-            self.stats['original_size'] += original_size
+            with self._lock:
+                self.stats['original_size'] += original_size
 
             # Open image
             with Image.open(image_path) as img:
@@ -235,8 +243,9 @@ class ImageOptimizer:
                 result['webp'] = str(webp_path)
                 result['webp_size'] = webp_size
                 result['webp_created'] = True
-                self.stats['webp_generated'] += 1
-                self.stats['optimized_size'] += webp_size
+                with self._lock:
+                    self.stats['webp_generated'] += 1
+                    self.stats['optimized_size'] += webp_size
 
                 # Generate AVIF version (best compression)
                 avif_created = False
@@ -253,8 +262,9 @@ class ImageOptimizer:
                     result['avif_size'] = avif_size
                     result['avif_created'] = True
                     avif_created = True
-                    self.stats['avif_generated'] += 1
-                    self.stats['optimized_size'] += avif_size
+                    with self._lock:
+                        self.stats['avif_generated'] += 1
+                        self.stats['optimized_size'] += avif_size
                 except Exception as e:
                     # AVIF might fail on some systems
                     print(f"⚠️  AVIF generation failed for {image_path.name}: {e}")
@@ -271,7 +281,6 @@ class ImageOptimizer:
                     self._generate_extra_width_variants(image_path, img, quality)
 
                 result['success'] = True
-                self.stats['optimized'] += 1
 
                 # Calculate savings (use smallest modern format vs original)
                 smallest_size = min(webp_size, avif_size if avif_created else webp_size)
@@ -279,16 +288,18 @@ class ImageOptimizer:
 
                 # Update cache with new format tracking
                 cache_key = str(image_path.relative_to(self.public_dir))
-                self.optimization_cache[cache_key] = {
-                    'hash': self.get_image_hash(image_path),
-                    'optimized_at': datetime.now().isoformat(),
-                    'optimized_size': webp_size,
-                    'timestamp': time.time(),
-                    'webp_created': True,
-                    'avif_created': avif_created,
-                    'webp': str(webp_path.relative_to(self.public_dir)),
-                    'avif': str(avif_path.relative_to(self.public_dir)) if avif_created else None
-                }
+                with self._lock:
+                    self.stats['optimized'] += 1
+                    self.optimization_cache[cache_key] = {
+                        'hash': self.get_image_hash(image_path),
+                        'optimized_at': datetime.now().isoformat(),
+                        'optimized_size': webp_size,
+                        'timestamp': time.time(),
+                        'webp_created': True,
+                        'avif_created': avif_created,
+                        'webp': str(webp_path.relative_to(self.public_dir)),
+                        'avif': str(avif_path.relative_to(self.public_dir)) if avif_created else None
+                    }
 
                 # Calculate savings for display
                 savings = original_size - webp_size
@@ -297,11 +308,13 @@ class ImageOptimizer:
 
         except Exception as e:
             result['error'] = str(e)
-            self.stats['errors'] += 1
+            with self._lock:
+                self.stats['errors'] += 1
             print(f"❌ Error optimizing {image_path.name}: {e}")
 
         result['duration_ms'] = int((time.time() - start_time) * 1000)
-        self.optimization_results.append(result)
+        with self._lock:
+            self.optimization_results.append(result)
         return result
 
     def _generate_extra_width_variants(self, original_path: Path, img: 'Image.Image', quality: int):
@@ -348,7 +361,8 @@ class ImageOptimizer:
             try:
                 resized.save(resized_png, 'PNG', optimize=True)
                 resized.save(resized_webp, 'WEBP', quality=quality, method=6)
-                self.stats['webp_generated'] += 1
+                with self._lock:
+                    self.stats['webp_generated'] += 1
             except Exception as e:
                 # Roll back any partial files so the srcset injection in
                 # convert_images_to_picture sees a clean "no variant" state.
@@ -361,7 +375,8 @@ class ImageOptimizer:
 
             try:
                 resized.save(resized_avif, 'AVIF', quality=quality, speed=4)
-                self.stats['avif_generated'] += 1
+                with self._lock:
+                    self.stats['avif_generated'] += 1
             except Exception as e:
                 # AVIF is optional — leave the PNG + WebP in place.
                 print(f"⚠️  AVIF write failed for {resized_avif.name}: {e}")


### PR DESCRIPTION
Fixes findings 3, 4, and 5 from the codebase review (follow-up to #77).

## 3. Non-blocking CI failures are no longer invisible

The 13 `continue-on-error: true` steps in `deploy-static-site.yml` keep their non-blocking semantics (a degraded build still deploys — unchanged by design), but their failures now surface:

- every such step has an `id`, and a new **Report non-blocking step failures** step (`if: always()`) aggregates the outcomes
- failures are written to the job summary as a list
- the Slack success notification flips to **warning** color, retitles to "Build Success (with warnings)", and lists the failed steps in a new field

The job-level `continue-on-error` on the spell-check job is untouched — a failed job is already visible in the Actions UI.

## 4. Thread-safe build caches

`incremental_builder.py` is mutated via `mark_processed()` from the generator's 3-worker thread pool, and `optimize_images.py` mutates `optimization_cache`/`stats`/`optimization_results` from a 4-worker pool — neither had any locking, so concurrent updates could be lost (lost cache entries → unnecessary re-optimisation; corrupted stats). Both now guard all shared-state mutation with a `threading.Lock`, and the incremental builder serialises the cache under the lock before writing.

## 5. Build cache invalidates when the generator or config changes

The incremental cache only hashed *content*, so a change to `config.py` or `wp_to_static_generator.py` left every cached page stale until a manual force-full-deploy. The cache now stores a BLAKE2b fingerprint of those two files; on mismatch (or for legacy caches without the key) it clears itself and logs `♻️ config.py / generator changed — clearing build cache`.

## Verification

- Workflow YAML parses; report-step shell logic tested locally with mixed success/failure/skipped/empty outcomes, including the zero-failure path under `set -e`
- Incremental builder: 8 threads × 500 `mark_processed` calls → 4000/4000 entries retained; cache survives reload with matching fingerprint; clears on fingerprint mismatch and for legacy caches; fresh start clean
- Image optimizer: real threaded run over 40 PNGs (4 workers) → 40/40 cache entries, consistent stats, all 40 skipped via cache on re-run

## Impact on `public/`

Nothing here writes to `public/` directly, but **the first pipeline run after merge will be a full rebuild** — the fingerprint key is new, so the existing `.build-cache.json` is treated as legacy and cleared. The same applies whenever `config.py` or the generator changes from then on. Expect a longer build and a large auto-commit diff on that first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)