### PR TITLE
fix(seo): wire 3 dead SEOFixer passes into pipeline + add sync-guard test

### DIFF
--- a/scripts/html_transformer.py
+++ b/scripts/html_transformer.py
@@ -331,17 +331,23 @@ class HTMLTransformer:
             modified = True
         if self.seo.fix_jsonld_headline_brand_suffix(soup, file_path):
             modified = True
+        if self.seo.fix_article_entity_links(soup, file_path):
+            modified = True
         if self.seo.fix_person_name(soup, file_path):
             modified = True
         if self.seo.fix_person_enrichment(soup, file_path):
             modified = True
         if self.seo.fix_organization_sameas(soup, file_path):
             modified = True
+        if self.seo.fix_og_site_name(soup, file_path):
+            modified = True
         if self.seo.fix_twitter_attribution(soup, file_path):
             modified = True
         if self.seo.fix_wordpress_host_leak(soup, file_path):
             modified = True
         if self.seo.fix_og_meta_alignment(soup, file_path):
+            modified = True
+        if self.seo.fix_malformed_stylesheet_attr(soup, file_path):
             modified = True
         return modified
 

--- a/tests/test_html_transformer.py
+++ b/tests/test_html_transformer.py
@@ -1,6 +1,52 @@
 """Tests for html_transformer's string-level <head> cleanup helpers."""
 
+import inspect
+import re
+
+from fix_seo_issues import SEOFixer
 from html_transformer import HTMLTransformer
+
+
+def _ordered_fix_calls(func, receiver):
+    """Extract the ordered list of `fix_*` method names called inside a
+    method's source, matching e.g. `self.fix_x(` or `self.seo.fix_x(`."""
+    src = inspect.getsource(func)
+    return re.findall(rf'{receiver}\.(fix_[a-z0-9_]+)\(', src)
+
+
+class TestSeoPassListInSync:
+    """The deploy pipeline runs html_transformer.py, whose _apply_seo_fixes()
+    is a hand-maintained mirror of SEOFixer.process_file's pass list (it drives
+    the SEOFixer methods on an already-parsed soup and never calls process_file).
+    A pass added to SEOFixer but not the mirror is silently DEAD in production —
+    the exact bug that left fix_jsonld_headline_brand_suffix and
+    fix_article_entity_links un-run. This test fails the build if the two lists
+    ever drift, so the mirror can't fall behind again.
+    """
+
+    def test_orchestrator_runs_every_seofixer_pass(self):
+        canonical = _ordered_fix_calls(SEOFixer.process_file, 'self')
+        mirror = _ordered_fix_calls(HTMLTransformer._apply_seo_fixes, 'self.seo')
+
+        missing = [p for p in canonical if p not in mirror]
+        extra = [p for p in mirror if p not in canonical]
+        assert not missing, (
+            f"passes in SEOFixer.process_file but NOT run by html_transformer "
+            f"(dead in production): {missing}"
+        )
+        assert not extra, (
+            f"passes run by html_transformer but absent from SEOFixer.process_file "
+            f"(stale mirror): {extra}"
+        )
+
+    def test_pass_order_matches(self):
+        canonical = _ordered_fix_calls(SEOFixer.process_file, 'self')
+        mirror = _ordered_fix_calls(HTMLTransformer._apply_seo_fixes, 'self.seo')
+        # Order matters: some passes depend on an earlier pass's output
+        # (e.g. headline cleanup before entity linking).
+        assert canonical == mirror, (
+            f"SEO pass order differs.\n  process_file: {canonical}\n  orchestrator: {mirror}"
+        )
 
 
 def _wrap(head_body, body='<body><p>x</p></body>'):


### PR DESCRIPTION
Follow-up to #101. Restores three SEO passes that were **silently dead in production**, and adds a regression test so this can't recur.

## What was broken
The pipeline runs `html_transformer.py`, whose `_apply_seo_fixes()` is a hand-maintained mirror of `SEOFixer.process_file`'s pass list. Three passes were in `process_file` but missing from the mirror (and called nowhere else), so they never ran on the live site:

| Pass | Impact of it being dead |
|------|------------------------|
| `fix_article_entity_links` | The **M1 feature** (commit `6c4496a`): author→Person `@id` linking + topic `about`/`mentions` entities. **Confirmed dead** — live site has zero `about`/`mentions` entities, despite `config.py` saying it's "applied at build time". |
| `fix_og_site_name` | Wrong `og:site_name` (e.g. the `Jameskilbycouk` slug) never corrected |
| `fix_malformed_stylesheet_attr` | Malformed stylesheet attrs never repaired |

## Fix
Wired all three into `_apply_seo_fixes` at their canonical positions (matching `SEOFixer.process_file` order — some passes depend on an earlier one's output, e.g. headline cleanup before entity linking).

**Validation** (sample of real posts, via the real orchestrator path):
- All JSON-LD stays valid.
- `fix_article_entity_links` links the author and adds `about`/`mentions` entities where `TOPIC_ENTITIES` match (AWS/Cloudflare posts: `about` 0→1, `mentions` 0→1); author-only link on others. No exceptions.

## Regression guard
New `TestSeoPassListInSync` extracts the ordered `fix_*` call lists from both methods and fails the build if they ever drift (set **or** order). This would have caught **both** this bug and the earlier `fix_jsonld_headline_brand_suffix` miss. Lists are now **24/24 in sync**; **96 tests pass**.

## Effect on output
Once merged + a full rebuild runs, back-catalogue posts gain the author entity links and topic `about`/`mentions` entities (richer JSON-LD / entity SEO) that have been configured-but-off since `6c4496a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)