### PR TITLE
feat: shared WP session module, exception logging, worker cache fixes, pytest+ruff CI

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -1,0 +1,53 @@
+name: Python Checks
+
+# Lint + unit tests for the build scripts. Separate from quality-checks.yml,
+# which is scoped to public/** (the built site) — this one fires on changes
+# to the Python tooling itself.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/**.py'
+      - 'tests/**'
+      - 'requirements*.txt'
+      - 'ruff.toml'
+      - '.github/workflows/python-checks.yml'
+  pull_request:
+    paths:
+      - 'scripts/**.py'
+      - 'tests/**'
+      - 'requirements*.txt'
+      - 'ruff.toml'
+      - '.github/workflows/python-checks.yml'
+  workflow_dispatch:
+
+jobs:
+  lint-and-test:
+    name: Lint and unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Ruff lint
+        run: |
+          ruff check scripts/ tests/
+
+      - name: Run unit tests
+        run: |
+          pytest tests/ -v

--- a/.github/workflows/wordpress-backup.yml
+++ b/.github/workflows/wordpress-backup.yml
@@ -218,9 +218,17 @@ jobs:
               "${SSH_USER}@${SSH_HOST}" \
               "rm -f ${REMOTE_DUMP}.gz"
 
-          rm -f ~/.ssh/wp_backup_key
           echo "ok=true" >> "$GITHUB_OUTPUT"
           echo "Database dump saved to ${LOCAL_DIR}/database.sql.gz"
+
+      # Remove the key IMMEDIATELY after the SSH step, success or failure —
+      # not only in the end-of-job cleanup. Otherwise the private key sits on
+      # the (shared, self-hosted) runner's disk through the archive/upload
+      # steps, and indefinitely if the job is cancelled before the final
+      # cleanup step runs.
+      - name: Remove SSH key
+        if: always()
+        run: rm -f ~/.ssh/wp_backup_key
 
       # ── Database dump via UpdraftPlus REST endpoint (fallback) ────────────
       # Requires UpdraftPlus Premium with the Remote REST add-on enabled, or

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.pytest_cache/
+.ruff_cache/
 *.so
 .Python
 wordpress_spellcheck_env/

--- a/_worker.template.js
+++ b/_worker.template.js
@@ -385,7 +385,12 @@ async function handleCacheAPI(request, env, ctx, path, hostname = '') {
   }
 
   const cache = caches.default;
-  const cacheKey = new Request(request.url, request);
+  // Key on the path only, mirroring the KV path's pathname-based keys —
+  // otherwise ?utm_source=… style tracking params fragment the cache into
+  // unlimited per-query copies that each go stale on their own clock.
+  const cacheKeyUrl = new URL(request.url);
+  cacheKeyUrl.search = '';
+  const cacheKey = new Request(cacheKeyUrl.toString(), { method: 'GET' });
 
   let response = await cache.match(cacheKey);
 
