### PR TITLE
fix(seo): sitemap lastmod, drop dead SearchAction, sort RSS, harden SEO validator

### DIFF
--- a/scripts/validate_seo.py
+++ b/scripts/validate_seo.py
@@ -23,10 +23,20 @@ Usage:
 import json
 import sys
 import re
+import xml.etree.ElementTree as ET
 from collections import defaultdict
+from datetime import datetime
 from pathlib import Path
 
 from bs4 import BeautifulSoup
+
+# config.py is the single source of truth for the live/WP hostnames used by
+# the sitemap/robots/feed checks below.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from config import Config
+except ImportError:  # pragma: no cover - config.py always ships alongside
+    Config = None
 
 
 # ── thresholds ───────────────────────────────────────────────────────────────
@@ -74,6 +84,71 @@ class Issue:
 
     def __str__(self) -> str:
         return f'{self.severity.upper():7}  {self.category:30}  {self.path}  — {self.detail}'
+
+
+# Article-family @types that Google treats as an Article rich result, and the
+# fields it requires on that node. The pipeline mutates JSON-LD in ~10 places
+# with no semantic checking, so a node that *parses* but is missing headline /
+# datePublished / author / image silently loses rich-result eligibility — the
+# class of regression validate_seo previously couldn't see.
+ARTICLE_TYPES = (
+    'Article', 'BlogPosting', 'TechArticle', 'NewsArticle',
+    'Report', 'ScholarlyArticle', 'AdvertiserContentArticle',
+)
+# headline + datePublished are the schema backbone — their absence means a real
+# break (e.g. a pipeline pass stripped them), so fail the build. author + image
+# are Google-*recommended* (not required) and legitimately absent on old
+# imageless posts, so warn rather than block every future deploy.
+ARTICLE_REQUIRED_ERROR = ('headline', 'datePublished')
+ARTICLE_RECOMMENDED_WARN = ('author', 'image')
+
+
+def _node_types(node: dict) -> list:
+    t = node.get('@type', '')
+    if isinstance(t, str):
+        return [t]
+    if isinstance(t, (list, tuple)):
+        return [str(x) for x in t]
+    return []
+
+
+def _validate_article_jsonld(ld_nodes: list, html_path: Path) -> list:
+    """Assert the post's Article-family JSON-LD node carries the fields Google
+    requires for an Article rich result, and that references resolve."""
+    issues = []
+    articles = [
+        n for n in ld_nodes
+        if isinstance(n, dict) and any(t in ARTICLE_TYPES for t in _node_types(n))
+    ]
+    if not articles:
+        issues.append(Issue('error', 'jsonld-article-missing',
+                            'no Article/BlogPosting/TechArticle JSON-LD node on post page',
+                            html_path))
+        return issues
+
+    ids = {n.get('@id') for n in ld_nodes if isinstance(n, dict) and n.get('@id')}
+
+    for art in articles:
+        atype = '/'.join(_node_types(art)) or 'Article'
+        for field in ARTICLE_REQUIRED_ERROR:
+            if art.get(field) in (None, '', [], {}):
+                issues.append(Issue('error', 'jsonld-article-incomplete',
+                                    f'{atype} JSON-LD missing required "{field}"', html_path))
+        for field in ARTICLE_RECOMMENDED_WARN:
+            if art.get(field) in (None, '', [], {}):
+                issues.append(Issue('warning', 'jsonld-article-recommended',
+                                    f'{atype} JSON-LD missing recommended "{field}"', html_path))
+        # author may be inline or an @id reference into the same @graph.
+        author = art.get('author')
+        if isinstance(author, dict) and list(author.keys()) == ['@id'] and author['@id'] not in ids:
+            issues.append(Issue('warning', 'jsonld-author-dangling',
+                                f'{atype} author @id {author["@id"]!r} not defined in @graph',
+                                html_path))
+        node_id = art.get('@id', '')
+        if node_id and not str(node_id).startswith('http'):
+            issues.append(Issue('warning', 'jsonld-id-relative',
+                                f'{atype} @id is not an absolute URL: {node_id!r}', html_path))
+    return issues
 
 
 def _is_post_page(rel_path: str) -> bool:
