### PR TITLE
chore(ci): run force-full-deploy weekly to backfill back-catalogue schema

### DIFF
--- a/.github/workflows/force-full-deploy.yml
+++ b/.github/workflows/force-full-deploy.yml
@@ -22,6 +22,17 @@ name: Force Full Deploy (no cache)
 
 on:
   workflow_dispatch:
+  # Weekly full rebuild — Sundays 03:00 UTC.
+  #
+  # Incremental builds skip unchanged back-catalogue posts, so any SEO/schema
+  # logic that only runs in the generator stage (FAQ / BlogPosting / breadcrumb
+  # / site-schema injection) never reaches a post until it's next edited in
+  # WordPress. A weekly cache-busting rebuild backfills the whole catalogue so
+  # newly-shipped schema features land site-wide without waiting for every post
+  # to be touched. Off-peak to avoid contending with normal content deploys on
+  # the self-hosted runner. Scheduled runs fire from the default branch (main).
+  schedule:
+    - cron: '0 3 * * 0'
 
 permissions:
   actions: write   # delete caches + trigger sibling workflow


### PR DESCRIPTION
Mitigates review item **#10** (incremental-build schema staleness) with the cheapest possible change.

## Problem
Incremental builds skip unchanged back-catalogue posts. SEO/schema logic that runs **only** in the generator stage (FAQ / BlogPosting / breadcrumb / site-schema injection) therefore never reaches a post until it's next edited in WordPress. New schema features ship only to freshly-touched posts; the back catalogue silently lacks them.

## Fix
Add a weekly `schedule` trigger to the **existing** `force-full-deploy.yml` (which already purges both GH Actions caches and triggers a clean deploy). A weekly cache-busting rebuild backfills the whole catalogue.

```yaml
schedule:
  - cron: '0 3 * * 0'   # Sundays 03:00 UTC
```

- **Off-peak** so it doesn't contend with normal content deploys on the self-hosted runner.
- `workflow_dispatch` retained for on-demand use.
- Scheduled runs fire from the default branch (`main`) once merged — no effect until then.

## Notes
- Independent of the open SEO PRs (#98/#99) — different file, no conflicts.
- The deploy it triggers shares the normal concurrency group, so it queues behind any in-flight deploy rather than colliding.
- This is a belt-and-braces backstop; the longer-term alternative (move retroactive-capable schema into the all-files transformer so it's applied every build) remains a possible follow-up but is a larger refactor.

## Verification
YAML parses; cron validated as 5-field `0 3 * * 0` → 03:00 UTC every Sunday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)