### PR TITLE
fix(stats): real Lighthouse scores, metric accuracy fixes, CWV + trend

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -43,6 +43,11 @@ jobs:
     name: Lighthouse Performance
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # contents: write so the "Record scores" step can commit the latest real
+    # measurement (data/lighthouse-latest.json) back to main. The org default
+    # GITHUB_TOKEN is read-only, so this must be granted explicitly.
+    permissions:
+      contents: write
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'push' ||
@@ -205,6 +210,55 @@ jobs:
           else
             echo "⚠️  No Lighthouse reports found"
             echo "has_results=false" >> $GITHUB_OUTPUT
+          fi
+
+      # Persist the real Lighthouse scores so the /changelog/ and /stats/ pages
+      # can show genuine numbers. generate_changelog.py (run by the deploy
+      # pipeline) reads data/lighthouse-latest.json and folds it into
+      # public/changelog/lighthouse-history.json. We commit to a NON-public path
+      # so this push doesn't re-trigger quality-checks (push paths: public/**)
+      # and doesn't collide with the deploy pipeline's regeneration of public/.
+      # Skipped on pull_request — PR runs can't (and shouldn't) push to main.
+      - name: Record Lighthouse scores to repo
+        if: github.event_name != 'pull_request' && steps.lighthouse_results.outputs.has_results == 'true'
+        continue-on-error: true
+        run: |
+          mkdir -p data
+          jq -n \
+            --arg measured_at "$(date -u '+%Y-%m-%d %H:%M:%S UTC')" \
+            --arg url "${{ steps.lighthouse_results.outputs.url }}" \
+            --argjson performance "${{ steps.lighthouse_results.outputs.performance }}" \
+            --argjson accessibility "${{ steps.lighthouse_results.outputs.accessibility }}" \
+            --argjson best_practices "${{ steps.lighthouse_results.outputs.best_practices }}" \
+            --argjson seo "${{ steps.lighthouse_results.outputs.seo }}" \
+            --arg lcp "${{ steps.lighthouse_results.outputs.lcp }}" \
+            --arg fcp "${{ steps.lighthouse_results.outputs.fcp }}" \
+            --arg cls "${{ steps.lighthouse_results.outputs.cls }}" \
+            --arg tti "${{ steps.lighthouse_results.outputs.tti }}" \
+            '{measured_at: $measured_at, url: $url, performance: $performance, accessibility: $accessibility, best_practices: $best_practices, seo: $seo, lcp: $lcp, fcp: $fcp, cls: $cls, tti: $tti}' \
+            > data/lighthouse-latest.json
+
+          echo "📄 data/lighthouse-latest.json:"
+          cat data/lighthouse-latest.json
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/lighthouse-latest.json
+
+          if git diff --cached --quiet; then
+            echo "ℹ️  No score change — nothing to commit"
+            exit 0
+          fi
+
+          git commit -m "chore(lighthouse): record scores P${{ steps.lighthouse_results.outputs.performance }}/A${{ steps.lighthouse_results.outputs.accessibility }}/BP${{ steps.lighthouse_results.outputs.best_practices }}/S${{ steps.lighthouse_results.outputs.seo }}"
+
+          # The deploy pipeline also pushes to main; rebase-retry on contention.
+          if git push origin HEAD:main; then
+            echo "✅ Pushed lighthouse scores"
+          else
+            echo "⚠️  Push rejected — rebasing onto latest main and retrying..."
+            git fetch origin main
+            git rebase origin/main && git push origin HEAD:main
           fi
 
       - name: Notify Slack with metrics (on push/PR)

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -15,7 +15,6 @@ import os
 from datetime import datetime
 from html import escape as html_escape
 from pathlib import Path
-import requests
 
 def load_lighthouse_history():
     """Load historical Lighthouse scores"""
@@ -29,67 +28,83 @@ def load_lighthouse_history():
             return []
     return []
 
+# Real Lighthouse scores are produced by the `Quality Checks` workflow
+# (quality-checks.yml), which runs the genuine Lighthouse CI against the
+# production URL and commits the latest run here. We READ that measurement
+# rather than calling Google's PageSpeed Insights API — the unauthenticated
+# PSI endpoint returns HTTP 429 (shared daily quota exhausted) and the old
+# code silently fell back to hardcoded 95/95/100/100 "Estimated" scores,
+# which then masqueraded as real data on /changelog/ and /stats/.
+LIGHTHOUSE_LATEST_FILE = Path('data/lighthouse-latest.json')
+
 def save_lighthouse_scores(scores, history):