@@ -167,14 +242,24 @@ def validate_page(html_path: Path, public_dir: Path) -> list:
             issues.append(Issue('error', 'h1-duplicate',
                                 f'post page has {len(h1s)} <h1> tags', html_path))
 
-    # ── JSON-LD parseability ─────────────────────────────────────────────────
+    # ── JSON-LD parseability + semantic required-fields ──────────────────────
+    ld_nodes = []
     for script in soup.find_all('script', type='application/ld+json'):
         try:
-            json.loads(script.string or '')
+            data = json.loads(script.string or '')
         except Exception as exc:
             issues.append(Issue('error', 'jsonld-parse-error',
                                 f'JSON-LD block failed to parse: {exc}', html_path))
             break  # one bad block is enough to surface
+        else:
+            if isinstance(data, dict):
+                ld_nodes.extend(data.get('@graph', [data]))
+            elif isinstance(data, list):
+                ld_nodes.extend(data)
+    else:
+        # No parse error — check that post pages carry a complete Article node.
+        if is_post:
+            issues.extend(_validate_article_jsonld(ld_nodes, html_path))
 
     # ── robots noindex on a post page ────────────────────────────────────────
     robots = soup.find('meta', attrs={'name': 'robots'})
@@ -207,6 +292,123 @@ def validate_page(html_path: Path, public_dir: Path) -> list:
     return issues
 
 