@@ -474,7 +479,9 @@ function getSecurityHeaders(hostname = '') {
     'X-Content-Type-Options': 'nosniff',
     'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',
     'Referrer-Policy': 'strict-origin-when-cross-origin',
-    'Permissions-Policy': 'geolocation=(), microphone=(), camera=()'
+    // Keep in sync with the Permissions-Policy line in _headers — the worker
+    // emits headers for cache HITs, _headers covers direct ASSETS responses.
+    'Permissions-Policy': 'geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=()'
   };
 
   if (CSP_FROM_HEADERS) {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,7 @@
 
 # Spell checking (CI spell-check workflow only)
 pyspellchecker==0.9.0
+
+# Lint + tests (python-checks workflow; run locally with `ruff check` / `pytest`)
+ruff==0.15.16
+pytest==9.0.3

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,16 @@
+# Lint gate for scripts/ and tests/ (run by .github/workflows/python-checks.yml).
+#
+# Deliberately starts with the "critical" subset only — syntax errors,
+# undefined names, broken f-strings/comparisons — so the existing 40+ scripts
+# pass without a big-bang cleanup. Tighten incrementally (add "E", "W", "I",
+# full "F") as files get touched.
+
+target-version = "py311"
+
+[lint]
+select = [
+    "E9",   # syntax errors / IO errors
+    "F63",  # invalid comparisons (is-literal, etc.)
+    "F7",   # syntax-adjacent logic errors (return outside function, etc.)
+    "F82",  # undefined names
+]

--- a/scripts/apply_alt_patches.py
+++ b/scripts/apply_alt_patches.py
@@ -43,24 +43,18 @@ from pathlib import Path
 
 import requests
 
+from config import Config
+from wp_session import build_session as _build_session
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PATCHES_PATH = REPO_ROOT / 'alt-patches.json'
 
-# Single source of truth (mirrors apply_typo_patches.py + scripts/config.py)
-WP_URL = 'https://wordpress.jameskilby.cloud'
+WP_URL = Config.WP_URL
 
 
 def build_session(auth_token: str, cf_id: str | None, cf_secret: str | None) -> requests.Session:
-    s = requests.Session()
-    s.headers.update({
-        'Authorization': f'Basic {auth_token}',
-        'User-Agent': 'apply-alt-patches/1.0',
-        'Accept': 'application/json',
-    })
-    if cf_id and cf_secret:
-        s.headers['CF-Access-Client-Id'] = cf_id
-        s.headers['CF-Access-Client-Secret'] = cf_secret
-    return s
+    return _build_session(auth_token, cf_id, cf_secret,
+                          user_agent='apply-alt-patches/1.0')
 
 
 def find_media(session: requests.Session, file_pattern: str) -> dict | None:

--- a/scripts/apply_typo_patches.py
+++ b/scripts/apply_typo_patches.py
@@ -35,26 +35,19 @@ from urllib.parse import urlparse
 
 import requests
 
+from config import Config
+from wp_session import build_session as _build_session
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PATCHES_PATH = REPO_ROOT / 'typo-patches.json'
 
-# Single source of truth for these URLs is scripts/config.py — kept inline here
-# for runner-side portability (this script can run standalone).
-WP_URL = 'https://wordpress.jameskilby.cloud'
-TARGET_DOMAIN = 'https://jameskilby.co.uk'
+WP_URL = Config.WP_URL
+TARGET_DOMAIN = Config.TARGET_DOMAIN
 
 
 def build_session(auth_token: str, cf_id: str | None, cf_secret: str | None) -> requests.Session:
-    s = requests.Session()
-    s.headers.update({
-        'Authorization': f'Basic {auth_token}',
-        'User-Agent': 'apply-typo-patches/1.0',
-        'Accept': 'application/json',
-    })
-    if cf_id and cf_secret:
-        s.headers['CF-Access-Client-Id'] = cf_id
-        s.headers['CF-Access-Client-Secret'] = cf_secret
-    return s
+    return _build_session(auth_token, cf_id, cf_secret,
+                          user_agent='apply-typo-patches/1.0')
 
 
 def slug_from_url(url: str) -> str:

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -67,6 +67,15 @@ class Config:
     # person name). Both refer to the same Person.
     PERSON_CANONICAL_NAMES = ('James Kilby', 'James')
 
+    # Canonical social/professional profiles. Single source of truth for the
+    # footer "Connect with me" links (wp_to_static_generator.add_social_links)
+    # AND the JSON-LD sameAs graph below. name/color feed the rendered links.
+    SOCIAL_PROFILES = (
+        {'name': 'GitHub',   'url': 'https://github.com/jameskilbynet',         'color': '#333'},
+        {'name': 'Twitter',  'url': 'https://x.com/jameskilbynet',              'color': '#1da1f2'},
+        {'name': 'LinkedIn', 'url': 'https://www.linkedin.com/in/james-kilby/', 'color': '#0077b5'},
+    )
+
     # sameAs URLs — the canonical professional profile graph for entity linking.
     # Pre-existing JSON-LD links to wordpress.jameskilby.cloud (the private CMS),
     # which is wrong on a public schema; this list replaces that.
@@ -75,11 +84,16 @@ class Config:
     # fix_person_enrichment and fix_organization_sameas respectively) — this
     # is a single-author blog so Person.sameAs and Organization.sameAs should
     # describe the same identity graph.
-    PERSON_SAME_AS = (
-        'https://github.com/jameskilbynet',
-        'https://x.com/jameskilbynet',
-        'https://www.linkedin.com/in/james-kilby/',
-    )
+    PERSON_SAME_AS = tuple(p['url'] for p in SOCIAL_PROFILES)
+
+    # GitHub repo (owner/name) whose issues back Utterances comments. The
+    # Utterances app must stay installed on this exact repo — do not change
+    # this to the code repo without migrating the comment issues.
+    UTTERANCES_REPO = 'jameskilbynet/jkcoukblog'
+
+    # Site logo, used as the default og:image fallback and the Organization
+    # JSON-LD logo. Path is relative to TARGET_DOMAIN.
+    DEFAULT_OG_IMAGE_PATH = '/wp-content/uploads/2025/12/ChatGPT-Image-Dec-17-2025-at-09_03_10-PM.png'
 
     PERSON_JOB_TITLE = 'Cloud / Infrastructure Architect'
 

--- a/scripts/generate_og_images.py
+++ b/scripts/generate_og_images.py
@@ -32,6 +32,13 @@ import tempfile
 from hashlib import blake2b
 from pathlib import Path
 
+from config import Config
+
+# Domain shown on the card and used in the rewritten og:image URL —
+# never hardcode jameskilby.co.uk here, Config is the source of truth.
+TARGET_DOMAIN = Config.TARGET_DOMAIN
+DOMAIN_NAME = TARGET_DOMAIN.replace('https://', '').replace('http://', '')
+
 # Import dependencies with a graceful fallback. The deploy pipeline shouldn't
 # fail just because the runner is missing image tooling — we'd rather skip
 # og:image generation and keep deploying than crash the build.
@@ -262,7 +269,7 @@ class OGImageGenerator:
         bottom_y = CANVAS_HEIGHT - 60
         draw.text((padding_x, bottom_y - 8), "JAMES KILBY", font=brand_font, fill=COLOR_ACCENT)
         # Right-aligned domain
-        domain = "jameskilby.co.uk"
+        domain = DOMAIN_NAME
         domain_w = draw.textlength(domain, font=domain_font)
         draw.text(
             (CANVAS_WIDTH - padding_x - domain_w, bottom_y),
@@ -352,7 +359,7 @@ class OGImageGenerator:
         title_hash = blake2b(title.encode('utf-8'), digest_size=8).hexdigest()
         output_filename = f"{slug}.png"
         output_path = self.output_dir / output_filename
-        new_url = f"https://jameskilby.co.uk/{OG_OUTPUT_REL}/{output_filename}"
+        new_url = f"{TARGET_DOMAIN}/{OG_OUTPUT_REL}/{output_filename}"
 
         prior = self.cache.get(cache_key, {})
         if (prior.get('title_hash') == title_hash

--- a/scripts/markdown_api.py
+++ b/scripts/markdown_api.py
@@ -174,8 +174,12 @@ class MarkdownAPIGenerator:
                                 'posts': []
                             }
                         archives[year_month]['posts'].append(post_data)
-                    except:
-                        pass
+                    except (ValueError, TypeError, KeyError) as e:
+                        # A post with an unparseable date would otherwise
+                        # silently vanish from the archive API.
+                        print(f"   ⚠️  Skipping post in archive (bad date "
+                              f"{post_data.get('date')!r}): "
+                              f"{post_data.get('slug', 'unknown')} — {e}")
         
         # Save each month
         for year_month, data in archives.items():

--- a/scripts/subset_fonts.py
+++ b/scripts/subset_fonts.py
@@ -198,10 +198,12 @@ def _collect_chars(site_dir: Path, spec: FontSpec) -> set:
     inside elements styled with this font."""
     chars = set()
     html_files = list(site_dir.rglob('*.html'))
+    bad_selectors = set()
     for f in html_files:
         try:
             body = f.read_text(encoding='utf-8', errors='ignore')
-        except Exception:
+        except Exception as e:
+            print(f"   ⚠️  Skipping unreadable {f}: {e}")
             continue
         soup = BeautifulSoup(body, 'html.parser')
         for tag in spec.tag_selectors:
@@ -211,8 +213,16 @@ def _collect_chars(site_dir: Path, spec: FontSpec) -> set:
             try:
                 for el in soup.select(sel):
                     chars.update(el.get_text())
-            except Exception:
-                # Bad selector syntax shouldn't kill the whole subset run.
+            except Exception as e:
+                # Bad selector syntax shouldn't kill the whole subset run —
+                # but a silently skipped selector means its characters are
+                # missing from the subset and render as .notdef boxes. Warn
+                # once per selector, not once per file.
+                if sel not in bad_selectors:
+                    bad_selectors.add(sel)
+                    print(f"   ⚠️  Selector {sel!r} failed ({e}) — its glyphs "
+                          f"will be missing from the subset unless covered "
+                          f"by another selector")
                 continue
     return chars
 

--- a/scripts/wp_session.py
+++ b/scripts/wp_session.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+Shared WordPress REST API session factory.
+
+Single source of truth for how scripts talk to the (Cloudflare Access
+protected) WordPress instance: Basic auth header, CF Access service-token
+headers, and retry/backoff on transient failures. Import this instead of
+hand-rolling a requests.Session per script.
+
+Usage:
+    from wp_session import build_session
+
+    session = build_session(auth_token, cf_id, cf_secret)
+    # or pull everything from the environment:
+    session = build_session_from_env()
+"""
+
+import os
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+# Transient statuses worth retrying: rate limit + upstream hiccups. 4xx auth
+# errors are NOT retried — they will not heal and retrying delays the real
+# error message.
+_RETRY_STATUSES = (429, 500, 502, 503, 504)
+
+
+def build_session(auth_token: str | None = None,
+                  cf_id: str | None = None,
+                  cf_secret: str | None = None,
+                  user_agent: str = 'jkcoukblog-scripts/1.0',
+                  retries: int = 3) -> requests.Session:
+    """Build a requests.Session for the WordPress REST API.
+
+    auth_token: base64 of "user:application-password" (Basic auth), or None
+                for unauthenticated reads.
+    cf_id/cf_secret: Cloudflare Access service-token pair — only needed when
+                running off the self-hosted runner.
+    retries: attempts per request on connect errors and _RETRY_STATUSES,
+             with exponential backoff (0.5s, 1s, 2s ...).
+    """
+    s = requests.Session()
+    s.headers.update({
+        'User-Agent': user_agent,
+        'Accept': 'application/json',
+    })
+    if auth_token:
+        s.headers['Authorization'] = f'Basic {auth_token}'
+    if cf_id and cf_secret:
+        s.headers['CF-Access-Client-Id'] = cf_id
+        s.headers['CF-Access-Client-Secret'] = cf_secret
+
+    retry = Retry(
+        total=retries,
+        backoff_factor=0.5,
+        status_forcelist=_RETRY_STATUSES,
+        allowed_methods=None,  # retry POST too — WP REST updates are idempotent per-id
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    s.mount('https://', adapter)
+    s.mount('http://', adapter)
+    return s
+
+
+def build_session_from_env(user_agent: str = 'jkcoukblog-scripts/1.0') -> requests.Session:
+    """build_session() reading WP_AUTH_TOKEN / CF_ACCESS_CLIENT_* from the env."""
+    return build_session(
+        auth_token=os.environ.get('WP_AUTH_TOKEN') or None,
+        cf_id=os.environ.get('CF_ACCESS_CLIENT_ID') or None,
+        cf_secret=os.environ.get('CF_ACCESS_CLIENT_SECRET') or None,
+        user_agent=user_agent,
+    )

--- a/scripts/wp_spell_check_and_fix.py
+++ b/scripts/wp_spell_check_and_fix.py
@@ -611,11 +611,12 @@ def main():
     
     args = parser.parse_args()
     
-    # Configuration
-    OLLAMA_URL = os.getenv('OLLAMA_URL', 'https://ollama.jameskilby.cloud')
-    WP_URL = os.getenv('WP_URL', 'https://wordpress.jameskilby.cloud')
+    # Configuration — env vars override, Config supplies the defaults
+    from config import Config
+    OLLAMA_URL = os.getenv('OLLAMA_URL', Config.OLLAMA_URL)
+    WP_URL = os.getenv('WP_URL', Config.WP_URL)
     AUTH_TOKEN = os.getenv('WP_AUTH_TOKEN')
-    MODEL = os.getenv('OLLAMA_MODEL', 'llama3.1:8b')
+    MODEL = os.getenv('OLLAMA_MODEL', Config.OLLAMA_MODEL)
     OLLAMA_AUTH = os.getenv('OLLAMA_API_CREDENTIALS')
     SINCE_TIMESTAMP = os.getenv('SINCE_TIMESTAMP')
     

--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -127,7 +127,8 @@ class WordPressStaticGenerator:
                             pagination_page += 1
                         else:
                             break
-                    except Exception:
+                    except Exception as e:
+                        print(f"   ⚠️  Pagination discovery stopped at page {pagination_page}: {e}")
                         break
 
             print(f"\n✅ Incremental build: {len(urls)} URLs to process")
@@ -248,7 +249,8 @@ class WordPressStaticGenerator:
                     pagination_page += 1
                 else:
                     break
-            except Exception:
+            except Exception as e:
+                print(f"   ⚠️  Pagination discovery stopped at page {pagination_page}: {e}")
                 break
         if pagination_page > 2:
             print(f"   ✅ Found {pagination_page - 2} homepage pagination pages")
@@ -531,7 +533,8 @@ class WordPressStaticGenerator:
         og_image = soup.find('meta', property='og:image')
         if not og_image and soup.head:
             # Use the site logo as default Open Graph image
-            default_image_url = f"{self.target_domain}/wp-content/uploads/2025/12/ChatGPT-Image-Dec-17-2025-at-09_03_10-PM.png"
+            from config import Config
+            default_image_url = f"{self.target_domain}{Config.DEFAULT_OG_IMAGE_PATH}"
             
             og_image = soup.new_tag('meta')
             og_image['property'] = 'og:image'
@@ -934,6 +937,8 @@ class WordPressStaticGenerator:
         if not soup.head:
             return
 
+        from config import Config as _org_config
+
         org_schema = {
             "@type": "Organization",
             "@id": f"{self.target_domain}/#organization",
@@ -941,12 +946,9 @@ class WordPressStaticGenerator:
             "url": self.target_domain,
             "logo": {
                 "@type": "ImageObject",
-                "url": f"{self.target_domain}/wp-content/uploads/2025/12/ChatGPT-Image-Dec-17-2025-at-09_03_10-PM.png"
+                "url": f"{self.target_domain}{_org_config.DEFAULT_OG_IMAGE_PATH}"
             },
-            "sameAs": [
-                "https://github.com/jameskilbynet",
-                "https://www.linkedin.com/in/james-kilby/"
-            ]
+            "sameAs": list(_org_config.PERSON_SAME_AS)
         }
 
         # Try to enrich existing schema
@@ -1493,9 +1495,11 @@ document.addEventListener('DOMContentLoaded', function() {
             section = soup.new_tag('section')
             section['id'] = 'utterances-comments'
 
+            from config import Config as _utt_config
+
             script = soup.new_tag('script')
             script['src'] = 'https://utteranc.es/client.js'
-            script['data-repo'] = 'jameskilbynet/jkcoukblog'
+            script['data-repo'] = _utt_config.UTTERANCES_REPO
             script['data-issue-term'] = 'pathname'
             script['data-theme'] = 'github-dark'
             script['crossorigin'] = 'anonymous'
@@ -2527,8 +2531,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 payload = json.loads(cache.read_text(encoding='utf-8'))
                 if time.time() - payload.get('computed_at', 0) < 24 * 3600:
                     return payload.get('formatted', '—')
-        except Exception:
-            pass  # fall through to live compute
+        except Exception as e:
+            # Fall through to live compute — but say why the cache was unusable
+            print(f"   ⚠️  words.total cache unreadable ({e}), recomputing")
 
         try:
             total = 0
@@ -2567,8 +2572,8 @@ document.addEventListener('DOMContentLoaded', function() {
                     'total': total,
                     'formatted': formatted,
                 }))
-            except Exception:
-                pass
+            except Exception as e:
+                print(f"   ⚠️  words.total cache write failed ({e}) — next build recomputes")
             return formatted
         except Exception as e:
             print(f"   ⚠️  words.total: {e}")
@@ -3894,24 +3899,10 @@ document.addEventListener('DOMContentLoaded', function() {
         links_container = soup.new_tag('div')
         links_container['style'] = 'display: flex; justify-content: center; gap: 20px; flex-wrap: wrap;'
         
-        # Social media links data
-        social_links = [
-            {
-                'name': 'GitHub',
-                'url': 'https://github.com/jameskilbynet',
-                'color': '#333'
-            },
-            {
-                'name': 'Twitter',
-                'url': 'https://x.com/jameskilbynet',
-                'color': '#1da1f2'
-            },
-            {
-                'name': 'LinkedIn',
-                'url': 'https://linkedin.com/in/jameskilbynet',
-                'color': '#0077b5'
-            }
-        ]
+        # Social media links — Config.SOCIAL_PROFILES is the single source of
+        # truth, shared with the JSON-LD sameAs graph.
+        from config import Config as _social_config
+        social_links = list(_social_config.SOCIAL_PROFILES)
         
         # Create link for each platform
         for platform in social_links:
@@ -4282,7 +4273,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
             return latest_date
 
-        except Exception:
+        except Exception as e:
+            print(f"   ⚠️  Could not determine latest post date: {e}")
             return None
 
     def _get_sitemap_priority(self, url_path):
@@ -4322,7 +4314,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 # Only read the first 4KB — robots meta is always in <head>
                 head_content = f.read(4096)
             return 'noindex' in head_content.lower() and 'name="robots"' in head_content.lower()
-        except Exception:
+        except Exception as e:
+            print(f"   ⚠️  noindex check failed for {html_file}: {e}")
             return False
 
     def _is_meta_refresh_shim(self, html_file):
@@ -4333,7 +4326,8 @@ document.addEventListener('DOMContentLoaded', function() {
             with open(html_file, 'r', encoding='utf-8', errors='ignore') as f:
                 head_content = f.read(2048)
             return 'http-equiv="refresh"' in head_content.lower()
-        except Exception:
+        except Exception as e:
+            print(f"   ⚠️  meta-refresh check failed for {html_file}: {e}")
             return False
 
     def _matches_noindex_pattern(self, url_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Make scripts/ importable from the tests (scripts are standalone modules,
+not a package — each one assumes scripts/ is on sys.path, which is true when
+they run as `python3 scripts/foo.py`)."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'scripts'))

--- a/tests/test_apply_typo_patches.py
+++ b/tests/test_apply_typo_patches.py
@@ -1,0 +1,63 @@
+"""Tests for the typo-patch matching logic — the pure functions that decide
+whether and how a find/replace lands in WP raw content."""
+
+from apply_typo_patches import (
+    apply_patches_to_content,
+    slug_from_url,
+    is_post_url,
+)
+
+
+def test_slug_from_url():
+    assert slug_from_url('https://jameskilby.co.uk/2026/01/my-post/') == 'my-post'
+    assert slug_from_url('https://jameskilby.co.uk/about-me/') == 'about-me'
+    assert slug_from_url('https://jameskilby.co.uk/') == ''
+
+
+def test_is_post_url():
+    assert is_post_url('https://jameskilby.co.uk/2026/01/my-post/') is True
+    assert is_post_url('https://jameskilby.co.uk/about-me/') is False
+
+
+def test_exact_match_applies():
+    raw = 'The quick brwon fox.'
+    new, results = apply_patches_to_content(raw, [{'find': 'brwon', 'replace': 'brown'}])
+    assert new == 'The quick brown fox.'
+    assert results[0]['ok'] is True
+    assert results[0]['matched_via'] == 'exact'
+
+
+def test_missing_find_is_reported_not_silently_skipped():
+    raw = 'Nothing to see here.'
+    new, results = apply_patches_to_content(raw, [{'find': 'absent', 'replace': 'x'}])
+    assert new == raw
+    assert results[0]['ok'] is False
+    assert 'not present' in results[0]['reason']
+
+
+def test_ambiguous_find_refuses_bulk_replace():
+    raw = 'dup text and dup text'
+    new, results = apply_patches_to_content(raw, [{'find': 'dup text', 'replace': 'fixed'}])
+    assert new == raw, 'must not replace when the find string is ambiguous'
+    assert results[0]['ok'] is False
+
+
+def test_smart_quote_normalisation_bridges_rendered_to_raw():
+    # The audit captured rendered curly quotes; WP raw content has straight ones.
+    raw = "It's a teh test."
+    new, results = apply_patches_to_content(
+        raw, [{'find': 'It’s a teh test.', 'replace': 'It’s a the test.'}])
+    assert results[0]['ok'] is True
+    assert results[0]['matched_via'] == 'normalised'
+    # The replacement is re-transformed into the raw style (straight quote).
+    assert new == "It's a the test."
+
+
+def test_patches_apply_sequentially():
+    raw = 'aa bb'
+    new, results = apply_patches_to_content(raw, [
+        {'find': 'aa', 'replace': 'cc'},
+        {'find': 'cc bb', 'replace': 'done'},
+    ])
+    assert new == 'done'
+    assert all(r['ok'] for r in results)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,36 @@
+"""Sanity tests for config.py invariants other scripts rely on."""
+
+import re
+
+from config import Config
+
+
+def test_person_same_as_derives_from_social_profiles():
+    assert Config.PERSON_SAME_AS == tuple(p['url'] for p in Config.SOCIAL_PROFILES)
+
+
+def test_social_profiles_have_required_fields():
+    for profile in Config.SOCIAL_PROFILES:
+        assert profile['name']
+        assert profile['url'].startswith('https://')
+        assert profile['color'].startswith('#')
+
+
+def test_noindex_patterns_compile():
+    for pattern in Config.NOINDEX_PATH_PATTERNS:
+        re.compile(pattern)
+
+
+def test_utterances_repo_is_owner_slash_name():
+    assert re.fullmatch(r'[\w.-]+/[\w.-]+', Config.UTTERANCES_REPO)
+
+
+def test_default_og_image_is_a_root_relative_path():
+    assert Config.DEFAULT_OG_IMAGE_PATH.startswith('/')
+    assert not Config.DEFAULT_OG_IMAGE_PATH.startswith('//')
+
+
+def test_urls_have_no_trailing_slash():
+    # Scripts concatenate paths onto these — a trailing slash would double up.
+    assert not Config.WP_URL.endswith('/')
+    assert not Config.TARGET_DOMAIN.endswith('/')

--- a/tests/test_extract_critical_css.py
+++ b/tests/test_extract_critical_css.py
@@ -1,0 +1,61 @@
+"""Tests for critical-CSS extraction — above all that the size cap can never
+produce unbalanced braces (the pre-2026-06 slice-at-15000-chars bug)."""
+
+from bs4 import BeautifulSoup
+
+from extract_critical_css import CriticalCSSExtractor
+
+
+def _brace_depth_ok(css: str) -> bool:
+    depth = 0
+    for ch in css:
+        if ch == '{':
+            depth += 1
+        elif ch == '}':
+            depth -= 1
+        if depth < 0:
+            return False
+    return depth == 0
+
+
+def _soup(css: str) -> BeautifulSoup:
+    return BeautifulSoup(
+        f'<html><head><style>{css}</style></head>'
+        f'<body><main><h1>t</h1><p>x</p></main></body></html>',
+        'html.parser')
+
+
+def test_small_input_passes_through():
+    ex = CriticalCSSExtractor()
+    out = ex._extract_matching_css_rules(_soup('p{color:red}h1{margin:0}'), {'p', 'h1'})
+    assert 'color:red' in out
+    assert 'margin:0' in out
+    assert ex.css_truncated == 0
+
+
+def test_truncation_keeps_braces_balanced():
+    ex = CriticalCSSExtractor()
+    # Enough rules to blow the cap, with the boundary landing inside @media.
+    rules = ''.join(f'p{{padding:{i}px;color:#0{i % 10}{i % 10}}}' for i in range(300))
+    media = '@media (max-width:600px){' + ''.join(f'h1{{margin:{i}px}}' for i in range(600)) + '}'
+    out = ex._extract_matching_css_rules(_soup(rules + media), {'p', 'h1'}, 'test.html')
+
+    assert 0 < len(out) <= ex.max_critical_css
+    assert _brace_depth_ok(out), 'truncated critical CSS has unbalanced braces'
+    assert ex.css_truncated == 1
+
+
+def test_media_query_rules_are_wrapped():
+    ex = CriticalCSSExtractor()
+    out = ex._extract_matching_css_rules(
+        _soup('@media (max-width:600px){h1{margin:0}}'), {'h1'})
+    assert '@media' in out
+    assert _brace_depth_ok(out)
+
+
+def test_keyframes_are_skipped():
+    ex = CriticalCSSExtractor()
+    out = ex._extract_matching_css_rules(
+        _soup('@keyframes spin{from{opacity:0}to{opacity:1}}p{color:red}'), {'p'})
+    assert '@keyframes' not in out
+    assert 'color:red' in out

--- a/tests/test_incremental_builder.py
+++ b/tests/test_incremental_builder.py
@@ -1,0 +1,97 @@
+"""Tests for the incremental build cache: URL routing, change detection,
+thread-safety, and the config/generator fingerprint invalidation."""
+
+import json
+import threading
+
+import pytest
+
+from incremental_builder import IncrementalBuilder
+
+
+@pytest.fixture
+def builder(tmp_path):
+    return IncrementalBuilder(cache_file=str(tmp_path / 'cache.json'))
+
+
+def test_cache_type_routing(builder):
+    assert builder._get_cache_type('/2026/01/some-post/') == 'posts'
+    assert builder._get_cache_type('/2026/01/some-post') == 'posts'
+    assert builder._get_cache_type('/2026/01/') == 'pages'      # monthly archive
+    assert builder._get_cache_type('/2026/') == 'pages'         # year archive
+    assert builder._get_cache_type('/about-me/') == 'pages'
+    assert builder._get_cache_type('/category/aws/') == 'pages'
+    assert builder._get_cache_type('/tag/vmware/') == 'pages'
+    assert builder._get_cache_type('/') == 'pages'
+
+
+def test_has_changed_lifecycle(builder):
+    url = '/2026/01/post/'
+    assert builder.has_changed(url, 'h1', 'd1') is True          # never seen
+    builder.mark_processed(url, 'h1', 'd1')
+    assert builder.has_changed(url, 'h1', 'd1') is False         # unchanged
+    assert builder.has_changed(url, 'h2', 'd1') is True          # content changed
+    assert builder.has_changed(url, 'h1', 'd2') is True          # date changed
+
+
+def test_mark_processed_is_thread_safe(builder):
+    n_threads, per_thread = 8, 250
+
+    def worker(start):
+        for i in range(start, start + per_thread):
+            builder.mark_processed(f'/2026/01/post-{i}/', f'h{i}', 'd')
+
+    threads = [threading.Thread(target=worker, args=(k * per_thread,))
+               for k in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert len(builder.cache['posts']) == n_threads * per_thread
+
+
+def test_cache_survives_reload_with_same_fingerprint(tmp_path):
+    cache_file = str(tmp_path / 'cache.json')
+    b1 = IncrementalBuilder(cache_file=cache_file)
+    b1.mark_processed('/2026/01/post/', 'h1', 'd1')
+    b1.finalize_build()
+
+    b2 = IncrementalBuilder(cache_file=cache_file)
+    assert '/2026/01/post/' in b2.cache['posts']
+    assert b2.cache.get('environment_fingerprint')
+
+
+def test_fingerprint_mismatch_clears_cache(tmp_path):
+    cache_file = tmp_path / 'cache.json'
+    b1 = IncrementalBuilder(cache_file=str(cache_file))
+    b1.mark_processed('/2026/01/post/', 'h1', 'd1')
+    b1.finalize_build()
+
+    data = json.loads(cache_file.read_text())
+    data['environment_fingerprint'] = 'stale'
+    cache_file.write_text(json.dumps(data))
+
+    b2 = IncrementalBuilder(cache_file=str(cache_file))
+    assert b2.cache['posts'] == {}
+
+
+def test_legacy_cache_without_fingerprint_is_cleared(tmp_path):
+    cache_file = tmp_path / 'cache.json'
+    cache_file.write_text(json.dumps({
+        'posts': {'/2026/01/x/': {'hash': 'h'}},
+        'pages': {}, 'assets': {},
+        'last_build_time': '2026-01-01T00:00:00',
+        'last_full_build': None,
+    }))
+    b = IncrementalBuilder(cache_file=str(cache_file))
+    assert b.cache['posts'] == {}
+    assert b.cache.get('environment_fingerprint')
+
+
+def test_remove_stale_entries(builder):
+    builder.mark_processed('/2026/01/keep/', 'h', 'd')
+    builder.mark_processed('/2026/01/drop/', 'h', 'd')
+    removed = builder.remove_stale_entries({'/2026/01/keep/'})
+    assert removed == 1
+    assert '/2026/01/keep/' in builder.cache['posts']
+    assert '/2026/01/drop/' not in builder.cache['posts']

--- a/tests/test_wp_session.py
+++ b/tests/test_wp_session.py
@@ -1,0 +1,37 @@
+"""Tests for the shared WordPress session factory."""
+
+from requests.adapters import HTTPAdapter
+
+from wp_session import build_session
+
+
+def test_auth_and_cf_headers_set():
+    s = build_session('dG9rZW4=', 'cf-id', 'cf-secret')
+    assert s.headers['Authorization'] == 'Basic dG9rZW4='
+    assert s.headers['CF-Access-Client-Id'] == 'cf-id'
+    assert s.headers['CF-Access-Client-Secret'] == 'cf-secret'
+    assert s.headers['Accept'] == 'application/json'
+
+
+def test_unauthenticated_session_has_no_auth_header():
+    s = build_session()
+    assert 'Authorization' not in s.headers
+    assert 'CF-Access-Client-Id' not in s.headers
+
+
+def test_cf_headers_require_both_halves():
+    s = build_session('t', 'cf-id', None)
+    assert 'CF-Access-Client-Id' not in s.headers
+
+
+def test_retry_adapter_mounted():
+    s = build_session(retries=5)
+    adapter = s.get_adapter('https://wordpress.jameskilby.cloud/wp-json/')
+    assert isinstance(adapter, HTTPAdapter)
+    assert adapter.max_retries.total == 5
+    assert 503 in adapter.max_retries.status_forcelist
+
+
+def test_custom_user_agent():
+    s = build_session(user_agent='apply-typo-patches/1.0')
+    assert s.headers['User-Agent'] == 'apply-typo-patches/1.0'


### PR DESCRIPTION
Closes out the last four findings from the codebase review (7, 8, 9, 10) plus the SSH-key cleanup. Follow-up to #77 / #85 / #86.

## 7 — Shared session module + config enforcement

- New `scripts/wp_session.py`: one session factory with Basic auth, Cloudflare Access headers, and retry/backoff (3 attempts, exponential, on 429/5xx). `apply_typo_patches.py` and `apply_alt_patches.py` use it instead of their copy-pasted builders — and gain retries they never had.
- `config.py` gains `SOCIAL_PROFILES` (single source for the footer links **and** the JSON-LD `sameAs` graph), `UTTERANCES_REPO`, and `DEFAULT_OG_IMAGE_PATH`. `PERSON_SAME_AS` is now derived from `SOCIAL_PROFILES`.
- The generator, `generate_og_images.py`, `wp_spell_check_and_fix.py`, and both apply scripts read these from Config instead of hardcoding.

⚠️ **Visible content change**: the footer LinkedIn link was `linkedin.com/in/jameskilbynet` but the canonical profile in config (used in JSON-LD) is `linkedin.com/in/james-kilby/`. They now agree on the canonical one. If `/in/jameskilbynet` was actually the right URL, fix it in `Config.SOCIAL_PROFILES` — one place now.

## 8 — Exception swallowing

Pagination discovery, the words-total cache, sitemap helpers (`_get_latest_post_date`, noindex/meta-refresh checks), archive generation in `markdown_api.py` (posts with bad dates used to silently vanish), and font subsetting (failed selectors = missing glyphs) all log what failed and keep going, instead of `except: pass`.

## 9 — Worker fixes

- The Cache-API fallback path now keys on path only (query string stripped), matching the KV path — `?utm_source=…` can no longer fragment the cache into per-query stale copies.
- Worker `Permissions-Policy` now matches `_headers` (adds `payment`, `usb`, `magnetometer`, `gyroscope`), so cache HITs and direct ASSETS responses carry the same policy.

## 10 — Test + lint layer

- `tests/` with **29 pytest tests**: incremental-cache routing/invalidation/thread-safety, critical-CSS truncation brace-balance, typo-patch matching (exact/normalised/ambiguous/missing), session factory, config invariants.
- `ruff.toml` with the critical rule subset (E9, F63, F7, F82) — passes on the whole codebase today, tighten incrementally.
- New `python-checks.yml` workflow runs ruff + pytest on changes to `scripts/`, `tests/`, requirements, or the config — separate from `quality-checks.yml`, which is scoped to `public/`.

## SSH key cleanup

`wordpress-backup.yml` now deletes the SSH key in a dedicated `if: always()` step immediately after the dump step. The end-of-job cleanup already existed, but the key previously sat on the shared self-hosted runner's disk through the archive/upload steps (and indefinitely on cancellation).

## Verification

ruff clean, 29/29 tests pass, `py_compile` on all touched scripts, `node --check` on the worker template, YAML validated, `test_csp.py` passes, and import smoke-tests confirm the config wiring.

## Impact on `public/`

Generator and config changed → the cache fingerprint from #85 will trigger a **full rebuild** on the next pipeline run (by design). Output diffs to expect: footer LinkedIn URL, Organization JSON-LD `sameAs` now includes X/Twitter, and worker-served responses get the longer Permissions-Policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)