-    """Save current Lighthouse scores to history"""
-    # Add current scores to history
-    history.append({
-        'date': datetime.now().strftime('%Y-%m-%d'),
+    """Save current Lighthouse scores to history (one entry per date — latest wins)."""
+    today = datetime.now().strftime('%Y-%m-%d')
+    entry = {
+        'date': today,
         'timestamp': scores['timestamp'],
         'performance': scores['performance'],
         'accessibility': scores['accessibility'],
         'best_practices': scores['best_practices'],
         'seo': scores['seo']
-    })
-    
-    # Keep only last 90 days of history
+    }
+
+    # Replace an existing same-date entry rather than appending a duplicate.
+    # The deploy pipeline runs many times a day; without this, history would
+    # fill with identical same-day rows and the trend series would be useless.
+    history = [e for e in history if e.get('date') != today]
+    history.append(entry)
+
+    # Keep only the last 90 days of history
     cutoff_date = datetime.now().timestamp() - (90 * 24 * 60 * 60)
     history = [entry for entry in history if datetime.strptime(entry['date'], '%Y-%m-%d').timestamp() > cutoff_date]
-    
+
     # Save to file
     history_file = Path('public/changelog/lighthouse-history.json')
     history_file.parent.mkdir(parents=True, exist_ok=True)
     with open(history_file, 'w') as f:
         json.dump(history, f, indent=2)
-    
+
     print(f"✅ Saved Lighthouse scores to history ({len(history)} entries)")
     return history
 
 def get_lighthouse_scores():
-    """Fetch Lighthouse scores for the site"""
-    print("📊 Fetching Lighthouse scores...")
-    
-    # Use PageSpeed Insights API (Google's public Lighthouse API)
-    url = "https://www.googleapis.com/pagespeedonline/v5/runPagespeed"
-    params = {
-        "url": "https://jameskilby.co.uk",
-        "category": ["performance", "accessibility", "best-practices", "seo"],
-        "strategy": "mobile"
-    }
-    
+    """Load the latest real Lighthouse scores measured by the Quality Checks workflow.
+
+    Returns a scores dict, or None when no real measurement is available yet
+    (e.g. the workflow has not run since this file was wired up). Returning
+    None lets main() reuse the most recent real history entry instead of
+    fabricating numbers.
+    """
+    print("📊 Loading Lighthouse scores from latest measurement...")
+
+    if not LIGHTHOUSE_LATEST_FILE.exists():
+        print(f"   ⚠️  {LIGHTHOUSE_LATEST_FILE} not found — no real scores to record this run")
+        return None
+
     try:
-        response = requests.get(url, params=params, timeout=60)
-        if response.status_code == 200:
-            data = response.json()
-            scores = data.get('lighthouseResult', {}).get('categories', {})
-            
-            return {
-                'performance': int(scores.get('performance', {}).get('score', 0) * 100),
-                'accessibility': int(scores.get('accessibility', {}).get('score', 0) * 100),
-                'best_practices': int(scores.get('best-practices', {}).get('score', 0) * 100),
-                'seo': int(scores.get('seo', {}).get('score', 0) * 100),
-                'timestamp': datetime.now().strftime('%Y-%m-%d %H:%M:%S UTC')
-            }
-    except Exception as e:
-        print(f"⚠️  Could not fetch Lighthouse scores: {e}")
-    
-    # Return default scores if API fails
-    return {
-        'performance': 95,
-        'accessibility': 95,
-        'best_practices': 100,
-        'seo': 100,
-        'timestamp': 'Estimated'
-    }
+        with open(LIGHTHOUSE_LATEST_FILE, 'r') as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"   ⚠️  Could not read {LIGHTHOUSE_LATEST_FILE} ({e}) — skipping")
+        return None
+
+    try:
+        scores = {
+            'performance': int(data['performance']),
+            'accessibility': int(data['accessibility']),
+            'best_practices': int(data['best_practices']),
+            'seo': int(data['seo']),
+            'timestamp': data.get('measured_at', 'unknown'),
+        }
+    except (KeyError, TypeError, ValueError) as e:
+        print(f"   ⚠️  {LIGHTHOUSE_LATEST_FILE} is missing expected fields ({e}) — skipping")
+        return None
+
+    print(f"   ✅ Loaded real scores measured {scores['timestamp']} "
+          f"(perf {scores['performance']}, a11y {scores['accessibility']}, "
+          f"bp {scores['best_practices']}, seo {scores['seo']})")
+    return scores
 
 def get_git_stats():
     """Get git repository statistics"""
@@ -640,14 +655,30 @@ def main():
     print("=" * 60)
     
     # Gather data
-    lighthouse_scores = get_lighthouse_scores()
+    real_scores = get_lighthouse_scores()
     git_stats = get_git_stats()
     changes = get_recent_changes()
-    
-    # Load and save Lighthouse history
+
+    # Load history; record the new measurement only when we actually have one.
     history = load_lighthouse_history()
-    history = save_lighthouse_scores(lighthouse_scores, history)
-    
+    if real_scores:
+        history = save_lighthouse_scores(real_scores, history)
+
+    # Choose what to render: the fresh measurement if present, else the most
+    # recent real entry already in history, else a clearly-labelled placeholder
+    # so the page still renders on a brand-new repo (before the first run).
+    if real_scores:
+        lighthouse_scores = real_scores
+    elif history:
+        lighthouse_scores = history[-1]
+        print(f"ℹ️  No new measurement — rendering last recorded scores from {lighthouse_scores.get('date', 'unknown')}")
+    else:
+        print("ℹ️  No Lighthouse data available yet — rendering placeholder scores")
+        lighthouse_scores = {
+            'performance': 0, 'accessibility': 0, 'best_practices': 0, 'seo': 0,
+            'timestamp': 'No measurement yet'
+        }
+
     # Generate HTML
     html = generate_changelog_html(lighthouse_scores, git_stats, changes)
     