+def validate_site_artifacts(public_dir: Path) -> list:
+    """Validate sitemap.xml, robots.txt and the RSS feed — site-wide artifacts
+    that nothing else in the pipeline checks. A sitemap that lost half its URLs,
+    gained a wrong-host <loc>, referenced a 404, or shipped a future <lastmod>
+    would otherwise sail through the entire build.
+    """
+    if Config is None:
+        return [Issue('warning', 'config-unavailable',
+                      'config.py not importable — skipping sitemap/robots/feed checks',
+                      public_dir)]
+
+    issues = []
+    target = Config.TARGET_DOMAIN.rstrip('/')
+    wp_host = Config.WP_URL.replace('https://', '').replace('http://', '').split('/')[0]
+    today = datetime.now().date()
+
+    # ── sitemap.xml ──────────────────────────────────────────────────────────
+    sitemap = public_dir / 'sitemap.xml'
+    if not sitemap.exists():
+        issues.append(Issue('error', 'sitemap-missing', 'public/sitemap.xml not found', sitemap))
+    else:
+        try:
+            root = ET.fromstring(sitemap.read_text(encoding='utf-8', errors='ignore'))
+        except ET.ParseError as exc:
+            issues.append(Issue('error', 'sitemap-parse-error',
+                                f'sitemap.xml is not valid XML: {exc}', sitemap))
+            root = None
+        if root is not None:
+            # Page URLs (<url><loc>) and image-sitemap URLs (<image:image>
+            # <image:loc>) live in different namespaces — keep them apart so an
+            # image is never validated as if it were a crawlable page.
+            sm_ns = 'http://www.sitemaps.org/schemas/sitemap/0.9'
+            img_ns = 'http://www.google.com/schemas/sitemap-image/1.1'
+            page_locs = [e.text.strip() for e in root.iter(f'{{{sm_ns}}}loc') if e.text]
+            image_locs = [e.text.strip() for e in root.iter(f'{{{img_ns}}}loc') if e.text]
+            if not page_locs:
+                issues.append(Issue('error', 'sitemap-empty',
+                                    'sitemap.xml has zero page <loc> entries', sitemap))
+
+            def _on_host(u):  # host + scheme check
+                return u == target or u.startswith(target + '/')
+
+            def _exists(u):   # does the URL map to a file under public/?
+                rel = u[len(target):].lstrip('/')
+                if rel == '' or u.endswith('/'):
+                    return (public_dir / rel / 'index.html').exists()
+                return (public_dir / rel).exists()
+
+            for u in page_locs:
+                if not _on_host(u):
+                    issues.append(Issue('error', 'sitemap-wrong-host',
+                                        f'page <loc> not on {target}: {u}', sitemap))
+                elif not _exists(u):
+                    issues.append(Issue('error', 'sitemap-url-404',
+                                        f'page <loc> has no file on disk: {u}', sitemap))
+                if wp_host in u:
+                    issues.append(Issue('error', 'sitemap-wp-host-leak',
+                                        f'page <loc> references the WordPress host: {u}', sitemap))
+
+            for u in image_locs:
+                if not _on_host(u):
+                    issues.append(Issue('error', 'sitemap-image-wrong-host',
+                                        f'image <loc> not on {target}: {u}', sitemap))
+                elif not _exists(u):
+                    # Image sitemap pointing at a missing file is a real but
+                    # low-severity issue (broken image-search entry), not a
+                    # reason to block the deploy.
+                    issues.append(Issue('warning', 'sitemap-image-404',
+                                        f'image <loc> has no file on disk: {u}', sitemap))
+
+            # No <lastmod> may be in the future.
+            for e in root.iter(f'{{{sm_ns}}}lastmod'):
+                if not e.text:
+                    continue
+                try:
+                    d = datetime.fromisoformat(e.text.strip().replace('Z', '+00:00')).date()
+                except (ValueError, AttributeError):
+                    continue
+                if d > today:
+                    issues.append(Issue('error', 'sitemap-future-lastmod',
+                                        f'<lastmod> {e.text.strip()} is in the future', sitemap))
+
+    # ── robots.txt ───────────────────────────────────────────────────────────
+    robots = public_dir / 'robots.txt'
+    if not robots.exists():
+        issues.append(Issue('error', 'robots-missing', 'public/robots.txt not found', robots))
+    else:
+        txt = robots.read_text(encoding='utf-8', errors='ignore')
+        if f'Sitemap: {target}/sitemap.xml' not in txt:
+            issues.append(Issue('error', 'robots-sitemap-directive',
+                                f'robots.txt lacks "Sitemap: {target}/sitemap.xml"', robots))
+        # A bare "Disallow: /" under a global User-agent would deindex the site.
+        if re.search(r'(?im)^\s*Disallow:\s*/\s*$', txt):
+            issues.append(Issue('error', 'robots-disallow-all',
+                                'robots.txt contains a blanket "Disallow: /"', robots))
+        if wp_host in txt:
+            issues.append(Issue('error', 'robots-wp-host-leak',
+                                f'robots.txt references the WordPress host {wp_host}', robots))
+
+    # ── RSS feed ─────────────────────────────────────────────────────────────
+    feed = public_dir / 'feed' / 'index.xml'
+    if not feed.exists():
+        issues.append(Issue('warning', 'feed-missing', 'public/feed/index.xml not found', feed))
+    else:
+        feed_txt = feed.read_text(encoding='utf-8', errors='ignore')
+        try:
+            ET.fromstring(feed_txt)
+        except ET.ParseError as exc:
+            issues.append(Issue('error', 'feed-parse-error',
+                                f'feed/index.xml is not valid XML: {exc}', feed))
+        if wp_host in feed_txt:
+            issues.append(Issue('error', 'feed-wp-host-leak',
+                                f'RSS feed references the WordPress host {wp_host}', feed))
+
+    return issues
+
+
 def main(argv):
     public_dir = Path(argv[1] if len(argv) > 1 else 'public').resolve()
     if not public_dir.is_dir():
@@ -221,6 +423,9 @@ def main(argv):
     all_issues: list = []
     for f in html_files:
         all_issues.extend(validate_page(f, public_dir))
+
+    # Site-wide artifacts (sitemap.xml, robots.txt, RSS feed).
+    all_issues.extend(validate_site_artifacts(public_dir))
 
     errors    = [i for i in all_issues if i.severity == 'error']
     warnings  = [i for i in all_issues if i.severity == 'warning']

--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -1106,15 +1106,14 @@ class WordPressStaticGenerator:
                     if item.get('@type') == 'WebSite':
                         if 'inLanguage' not in item:
                             item['inLanguage'] = 'en-GB'
