### PR TITLE
fix(seo): noindex markdown/JSON mirrors to stop crawl-budget waste

### DIFF
--- a/_headers
+++ b/_headers
@@ -102,10 +102,19 @@
   ! X-Frame-Options
   ! Permissions-Policy
 
-# Markdown files - allow CORS for API access
+# Markdown files - allow CORS for API access.
+# X-Robots-Tag: noindex keeps this AI-ingestion mirror out of Google's
+# index — the .md files duplicate the HTML posts, and Googlebot was
+# following the in-page "Markdown" links, crawling all ~80 mirrors and
+# parking them under "Crawled - currently not indexed" (wasted crawl
+# budget). noindex only governs SEARCH indexing, not fetching, so AI
+# crawlers (GPTBot/ClaudeBot/etc., deliberately allowed in robots.txt)
+# can still ingest the corpus. Pairs with rel="nofollow" on the footer
+# links emitted by wp_to_static_generator.py.
 /markdown/*
   Content-Type: text/markdown; charset=utf-8
   Cache-Control: public, max-age=3600
+  X-Robots-Tag: noindex
   Access-Control-Allow-Origin: *
   Access-Control-Allow-Methods: GET, HEAD, OPTIONS
   ! Content-Security-Policy
@@ -138,10 +147,15 @@
   ! X-Frame-Options
   ! Permissions-Policy
 
-# API endpoints - JSON with CORS
+# API endpoints - JSON with CORS.
+# X-Robots-Tag: noindex for the same reason as /markdown/* — these JSON
+# mirrors duplicate post content and must never appear in search. robots.txt
+# already Disallows /api/, so this is belt-and-braces for any URL Google
+# learned before that rule (or via the footer "JSON API" link).
 /api/*
   Content-Type: application/json; charset=utf-8
   Cache-Control: public, max-age=600
+  X-Robots-Tag: noindex
   Access-Control-Allow-Origin: *
   Access-Control-Allow-Methods: GET, HEAD, OPTIONS
   Access-Control-Allow-Headers: Content-Type

--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -3034,13 +3034,17 @@ document.addEventListener('DOMContentLoaded', function() {
         p = soup.new_tag('p')
         p.string = 'Content also available in: '
 
-        md_link = soup.new_tag('a', href=md_href)
+        # rel="nofollow": these mirrors are noindex'd via X-Robots-Tag (see
+        # _headers) and exist for AI ingestion, not search. nofollow stops
+        # Googlebot following the link and wasting crawl budget re-fetching
+        # the ~80 .md / JSON duplicates of the HTML posts.
+        md_link = soup.new_tag('a', href=md_href, rel='nofollow')
         md_link.string = 'Markdown'
         p.append(md_link)
 
         p.append(' | ')
 
-        api_link = soup.new_tag('a', href=api_href)
+        api_link = soup.new_tag('a', href=api_href, rel='nofollow')
         api_link.string = 'JSON API'
         p.append(api_link)
 


### PR DESCRIPTION
## Problem

Google Search Console flags ~80 `/markdown/…/index.md` mirror files (and the `/api/` JSON mirrors) under **"Crawled – currently not indexed."** Each post footer emits a followable `Content also available in: Markdown | JSON API` link, so Googlebot crawls every mirror, finds it duplicates the HTML post, and declines to index it — pure crawl-budget waste, with the count climbing over time.

These mirrors exist **for AI-ingestion crawlers** (GPTBot/ClaudeBot/etc., deliberately allowed in `robots.txt`), not for search. They were served `200` with no robots directive.

## Fix

- **`_headers`** — add `X-Robots-Tag: noindex` to the `/markdown/*` and `/api/*` blocks. `noindex` governs *search indexing only, not fetching*, so AI crawlers can still ingest the corpus; Google just stops indexing the duplicates.
- **`scripts/wp_to_static_generator.py`** — add `rel="nofollow"` to the footer "Markdown"/"JSON API" links so Googlebot stops following them into the mirrors in the first place.

## Affects `public/`

⚠️ Yes — `_headers` is copied to `public/_headers`, and the generator change alters generated post HTML (footer links). Both land in `public/` on the next pipeline run.

## Verification

- ✅ `python3 scripts/test_csp.py` passes (build-gating CSP check parses `_headers`)
- ✅ BeautifulSoup renders `<a href="…" rel="nofollow">` correctly
- ✅ gitleaks clean

## Expected effect

The `.md`/`/api/` URLs move out of "Crawled – currently not indexed"; some re-bucket as "Excluded by 'noindex' tag" (the correct, intentional bucket). Crawl budget is reclaimed for real posts. Google re-crawls on its own schedule (days–weeks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)