### PR DESCRIPTION
Overhauls how the `/stats/` and `/changelog/` Lighthouse sections get their data, fixes every inaccurate metric on the stats page, and adds Core Web Vitals + a performance trend. Three commits, summarised below.

## Background — the original bug

The Lighthouse section showed hardcoded **95/95/100/100 "Estimated"** scores, not real measurements. `generate_changelog.py` fetched from Google's PageSpeed Insights API **without an API key**, so the shared anonymous quota returned HTTP 429 on every run and the code silently fell back to fabricated defaults — which were then persisted to `lighthouse-history.json` and rendered as if real. Reproduced live:

```
status: 429  "Quota exceeded for quota metric 'Queries' ... reason: rateLimitExceeded"
```

Meanwhile `quality-checks.yml` already ran **genuine** Lighthouse CI against production but threw the results away (Slack-only).

---

## Commit 1 — wire real Lighthouse scores into history

- **`quality-checks.yml`**: new *"Record Lighthouse scores"* step writes the real scores + Core Web Vitals to `data/lighthouse-latest.json` and commits it to `main` (rebase-retry for contention with the deploy pipeline). Granted `permissions: contents: write`; skipped on `pull_request`.
- **`generate_changelog.py`**: reads that file instead of calling PageSpeed; returns `None` (never fabricates) when no measurement exists; dedupes history by date.

## Commit 2 — fix 5 inaccurate stats metrics

| Metric | Before | After |
|---|---|---|
| Average Page Size | `1.05 KB` (site-size÷pages, MB mislabelled as KB) | `95.1 KB` (real mean HTML weight) |
| Total Images | `3589` (image files, AVIF excluded) | `450` (distinct logical images; file count shown in note) |
| Images per Post | `47.9` (inflated by variants) | `6.0` (distinct/post) |
| Deployments | `980` (every commit) | `295` (actual auto-deploy commits; total shown in note) |
| Total Site Size | `194 MB` ("all files") | same, but note breaks out `163 MB images + 8 MB .br/.gz` |

## Commit 3 — CWV, trend sparkline, median run, shared module

1. **Core Web Vitals** — render LCP/FCP/CLS/TTI on `/stats/` from the real measurement; block self-hides when absent.
2. **Performance trend sparkline** — inline dependency-free SVG of the last ~30 history points with min/now/max labels; hidden below 2 points.
3. **No-fabricate fallback** — `generate_stats_page.py` no longer invents 95/95/100/100; prefers latest → last real history entry → honest "no measurement yet".
4. **Median Lighthouse run** — `quality-checks.yml` selects the representative (median) run from `.lighthouseci/manifest.json` instead of `ls -t | head -1`, so the recorded/Slack'd score stops jittering across the 3 runs and desktop/mobile passes (falls back to newest).
5. **Shared module** — new `scripts/lighthouse_data.py` is the single source for reading the latest measurement, history load/save (per-date dedup, 90-day window, CWV persisted), and the score CSS class. Both generators import it; the drifted copy-paste is gone.
6. **Tighter posts regex** — counts only `YYYY/MM/slug/index.html`, so bare year/month archive pages can't be miscounted as posts.

---

## Data flow

```
quality-checks.yml (real Lighthouse on prod, median run)
  -> data/lighthouse-latest.json            [committed]
    -> generate_changelog.py (lighthouse_data)
      -> public/changelog/lighthouse-history.json   [dated trend, deduped]
        -> generate_stats_page.py -> /stats/ (scores + CWV + sparkline)
```

## Loop safety

- `data/` is outside `public/`, and `quality-checks.yml` only push-triggers on `public/**` — its own commit doesn't re-trigger it.
- `deploy-static-site.yml` triggers only on `workflow_dispatch`/`repository_dispatch`, not push.
- The two committers touch disjoint paths (`data/` vs `public/`).

## ⚠️ Affects `public/`

Changes how `public/changelog/lighthouse-history.json` is populated — the next auto-pipeline commit will replace the `"Estimated"` row with real scores. The sparkline needs ≥2 real dated entries, so it appears after the workflow has run a couple of times post-merge.

## Testing

- Unit assertions on the shared logic (missing-file → `None`, valid parse, same-date dedup).
- Rendered both pages against a seeded CWV measurement + 12-point history: CWV cards, sparkline polyline + range, `score_class` circles, and the real measured-at timestamp all verified; regenerated `public/` artifacts reverted (pipeline owns them).
- `py_compile` + YAML validation; no unused imports.

## Not included (possible follow-up)

CrUX real-field data (`fetch_crux_metrics.py` exists but isn't wired in), modern-format coverage %, real homepage transfer size, and unit tests for the stats metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)