-                        if 'potentialAction' not in item:
-                            item['potentialAction'] = {
-                                "@type": "SearchAction",
-                                "target": {
-                                    "@type": "EntryPoint",
-                                    "urlTemplate": f"{self.target_domain}/?s={{search_term_string}}"
-                                },
-                                "query-input": "required name=search_term_string"
-                            }
+                        # Drop any SearchAction (Rank Math injects one pointing at
+                        # the WordPress "/?s=" endpoint). The static site has no
+                        # server-side search route — search is client-side JS with
+                        # no deep-linkable results page — so a Sitelinks Search Box
+                        # action would resolve to a dead URL. No action is better
+                        # than a broken one. Re-add only if a real /search?q= route
+                        # with query-param deep-linking is ever shipped.
+                        item.pop('potentialAction', None)
                         if 'publisher' not in item:
                             item['publisher'] = {"@id": f"{self.target_domain}/#organization"}
                         enriched = True
@@ -1142,15 +1141,11 @@ class WordPressStaticGenerator:
                     "name": "James Kilby",
                     "description": "Technical blog covering VMware, homelab, AI, and cloud computing",
                     "inLanguage": "en-GB",
-                    "publisher": {"@id": f"{self.target_domain}/#organization"},
-                    "potentialAction": {
-                        "@type": "SearchAction",
-                        "target": {
-                            "@type": "EntryPoint",
-                            "urlTemplate": f"{self.target_domain}/?s={{search_term_string}}"
-                        },
-                        "query-input": "required name=search_term_string"
-                    }
+                    "publisher": {"@id": f"{self.target_domain}/#organization"}
+                    # No SearchAction: the static site has no server-side search
+                    # route (search is client-side JS, no deep-linkable results
+                    # page), so a Sitelinks Search Box action would point at a
+                    # dead "/?s=" URL. See the enrich path above.
                 },
                 org_schema
             ]
