### PR TITLE
fix: make Slack notify and secret-scan workflows survive Dependabot PRs

### DIFF
--- a/.github/workflows/issue-to-slack-improved.yml
+++ b/.github/workflows/issue-to-slack-improved.yml
@@ -10,6 +10,10 @@ on:
 
 jobs:
   notify-slack:
+    # Dependabot-triggered runs don't get repository secrets, so the Slack
+    # webhook resolves empty and the action hard-fails. Bot PRs don't need
+    # Slack noise anyway — skip the job entirely.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Determine event details

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -13,6 +13,11 @@ on:
 jobs:
   scan:
     name: Scan for secrets
+    # Dependabot-triggered runs don't get repository secrets: GITLEAKS_LICENSE
+    # resolves empty and gitleaks-action aborts before scanning (org repos
+    # require a license). Dependabot only edits manifests, and the push to
+    # main after merge is scanned anyway, so skipping bot PRs loses nothing.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     
@@ -23,21 +28,26 @@ jobs:
           fetch-depth: 0  # Full history for comprehensive scanning
       
       - name: Run Gitleaks scan
+        id: gitleaks
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}  # Optional: for Gitleaks Pro features
-      
+
+      # Gitleaks writes results.sarif only when it actually ran and found
+      # leaks. Gating on the file (not just step failure) stops infrastructure
+      # errors — missing license, network issues — from uploading an empty
+      # artifact and posting a false "Secrets Detected" alert to Slack.
       - name: Upload scan results
-        if: failure()
+        if: failure() && steps.gitleaks.outcome == 'failure' && hashFiles('results.sarif') != ''
         uses: actions/upload-artifact@v7
         with:
           name: gitleaks-report-${{ github.run_id }}
           path: results.sarif
           retention-days: 7
-      
+
       - name: Notify on secret detection
-        if: failure()
+        if: failure() && steps.gitleaks.outcome == 'failure' && hashFiles('results.sarif') != ''
         uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Fixes the check failures on all 7 open Dependabot PRs (#78–#84). Root cause: Dependabot-triggered workflow runs don't receive repository secrets, so every `${{ secrets.* }}` reference resolves empty.

## Changes

1. **`issue-to-slack-improved.yml`** — skip the `notify-slack` job when the actor is `dependabot[bot]`. The empty `SLACK_WEBHOOK_URL` made the Slack action hard-fail, and bot PRs don't need Slack notifications anyway.

2. **`secret-scan.yml`** — same guard on the scan job. With an empty `GITLEAKS_LICENSE`, gitleaks-action aborts before scanning because org-owned repos require a license. No coverage is lost: Dependabot only edits manifests, and the push to main after merge is scanned.

3. **`secret-scan.yml`** — the `if: failure()` notify step fired on *any* job failure, which would post a false "🚨 Secrets Detected" alert to Slack for infrastructure errors (like the license abort). The artifact upload and Slack alert are now gated on `results.sarif` existing — gitleaks only writes it when it actually ran and found leaks.

## After merge

The open Dependabot PRs need a rebase (`@dependabot rebase` comment on each) so their checks re-run against the fixed workflows.

Nothing in this PR touches `public/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)