### PR TITLE
fix(seo): wire headline-suffix pass into html_transformer (was dead in pipeline)

### DIFF
--- a/scripts/html_transformer.py
+++ b/scripts/html_transformer.py
@@ -329,6 +329,8 @@ class HTMLTransformer:
             modified = True
         if self.seo.fix_techarticle_dedupe_and_dates(soup, file_path):
             modified = True
+        if self.seo.fix_jsonld_headline_brand_suffix(soup, file_path):
+            modified = True
         if self.seo.fix_person_name(soup, file_path):
             modified = True
         if self.seo.fix_person_enrichment(soup, file_path):


### PR DESCRIPTION
Found while confirming the #98/#99 SEO changes went live. **5 of 6 took effect; the JSON-LD headline cleanup did not** — this fixes it.

## Root cause
The deploy pipeline runs `html_transformer.py`, whose `_apply_seo_fixes()` is a **hardcoded mirror** of `SEOFixer`'s pass list (it drives the SEOFixer methods on an already-parsed soup; it never calls `SEOFixer.process_file`). Its docstring even warns: *"When you add a fix method to SEOFixer, you MUST also add it here."*

PR #99 added `fix_jsonld_headline_brand_suffix` to `SEOFixer` and registered it in `SEOFixer.process_file` — but not in the orchestrator. So it never ran in production. The other two #99 changes (wp-json link removal, `twitter:image:alt`) **did** take effect because they extended *existing* passes already in the mirror.

## Fix
Add the pass to `_apply_seo_fixes`, in the same position as SEOFixer's order. Verified: running `_apply_seo_fixes` on a real post strips `…Setup & Results - James Kilby` → `…Setup & Results`. All 94 unit tests pass.

## ⚠️ Bigger pre-existing issue this uncovered (NOT fixed here)
The same wiring gap means **three other passes are also dead in production** — present in `SEOFixer.process_file`, absent from the orchestrator, called nowhere else:
- `fix_article_entity_links` — the **author→Person @id + topic about/mentions entity** feature (commit `6c4496a`). Confirmed dead: the live site has **no `about`/`mentions` entities**. `config.py` still claims it's "applied at build time", so this is unintended.
- `fix_og_site_name`
- `fix_malformed_stylesheet_attr`

These predate my work and deserve their own change (wiring `fix_article_entity_links` back in will alter JSON-LD output and should be validated). **Strongly recommend** a follow-up that (a) wires in the intended ones and (b) adds a regression test asserting `SEOFixer.process_file`'s pass list and `_apply_seo_fixes` stay in sync, so this whole class of bug can't recur.

## Live verification status of #98/#99
| Change | Live? |
|--------|-------|
| #98 sitemap `lastmod` = real WP date | ✅ (intel-optane = 2026-04-16, 12 distinct dates) |
| #98 SearchAction removed | ✅ |
| #98 RSS newest-first | ✅ |
| #99 dead `/wp-json` link removed | ✅ |
| #99 `twitter:image:alt` | ✅ |
| #99 JSON-LD headline suffix stripped | ❌ → **fixed by this PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)