@@ -4341,41 +4336,81 @@ document.addEventListener('DOMContentLoaded', function() {
         print(f"✅ Created sitemap.xml with {len(seen_urls)} URLs and {total_images} image entries")
 
     def _extract_modified_date(self, html_file):
-        """Extract modification date from HTML file's Schema.org JSON-LD"""
+        """Best <lastmod> date for the sitemap, most-trustworthy source first.
+
+        Order of preference:
+          1. <meta property="article:modified_time"> — the real WordPress
+             "last edited" timestamp from Rank Math. Present on every post and,
+             crucially, available even on incrementally-seeded HTML that skipped
+             JSON-LD re-injection.
+          2. JSON-LD dateModified on any Article-family / WebPage node
+             (TechArticle, Article, BlogPosting, WebPage, …). The previous code
+             only matched Article/BlogPosting/WebPage, so posts (typed
+             TechArticle) never matched and silently fell through to mtime.
+          3. <meta property="article:published_time"> — fall back to the publish
+             date rather than inventing one.
+          4. File mtime — last resort. For a freshly generated file this is the
+             BUILD date, so the old behaviour stamped every post with "today",
+             clustering all <lastmod> on the deploy date and training Google to
+             distrust the freshness signal.
+
+        Any future date (clock skew / bad CMS data) is clamped to today — a
+        future <lastmod> is an SEO red flag.
+        """
+        def _to_date(value):
+            if not value:
+                return None
+            try:
+                parsed = datetime.fromisoformat(str(value).strip().replace('Z', '+00:00'))
+            except (ValueError, AttributeError, TypeError):
+                return None
+            # Compare on the naive date so aware/naive datetimes never clash.
+            return min(parsed.date(), datetime.now().date())
+
         try:
             with open(html_file, 'r', encoding='utf-8', errors='ignore') as f:
                 html_content = f.read()
-
             soup = BeautifulSoup(html_content, 'html.parser')
 
-            # Look for Schema.org JSON-LD script
-            json_ld_scripts = soup.find_all('script', type='application/ld+json')
+            # 1. article:modified_time meta (primary)
+            tag = soup.find('meta', attrs={'property': 'article:modified_time'})
+            d = _to_date(tag.get('content')) if tag else None
+            if d:
+                return d.strftime('%Y-%m-%d')
 
-            for script in json_ld_scripts:
+            # 2. JSON-LD dateModified on any *Article / WebPage node
+            for script in soup.find_all('script', type='application/ld+json'):
                 try:
                     data = json.loads(script.string)
-
-                    # Handle both single objects and @graph arrays
-                    items = data.get('@graph', [data]) if isinstance(data, dict) else [data]
-
-                    for item in items:
-                        if isinstance(item, dict):
-                            # Look for dateModified in Article, BlogPosting, or WebPage
-                            if item.get('@type') in ['Article', 'BlogPosting', 'WebPage']:
-                                date_modified = item.get('dateModified')
-                                if date_modified:
-                                    # Parse and format date (handle ISO8601 format)
-                                    parsed_date = datetime.fromisoformat(date_modified.replace('Z', '+00:00'))
-                                    return parsed_date.strftime('%Y-%m-%d')
-                except (json.JSONDecodeError, ValueError, AttributeError):
+                except (json.JSONDecodeError, TypeError):
                     continue
+                if isinstance(data, dict):
+                    items = data.get('@graph', [data])
+                elif isinstance(data, list):
+                    items = data
+                else:
+                    items = [data]
+                for item in items:
+                    if not isinstance(item, dict):
+                        continue
+                    t = item.get('@type', '')
+                    types = t if isinstance(t, list) else [t]
+                    if any(str(x).endswith('Article') or x == 'WebPage' for x in types):
+                        d = _to_date(item.get('dateModified'))
+                        if d:
+                            return d.strftime('%Y-%m-%d')
 
-            # Fallback: try to get file modification time
-            file_mtime = html_file.stat().st_mtime
-            return datetime.fromtimestamp(file_mtime).strftime('%Y-%m-%d')
+            # 3. article:published_time meta
+            tag = soup.find('meta', attrs={'property': 'article:published_time'})
+            d = _to_date(tag.get('content')) if tag else None
+            if d:
+                return d.strftime('%Y-%m-%d')
 
-        except Exception as e:
-            # Ultimate fallback: use current date
+            # 4. file mtime (build date — last resort)
+            return datetime.fromtimestamp(html_file.stat().st_mtime).strftime('%Y-%m-%d')
+
+        except Exception:
+            # Ultimate fallback: today.
             return datetime.now().strftime('%Y-%m-%d')
 
     def _get_archive_latest_post_date(self, html_file, post_dates):
@@ -4544,19 +4579,34 @@ document.addEventListener('DOMContentLoaded', function() {
                                         words = text.split()[:50]
                                         description = ' '.join(words) + ('...' if len(words) >= 50 else '')
                                 
-                                # Extract date
+                                # Extract date — prefer the <time class=published>
+                                # element, fall back to the article:published_time
+                                # meta (always present from Rank Math). Keep a
+                                # parsed datetime (pub_dt) so the feed can be sorted
+                                # reliably before it is truncated to the latest 20.
+                                from email.utils import format_datetime
+                                from datetime import datetime as dt, timezone
+                                datetime_str = ''
                                 date_elem = soup.find('time', class_=re.compile(r'published', re.I))
-                                pub_date = ''
                                 if date_elem:
-                                    datetime_str = date_elem.get('datetime', '')
-                                    if datetime_str:
-                                        try:
-                                            from email.utils import format_datetime
-                                            from datetime import datetime as dt
-                                            dt_obj = dt.fromisoformat(datetime_str.replace('Z', '+00:00'))
-                                            pub_date = format_datetime(dt_obj)
-                                        except (ValueError, AttributeError, TypeError):
-                                            pub_date = datetime_str
+                                    datetime_str = date_elem.get('datetime', '') or ''
+                                if not datetime_str:
+                                    meta_pub = soup.find('meta', attrs={'property': 'article:published_time'})
+                                    if meta_pub:
+                                        datetime_str = (meta_pub.get('content') or '').strip()
+                                pub_date = ''
+                                pub_dt = None
+                                if datetime_str:
+                                    try:
+                                        dt_obj = dt.fromisoformat(datetime_str.replace('Z', '+00:00'))
+                                        # Normalise to aware UTC so the later sort
+                                        # never mixes aware and naive datetimes.
+                                        if dt_obj.tzinfo is None:
+                                            dt_obj = dt_obj.replace(tzinfo=timezone.utc)
+                                        pub_dt = dt_obj
+                                        pub_date = format_datetime(dt_obj)
+                                    except (ValueError, AttributeError, TypeError):
+                                        pub_date = datetime_str
                                 
                                 # Extract author
                                 author_elem = soup.find('a', class_=re.compile(r'author|fn', re.I))
@@ -4571,13 +4621,20 @@ document.addEventListener('DOMContentLoaded', function() {
                                     'description': description,
                                     'link': url,
                                     'pub_date': pub_date,
+                                    'pub_dt': pub_dt,
                                     'author': author
                                 })
                             except Exception as e:
                                 print(f"   ⚠️  Error processing {post_dir}: {str(e)}")
                                 continue
         
-        # Sort posts by date (newest first) - take top 20
+        # Sort posts by publication date (newest first), THEN take the top 20.
+        # post_dir.iterdir() yields posts in arbitrary order, so without this
+        # the "latest 20" could omit genuinely recent posts and mis-order the
+        # feed. Posts with an unparseable/absent date sink to the bottom.
+        from datetime import timezone
+        _oldest = datetime.min.replace(tzinfo=timezone.utc)
+        posts.sort(key=lambda p: p.get('pub_dt') or _oldest, reverse=True)
         posts = posts[:20]
         
         if not posts:


### PR DESCRIPTION
Five SEO fixes from the content/code review (#5, #6, #7, #11, #12). Touches `scripts/wp_to_static_generator.py` and `scripts/validate_seo.py`. **No site output is regenerated in this PR** — it changes how the *next* pipeline build emits sitemap/feed/schema and what the validator enforces.

## #5 — Sitemap `<lastmod>` reflects real edits, not the build date
`_extract_modified_date` only matched `Article/BlogPosting/WebPage`, but posts are typed **`TechArticle`** — so the JSON-LD date never matched and every post fell back to file **mtime = the build date**. That clustered all `<lastmod>` on the deploy day and trains Google to ignore the freshness signal.

Now sourced in order: `article:modified_time` meta (real WP edit date) → JSON-LD `dateModified` on any `*Article`/`WebPage` node → `article:published_time` → mtime. Future dates clamped to today. **Verified**: returns `2026-04-16` (the real WP edit date) for sample posts instead of the build date.

## #6 — Remove the broken `SearchAction`
The WebSite `potentialAction` `urlTemplate` was `…/?s={search_term_string}` — the WordPress search endpoint, which doesn't exist on the static site (search is client-side JS with no deep-linkable results page). Google's Sitelinks Search Box would resolve to a dead URL. Removed from both the inject path and the enrich path (the latter now also `pop`s any Rank-Math-supplied one).

## #7 — Sort the RSS feed before truncating to 20
`posts[:20]` sliced filesystem-`iterdir()` order with no sort (despite the comment), so "latest 20" could omit genuinely recent posts and mis-order the feed. Now captures a tz-normalised `pub_dt` (falling back to `article:published_time` meta) and sorts newest-first; undated posts sink. Aware/naive mixing handled (verified no `TypeError`).

## #11 — `validate_seo.py` checks JSON-LD *semantics*, not just parseability
Per-post Article node must carry `headline` + `datePublished` (**error**); missing `author`/`image` **warns** (Google-recommended, legitimately absent on old imageless posts). Also warns on dangling `author` `@id` references and non-absolute `@id`.

## #12 — `validate_seo.py` validates sitemap / robots / feed
Nothing checked these before. Now:
- **sitemap.xml**: page `<loc>` on-host + on-disk (error); image `<loc>` on-host (error) + on-disk (warning); no future `<lastmod>`; no WP-host leak. Page vs image URLs split by XML namespace so an image is never validated as a page.
- **robots.txt**: `Sitemap:` directive present, no blanket `Disallow: /`, no WP host.
- **feed/index.xml**: valid XML, no WP host.

## Verification
- Both files `py_compile` clean.
- `validate_seo.py` against current `public/`: **0 errors, 20 warnings** — all real/actionable (the `about me` title, 4 imageless posts, 2 broken image-sitemap thumbnails, 12 over-length titles). Severity is calibrated so legacy-content gaps warn rather than block deploys, while genuine pipeline regressions (missing headline/dates, page-loc 404, wrong host, WP leak, future lastmod, unparseable JSON-LD) fail the build.
- `_extract_modified_date` and the RSS sort key tested in isolation.
- No existing tests reference the changed behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)