### PR TITLE
fix(ci): correct compression ordering, drop dead Google ping, prune redundant cache

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -132,7 +132,11 @@ jobs:
 
   build-and-deploy:
     runs-on: self-hosted  # Changed to self-hosted for Cloudflare Access
-    timeout-minutes: 60  # Prevent workflow from running indefinitely
+    # 90, not 60: a full cache-miss rebuild runs generate (≤30m) + image
+    # optimization (≤40m) back to back, which alone can exceed a 60m job
+    # budget and get killed mid-image-pass. Incremental builds finish in a
+    # fraction of this; the ceiling only bites on a cold first run.
+    timeout-minutes: 90  # Prevent workflow from running indefinitely
     
     steps:
     - name: Validate required environment variables
@@ -184,16 +188,12 @@ jobs:
       with:
         fetch-depth: 0  # Fetch full history for accurate git stats in changelog
       
-    - name: Restore build cache
-      id: cache-restore
-      uses: actions/cache@v5
-      with:
-        path: |
-          .image_optimization_cache
-          .last_spell_check_timestamp
-        key: build-cache-avif-v3-${{ hashFiles('.image_optimization_cache/**') }}
-        restore-keys: |
-          build-cache-avif-v3-
+    # No Actions cache for .image_optimization_cache / .last_spell_check_timestamp:
+    # both are git-tracked (committed by the "Commit and push" step every run and
+    # restored on checkout), so an actions/cache layer on top was pure redundancy —
+    # and its hashFiles() key lagged a build behind, masking that fact. The
+    # incremental build cache below is different: .build-cache.json is gitignored,
+    # so the Actions cache is the only thing that persists it between runs.
 
     - name: Restore incremental build cache
       id: incremental-cache-restore
@@ -211,8 +211,7 @@ jobs:
     - name: Check cache status
       run: |
         echo "🔍 Checking cache restoration status..."
-        echo "Image cache hit: ${{ steps.cache-restore.outputs.cache-hit }}"
-        echo "Image cache matched key: ${{ steps.cache-restore.outputs.cache-matched-key }}"
+        echo "Image cache source: git-tracked .image_optimization_cache (restored on checkout)"
 
         if [ -f ".image_optimization_cache/optimization_cache.json" ]; then
           ENTRIES=$(python3 -c "import json; print(len(json.load(open('.image_optimization_cache/optimization_cache.json'))))" 2>/dev/null || echo "0")
@@ -949,7 +948,11 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
 
-        # Preserve the populated cache before reset
+        # Preserve the populated cache before reset. .image_optimization_cache
+        # is git-tracked, so the `git reset --hard origin/main` below would
+        # otherwise clobber this build's freshly-optimized entries with the
+        # older committed copy. Back it up, then restore after the reset so the
+        # "Commit and push" step commits the up-to-date cache.
         echo "💾 Preserving optimization cache before reset..."
         if [ -f ".image_optimization_cache/optimization_cache.json" ]; then
           CACHE_ENTRIES=$(python3 -c "import json; print(len(json.load(open('.image_optimization_cache/optimization_cache.json'))))" 2>/dev/null || echo "0")
@@ -1012,11 +1015,19 @@ jobs:
         echo "📊 Generating stats page..."
         PLAUSIBLE_SHARE_LINK="${{ secrets.PLAUSIBLE_SHARE_LINK }}" python3 scripts/generate_stats_page.py || echo "⚠️  Stats page generation failed (non-blocking)"
 
-        # Recompress files created after the main Brotli pass
-        echo "🗜️  Recompressing post-deploy generated files..."
-        for dir in public/changelog public/stats; do
-          [ -d "$dir" ] && python3 scripts/brotli_compress.py "$dir" 2>/dev/null || true
-        done
+        # Recompress the WHOLE tree, not just changelog/stats. The main Brotli
+        # pass ran on static-output BEFORE the "Prepare output for deployment"
+        # step rewrote HTML/CSS in place — convert_to_staging.py converts
+        # absolute → relative URLs and only writes files it actually changes.
+        # Every rewritten file's .br/.gz sidecar is now stale (it still encodes
+        # the absolute-URL bytes the validators checked). A full-tree pass
+        # regenerates exactly those changed sidecars — brotli_compress.py skips
+        # any file whose .br is already newer than its source (mtime check) — and
+        # also covers the just-generated changelog/stats pages and security.txt.
+        # Without this, Cloudflare would serve precompressed HTML that no longer
+        # matches the deployed source.
+        echo "🗜️  Recompressing files changed after the main Brotli pass (URL rewrite, changelog, stats)..."
+        python3 scripts/brotli_compress.py public/ || echo "⚠️  Recompression failed (non-blocking)"
       continue-on-error: true
 
     - name: Commit and push static site
@@ -1339,44 +1350,11 @@ jobs:
         python3 scripts/submit_indexnow.py ./public || echo "⚠️  IndexNow submission failed (non-blocking)"
       continue-on-error: true
 
