### PR TITLE
feat(seo): auto-inject FAQPage JSON-LD for posts with FAQ sections

### DIFF
--- a/docs/SEO.md
+++ b/docs/SEO.md
@@ -287,7 +287,7 @@ https://securityheaders.com/?q=jameskilby.co.uk
 ### Remaining Tasks
 
 #### Content
-- [ ] Add FAQ schema markup
+- [x] Add FAQ schema markup (auto-injected `FAQPage` JSON-LD when a post has a FAQ section — see `add_faq_schema` in `scripts/wp_to_static_generator.py`)
 - [ ] Implement article series/collection pages
 - [ ] Create cornerstone content
 

--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -454,6 +454,9 @@ class WordPressStaticGenerator:
         # Add BlogPosting JSON-LD schema to article pages
         self.add_blogposting_schema(soup, current_url)
 
+        # Add FAQPage JSON-LD when the article contains an FAQ section
+        self.add_faq_schema(soup)
+
         # Add site-level WebSite + Organization schema (all pages)
         self.add_site_schema(soup)
 
@@ -925,6 +928,139 @@ class WordPressStaticGenerator:
             script_tag.string = json.dumps(schema, ensure_ascii=False, separators=(',', ':'))
             soup.head.append(script_tag)
             print(f"   📋 Added BlogPosting schema: {title[:60]}")
+
+    @staticmethod
+    def _extract_faq_pairs(soup):
+        """Find an FAQ section in the article and return an ordered list of
+        ``{'question': str, 'answer': str}`` dicts.
+
+        Conservative by design — it only fires when a heading explicitly marks
+        a "FAQ" / "Frequently Asked Questions" section, so we never invent
+        FAQ structured data for content that isn't actually a FAQ (which would
+        violate Google's structured-data guidelines). Returns ``[]`` when no
+        FAQ section is found.
+
+        Two question/answer shapes are recognised inside that section:
+          * a definition list — ``<dt>`` question, ``<dd>`` answer; and
+          * sub-headings deeper than the section heading whose text ends with
+            "?", followed by their answer paragraphs/lists.
+        """
+        def _level(tag):
+            name = getattr(tag, 'name', '') or ''
+            if len(name) == 2 and name[0] == 'h' and name[1].isdigit():
+                return int(name[1])
+            return None
+
+        # Locate the FAQ section heading.
+        faq_heading = None
+        for h in soup.find_all(['h2', 'h3', 'h4']):
+            text = h.get_text(strip=True).lower()
+            if 'frequently asked question' in text or re.search(r'\bfaqs?\b', text):
+                faq_heading = h
+                break
+        if not faq_heading:
+            return []
+
+        section_level = _level(faq_heading)
+        pairs = []
+        current_q = None
+        current_answer_parts = []
+
+        def _flush():
+            if current_q:
+                answer = ' '.join(p for p in current_answer_parts if p).strip()
+                if answer:
+                    pairs.append({'question': current_q, 'answer': answer})
+
+        for el in faq_heading.find_all_next(
+            ['h2', 'h3', 'h4', 'h5', 'h6', 'p', 'ul', 'ol', 'dl']
+        ):
+            lvl = _level(el)
+            # A heading at or above the section level ends the FAQ section.
+            if lvl is not None and lvl <= section_level:
+                break
+            if el.name == 'dl':
+                for dt in el.find_all('dt'):
+                    q = dt.get_text(strip=True)
+                    dd = dt.find_next_sibling('dd')
+                    a = dd.get_text(' ', strip=True) if dd else ''
+                    if q and a:
+                        pairs.append({'question': q, 'answer': a})
+                continue
+            if lvl is not None:
+                # A deeper heading starts a new question.
+                _flush()
+                current_answer_parts = []
+                q_text = el.get_text(strip=True)
+                current_q = q_text if q_text.endswith('?') else None
+            elif current_q:
+                current_answer_parts.append(el.get_text(' ', strip=True))
+        _flush()
+
+        # Deduplicate by question text, preserving order.
+        seen = set()
+        unique = []
+        for pair in pairs:
+            key = pair['question'].lower()
+            if key not in seen:
+                seen.add(key)
+                unique.append(pair)
+        return unique
+
+    def add_faq_schema(self, soup):
+        """Inject FAQPage JSON-LD when an article contains a FAQ section.
+
+        Purely additive: a no-op when no FAQ is detected, when a FAQPage
+        schema is already present, or when fewer than two Q&A pairs are found
+        (a single question is too thin for FAQ rich results and risks a
+        structured-data / visible-content mismatch).
+        """
+        body = soup.find('body')
+        if not body:
+            return
+        body_class_str = ' '.join(body.get('class', [])).lower()
+        if 'single-post' not in body_class_str and 'page' not in body_class_str:
+            return
+
+        # Skip if a FAQPage schema already exists (e.g. supplied by Rank Math).
+        for script in soup.find_all('script', type='application/ld+json'):
+            try:
+                data = json.loads(script.string or '')
+                items = data.get('@graph', [data]) if isinstance(data, dict) else data
+                if any(
+                    isinstance(i, dict) and i.get('@type') == 'FAQPage'
+                    for i in items
+                ):
+                    return  # Already present – nothing to do
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        pairs = self._extract_faq_pairs(soup)
+        if len(pairs) < 2:
+            return
+
+        schema = {
+            "@context": "https://schema.org",
+            "@type": "FAQPage",
+            "mainEntity": [
+                {
+                    "@type": "Question",
+                    "name": pair['question'],
+                    "acceptedAnswer": {
+                        "@type": "Answer",
+                        "text": pair['answer'],
+                    },
+                }
+                for pair in pairs
+            ],
+        }
+
+        if soup.head:
+            script_tag = soup.new_tag('script')
+            script_tag['type'] = 'application/ld+json'
+            script_tag.string = json.dumps(schema, ensure_ascii=False, separators=(',', ':'))
+            soup.head.append(script_tag)
+            print(f"   ❓ Added FAQPage schema: {len(pairs)} Q&A pairs")
 
     def add_site_schema(self, soup):
         """Enrich or inject WebSite and Organization JSON-LD schema.

--- a/tests/test_wp_faq_schema.py
+++ b/tests/test_wp_faq_schema.py
@@ -1,0 +1,165 @@
+"""Tests for FAQPage JSON-LD generation in wp_to_static_generator.
+
+Covers the pure extraction helper (_extract_faq_pairs) and the injection
+method (add_faq_schema), both of which must be conservative: they only emit
+FAQ structured data for content that genuinely has a FAQ section.
+"""
+
+import json
+
+from bs4 import BeautifulSoup
+
+from wp_to_static_generator import WordPressStaticGenerator
+
+
+def _gen():
+    # Network is never touched by the schema helpers; build a generator with
+    # incremental mode off so no cache/state is initialised.
+    return WordPressStaticGenerator(
+        wp_url='https://wp.example',
+        auth_token='x',
+        output_dir='/tmp/faq-test-out',
+        target_domain='https://example.com',
+        use_incremental=False,
+    )
+
+
+def _soup(article_html, body_class='single-post'):
+    return BeautifulSoup(
+        f'<html><head><title>t</title></head>'
+        f'<body class="{body_class}"><article>{article_html}</article></body></html>',
+        'html.parser',
+    )
+
+
+# ── _extract_faq_pairs ────────────────────────────────────────────────────
+
+def test_heading_based_faq_pairs_extracted():
+    soup = _soup(
+        '<h2>FAQ</h2>'
+        '<h3>What is it?</h3><p>It is a thing.</p>'
+        '<h3>How much?</h3><p>It is free.</p>'
+    )
+    pairs = WordPressStaticGenerator._extract_faq_pairs(soup)
+    assert pairs == [
+        {'question': 'What is it?', 'answer': 'It is a thing.'},
+        {'question': 'How much?', 'answer': 'It is free.'},
+    ]
+
+
+def test_frequently_asked_questions_heading_is_recognised():
+    soup = _soup(
+        '<h2>Frequently Asked Questions</h2>'
+        '<h3>Q one?</h3><p>A one.</p>'
+        '<h3>Q two?</h3><p>A two.</p>'
+    )
+    pairs = WordPressStaticGenerator._extract_faq_pairs(soup)
+    assert len(pairs) == 2
+
+
+def test_definition_list_faq_extracted():
+    soup = _soup(
+        '<h2>FAQ</h2>'
+        '<dl>'
+        '<dt>First question</dt><dd>First answer.</dd>'
+        '<dt>Second question</dt><dd>Second answer.</dd>'
+        '</dl>'
+    )
+    pairs = WordPressStaticGenerator._extract_faq_pairs(soup)
+    assert pairs == [
+        {'question': 'First question', 'answer': 'First answer.'},
+        {'question': 'Second question', 'answer': 'Second answer.'},
+    ]
+
+
+def test_section_ends_at_next_same_level_heading():
+    soup = _soup(
+        '<h2>FAQ</h2>'
+        '<h3>In scope?</h3><p>Yes.</p>'
+        '<h2>Related Posts</h2>'
+        '<h3>Not a question?</h3><p>Should be ignored.</p>'
+    )
+    pairs = WordPressStaticGenerator._extract_faq_pairs(soup)
+    assert pairs == [{'question': 'In scope?', 'answer': 'Yes.'}]
+
+
+def test_subheading_without_question_mark_is_skipped():
+    soup = _soup(
+        '<h2>FAQ</h2>'
+        '<h3>Just a note</h3><p>Not a question.</p>'
+        '<h3>Real question?</h3><p>Real answer.</p>'
+    )
+    pairs = WordPressStaticGenerator._extract_faq_pairs(soup)
+    assert pairs == [{'question': 'Real question?', 'answer': 'Real answer.'}]
+
+
+def test_no_faq_section_returns_empty():
+    soup = _soup('<h2>Introduction</h2><p>Hello.</p>')
+    assert WordPressStaticGenerator._extract_faq_pairs(soup) == []
+
+
+def test_faq_in_word_boundary_only():
+    # "FAQS" appearing inside another word must not trip detection.
+    soup = _soup('<h2>Effaqsomething overview</h2><p>x</p>')
+    assert WordPressStaticGenerator._extract_faq_pairs(soup) == []
+
+
+# ── add_faq_schema ────────────────────────────────────────────────────────
+
+def _faq_schemas(soup):
+    out = []
+    for s in soup.find_all('script', type='application/ld+json'):
+        data = json.loads(s.string)
+        if data.get('@type') == 'FAQPage':
+            out.append(data)
+    return out
+
+
+def test_add_faq_schema_injects_for_valid_faq():
+    soup = _soup(
+        '<h2>FAQ</h2>'
+        '<h3>What is it?</h3><p>A thing.</p>'
+        '<h3>Why?</h3><p>Because.</p>'
+    )
+    _gen().add_faq_schema(soup)
+    schemas = _faq_schemas(soup)
+    assert len(schemas) == 1
+    entities = schemas[0]['mainEntity']
+    assert entities[0]['@type'] == 'Question'
+    assert entities[0]['name'] == 'What is it?'
+    assert entities[0]['acceptedAnswer']['text'] == 'A thing.'
+    assert len(entities) == 2
+
+
+def test_single_question_is_not_emitted():
+    soup = _soup('<h2>FAQ</h2><h3>Only one?</h3><p>Yes.</p>')
+    _gen().add_faq_schema(soup)
+    assert _faq_schemas(soup) == []
+
+
+def test_no_faq_no_schema():
+    soup = _soup('<h2>Body</h2><p>No questions here.</p>')
+    _gen().add_faq_schema(soup)
+    assert _faq_schemas(soup) == []
+
+
+def test_not_injected_on_non_article_pages():
+    soup = _soup(
+        '<h2>FAQ</h2><h3>A?</h3><p>1.</p><h3>B?</h3><p>2.</p>',
+        body_class='archive',
+    )
+    _gen().add_faq_schema(soup)
+    assert _faq_schemas(soup) == []
+
+
+def test_existing_faqpage_schema_not_duplicated():
+    soup = _soup(
+        '<h2>FAQ</h2><h3>A?</h3><p>1.</p><h3>B?</h3><p>2.</p>'
+    )
+    existing = soup.new_tag('script', type='application/ld+json')
+    existing.string = json.dumps({'@context': 'https://schema.org',
+                                  '@type': 'FAQPage', 'mainEntity': []})
+    soup.head.append(existing)
+    _gen().add_faq_schema(soup)
+    # Still only the one we pre-seeded — no second FAQPage added.
+    assert len(_faq_schemas(soup)) == 1


### PR DESCRIPTION
Implements the **"Add FAQ schema markup"** item from the SEO checklist (`docs/SEO.md`). Cherry-picked from the abandoned `claude/todo-implementation-hhiidq` branch (orig commit `8d914a82`) onto current `main`.

## What it does
`add_faq_schema()` runs in the article transform pass (right after `add_blogposting_schema`) and emits `FAQPage` structured data when a post contains a clearly-marked FAQ section, so the Q&As become eligible for Google FAQ rich results.

Detection is deliberately conservative to avoid structured-data / visible-content mismatches (which violate Google's guidelines):
- only fires when a heading explicitly marks an **"FAQ" / "Frequently Asked Questions"** section (word-boundary match)
- recognises both definition-list (`<dt>`/`<dd>`) and sub-heading Q&A shapes; sub-heading questions must end with `?`
- bounds the section at the next same-or-higher-level heading
- requires **≥ 2** Q&A pairs
- no-op when a `FAQPage` schema already exists (e.g. from Rank Math) or on non-article pages

## Tests
Adds `tests/test_wp_faq_schema.py` (12 tests) covering extraction and injection paths. Verified locally: **12 passed**, `ruff` clean.

## ⚠️ Pipeline-output impact
This changes generated HTML that lands in `public/` — the next `🚀 Auto-update static site` commit will include new `<script type="application/ld+json">` FAQPage blocks on posts that have FAQ sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)