-    - name: Ping Google sitemap on new post
-      id: google_ping
-      if: success()
-      run: |
-        # Only ping Google when a genuinely new post page was added this build.
-        # New posts appear as added files matching public/YYYY/MM/<slug>/index.html.
-        # Updates to existing posts, CSS, images etc. don't warrant a sitemap ping.
-        NEW_POSTS=$(git diff --name-only HEAD~1 HEAD 2>/dev/null \
-          | grep -E '^public/[0-9]{4}/[0-9]{2}/.+/index\.html$' || true)
-
-        if [ -z "$NEW_POSTS" ]; then
-          echo "ℹ️  No new posts in this build — skipping Google sitemap ping"
-          exit 0
-        fi
-
-        echo "🆕 New post(s) detected:"
-        echo "$NEW_POSTS" | sed 's|public/||;s|/index\.html||' | while read -r slug; do
-          echo "   • /$slug/"
-        done
-
-        SITEMAP_URL="https://jameskilby.co.uk/sitemap.xml"
-        echo "📡 Pinging Google sitemap: $SITEMAP_URL"
-        HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-          --max-time 15 \
-          "https://www.google.com/ping?sitemap=${SITEMAP_URL}" 2>/dev/null || echo "000")
-
-        if [ "$HTTP_CODE" = "200" ]; then
-          echo "✅ Google sitemap ping accepted (HTTP 200)"
-        else
-          echo "⚠️  Google sitemap ping returned HTTP $HTTP_CODE (non-blocking)"
-        fi
-
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "## 📡 Google Sitemap Ping" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "- **Status:** HTTP $HTTP_CODE" >> $GITHUB_STEP_SUMMARY
-        echo "- **Triggered by:** $(echo "$NEW_POSTS" | wc -l | tr -d ' ') new post(s)" >> $GITHUB_STEP_SUMMARY
-      continue-on-error: true
+    # The "Ping Google sitemap on new post" step was removed: Google shut down
+    # the sitemap ping endpoint (https://www.google.com/ping?sitemap=) in
+    # January 2024 — it now returns HTTP 404 and does nothing. Google discovers
+    # the sitemap via robots.txt + Search Console instead. IndexNow (above)
+    # already covers fast push-notification of new URLs to Bing/Yandex.
 
     - name: Report non-blocking step failures
       id: nonblocking_report
@@ -1401,7 +1379,6 @@ jobs:
         check "KV HTML cache purge"         "${{ steps.kv_purge.outcome }}"
         check "Static asset cache purge"    "${{ steps.static_purge.outcome }}"
         check "IndexNow submission"         "${{ steps.indexnow.outcome }}"
-        check "Google sitemap ping"         "${{ steps.google_ping.outcome }}"
 
         COUNT=${#FAILED[@]}
         echo "failed_count=$COUNT" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Four fixes to the **WordPress → Static Site Deploy** workflow (`.github/workflows/deploy-static-site.yml`). Reviewed for both **task ordering** and **cache correctness**.

> **Touches CI only** — no files under `public/` change in this PR, so the next pipeline auto-commit diff is unaffected.

## 1. Stale `.br`/`.gz` sidecars after the URL rewrite (correctness)
The main Brotli pass runs on `static-output` **before** `Prepare output for deployment` rewrites HTML/CSS in place (`convert_to_staging.py`, absolute → relative URLs). Every rewritten file's precompressed sidecar was left encoding the *old* bytes, while only `changelog/` + `stats/` got recompressed. Result: Cloudflare could serve precompressed HTML that no longer matches the deployed source.

**Fix:** replace the changelog/stats-only recompress with a full-tree `brotli_compress.py public/` after `convert_to_staging`. `brotli_compress.py` skips any file whose `.br` is already newer than its source (mtime check), and `convert_to_staging` only writes files it actually changes — so this regenerates *exactly* the stale sidecars and nothing else.

Note: this is "compress **correctly**", not "compress **once**". `validate_deployment.py` requires `.br` to exist and byte-match at validation time, and validation deliberately runs on absolute-URL HTML — so the pre-validation pass must stay and the post-rewrite pass fixes the staleness.

## 2. Remove the dead Google sitemap ping
Google retired the `google.com/ping?sitemap=` endpoint in early 2024 (now returns 404). The step did nothing. IndexNow already covers push-notification of new URLs. Removed the step and its non-blocking-report entry.

## 3. Bump job timeout 60 → 90 min
A cold cache-miss rebuild runs generate (≤30m) + image optimization (≤40m) back to back, which can exceed a 60m budget and be killed mid-image-pass. Incremental builds finish in a fraction of this; the ceiling only bites on a cold first run.

## 4. Drop redundant `actions/cache` for git-tracked paths
`.image_optimization_cache/` and `.last_spell_check_timestamp` are both git-tracked (committed every run, restored on checkout), so the `actions/cache` layer was pure redundancy — and its `hashFiles()` key lagged a build behind, masking that fact. Removed it and the dead `cache-restore` output references.

**Kept deliberately:**
- The incremental build cache (`.build-cache.json`) — gitignored, so the Actions cache is the only thing persisting it between runs.
- The `/tmp` cache backup around `git reset --hard` — it guards the git-tracked cache from being clobbered by the reset (unrelated to the removed Actions cache). Comment clarified.

## Verification
- `python3 -c yaml.safe_load(...)` → valid
- No dangling references to removed step/cache ids
- gitleaks clean

Suggested live check after merge: `curl -H 'Accept-Encoding: br' -I https://jameskilby.co.uk/<a-post>/` and diff the decoded `.br` against the live `.html` to confirm #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)