### PR TITLE
feat(homepage): top band → status ribbon (Option B)

### DIFF
--- a/scripts/brutalist-theme.css
+++ b/scripts/brutalist-theme.css
@@ -1281,182 +1281,81 @@ div, section, aside, nav {
    wp_to_static_generator.py. Class prefix: .jkr-* (jk redesign).
 ─────────────────────────────────────────────────────────────────────── */
 
-/* Hero strap ---------------------------------------------------------- */
+/* ---- Homepage top band (Option B) ----
+   Strap + filter share the top row, the editorial <h1> is the headline, and a
+   single-line stats ribbon replaces the old terminal box. Reclaims the wasted
+   vertical space so the featured hero sits above the fold. */
+.jkr-top {
+  max-width: 1280px;
+  margin: 0 auto 2.5rem;
+  padding: 2.5rem 2.5rem 1.75rem;
+  border-bottom: 1px solid var(--gray-mid, #1f1f1f);
+}
+.jkr-top-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.25rem;
+}
 .jkr-strap {
-  position: relative;
-  border-bottom: 1px solid #1f1f1f;
-  background-color: var(--bg-dark) !important;
-}
-.jkr-strap-inner {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 4.5rem 2.5rem 4rem;
-}
-.jkr-strap-meta {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.6875rem;
-  letter-spacing: 0.18em;
-  color: var(--accent-orange);
-  margin-bottom: 1.5rem;
-}
-.jkr-strap-h {
-  font-family: 'Anton', sans-serif !important;
-  font-size: 4.75rem !important;
-  line-height: 0.98 !important;
-  margin: 0 !important;
-  font-weight: 400 !important;
-  letter-spacing: 0.01em !important;
-  text-transform: uppercase;
-  color: var(--text-light) !important;
-}
-
-/* Terminal stats ----------------------------------------------------- */
-.jkr-term-wrap {
-  position: relative;
-  border-bottom: 1px solid #1f1f1f;
-  background-color: var(--bg-dark) !important;
-}
-.jkr-term-inner {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem 2.5rem 0.5rem;
-}
-.jkr-term {
-  border: 1px solid #1f1f1f;
-  background: #070707;
-  font-family: 'JetBrains Mono', monospace;
-}
-.jkr-term-head {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.625rem 1rem;
-  border-bottom: 1px solid #1f1f1f;
-  background: #101010;
-}
-.jkr-term-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: #2a2a2a;
-}
-.jkr-term-path {
-  color: #7a766c;
-  font-size: 0.71875rem;
-  margin-left: 0.75rem;
-  flex: 1;
-}
-.jkr-term-live {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-  font-size: 0.6875rem;
-  color: #7da87d;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-.jkr-term-live-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: #7da87d;
-  box-shadow: 0 0 6px #7da87d;
-}
-.jkr-term-body {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 0;
-  padding: 1.375rem 1.5rem 1.125rem;
-}
-.jkr-term-col {
-  display: flex;
-  flex-direction: column;
-  gap: 0.375rem;
-  padding-right: 1.5rem;
-}
-.jkr-term-row {
-  display: flex;
-  align-items: baseline;
-  font-size: 0.8125rem;
-  white-space: nowrap;
-  overflow: hidden;
-}
-.jkr-term-k { color: #9a978e; }
-.jkr-term-dots {
-  color: #2a2a2a;
-  margin: 0 0.5rem;
-  flex: 1;
-  overflow: hidden;
-  white-space: nowrap;
-  letter-spacing: 1px;
-}
-.jkr-term-v { color: var(--accent-orange) !important; font-weight: 500; }
-.jkr-term-prompt {
-  padding: 0 1.5rem 1.125rem;
-  display: flex;
-  gap: 0.625rem;
-  font-size: 0.8125rem;
-}
-.jkr-term-arrow { color: #7da87d; }
-.jkr-term-cursor {
-  color: var(--text-light);
-  animation: jkr-blink 1s steps(2) infinite;
-}
-@keyframes jkr-blink {
-  0%, 50% { opacity: 1; }
-  51%, 100% { opacity: 0; }
-}
-
-/* Filter bar --------------------------------------------------------- */
-.jkr-filter {
-  position: relative;
-  border-top: 1px solid #1f1f1f;
-  border-bottom: 1px solid #1f1f1f;
-  margin-top: 1.5rem;
-  background-color: var(--bg-dark) !important;
-}
-.jkr-filter-inner {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 1rem 2.5rem;
-  display: flex;
-  align-items: center;
-  gap: 1.5rem;
-}
-.jkr-filter-label {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.6875rem;
   letter-spacing: 0.16em;
-  color: #7a766c;
+  color: var(--accent, #f6821f);
 }
-.jkr-filter-chips {
+
+/* filter — inline, no longer its own block */
+.jkr-filter { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+.jkr-filter-label {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.6875rem; letter-spacing: 0.16em; color: var(--gray-light, #7a766c);
+  margin-right: 0.25rem;
+}
+.jkr-filter a {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem; letter-spacing: 0.04em;
+  color: #c8c5bd; text-decoration: none;
+  border: 1px solid var(--gray-mid, #262625);
+  padding: 0.3rem 0.7rem;
+}
+.jkr-filter a.is-active { background: var(--accent, #f6821f); color: #0a0a0a; border-color: var(--accent, #f6821f); font-weight: 600; }
+.jkr-filter a:hover:not(.is-active) { border-color: var(--accent, #f6821f); color: #f5f3ee; }
+
+/* headline — tighter, capped measure so the right gutter isn't dead space */
+.jkr-headline {
+  font-family: "Anton", sans-serif;
+  font-weight: 400;
+  font-size: clamp(2rem, 5vw, 3rem);
+  line-height: 1.04;
+  letter-spacing: 0.005em;
+  color: #f5f3ee;
+  margin: 0 0 1.5rem;
+  max-width: 46rem;
+}
+
+/* the ribbon that replaces the terminal box */
+.jkr-ribbon {
   display: flex;
-  gap: 0.25rem;
-  flex: 1;
+  align-items: center;
+  gap: 0.75rem;
   flex-wrap: wrap;
-}
-.jkr-filter-chip {
-  background: transparent;
-  border: 1px solid transparent;
-  color: #9a978e !important;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--gray-mid, #1f1f1f);
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.8125rem;
-  padding: 0.375rem 0.75rem;
-  font-weight: 500;
-  text-decoration: none !important;
-  cursor: pointer;
-  text-transform: none;
-  letter-spacing: 0;
+  color: var(--gray-light, #7a766c);
 }
-.jkr-filter-chip:hover {
-  color: var(--text-light) !important;
-  text-decoration: none !important;
-  opacity: 1;
-}
-.jkr-filter-chip-active,
-.jkr-filter-chip-active:hover {
-  background: var(--accent-orange) !important;
-  color: var(--bg-dark) !important;
-  font-weight: 600;
+.jkr-ribbon b { color: #f5f3ee; font-weight: 600; }
+.jkr-ribbon span { color: #c8c5bd; }
+.jkr-r-dot { color: #3a3a38 !important; }
+.jkr-r-live { margin-left: auto; color: #7da87d !important; font-size: 0.72rem; letter-spacing: 0.1em; }
+
+/* mobile: ribbon wraps, live marker drops below */
+@media (max-width: 640px) {
+  .jkr-r-live { margin-left: 0; width: 100%; }
+  .jkr-headline { font-size: clamp(1.75rem, 8vw, 2.25rem); }
 }
 
 /* Refined post-card hover (offset translate + orange shadow) ----------
@@ -1543,22 +1442,7 @@ div, section, aside, nav {
 
 /* Mobile adjustments for redesign sections --------------------------- */
 @media (max-width: 768px) {
-  .jkr-strap-inner {
-    padding: 2.5rem 1.25rem 2rem;
-  }
-  .jkr-strap-h { font-size: 2.5rem !important; }
-  .jkr-term-inner { padding: 1.25rem 1.25rem 0.5rem; }
-  .jkr-term-body {
-    grid-template-columns: 1fr;
-    padding: 1rem 1rem 0.75rem;
-  }
-  .jkr-term-col { padding-right: 0; }
-  .jkr-term-prompt { padding: 0 1rem 1rem; }
-  .jkr-filter-inner {
-    padding: 0.75rem 1.25rem;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-  }
+  .jkr-top { padding: 2rem 1.25rem 1.5rem; }
   .jkr-topics { padding: 2.5rem 1.25rem; margin-top: 1.5rem; }
   .jkr-topics-h2 { font-size: 2rem !important; }
   .jkr-topics-grid { grid-template-columns: 1fr; }
@@ -1609,9 +1493,7 @@ div, section, aside, nav {
   #colophon,
   script,
   .splide,
-  .jkr-strap,
-  .jkr-term-wrap,
-  .jkr-filter,
+  .jkr-top,
   .jkr-topics {
     display: none !important;
   }

--- a/scripts/subset_fonts.py
+++ b/scripts/subset_fonts.py
@@ -125,8 +125,8 @@ FONT_SPECS = (
         tag_selectors=('h1', 'h2', 'h3', 'h4', 'h5', 'h6'),
         class_selectors=(
             '.site-title', '.entry-title',
-            '.jkr-eyebrow', '.jkr-strap-meta', '.jkr-filter-label',
-            '.jkr-topic-count', '.jkr-term',
+            '.jkr-eyebrow', '.jkr-topic-count',
+            # .jkr-headline is an <h1> (covered by the tag selector above).
         ),
     ),
 
@@ -143,8 +143,13 @@ FONT_SPECS = (
             '.wp-block-code',
             '.jkr-hero-cats', '.jkr-hero-cats span',
             '.jkr-hero-meta',
+            # Homepage top band (Option B): strap, filter and stats ribbon all
+            # render in JetBrains Mono.
+            '.jkr-strap', '.jkr-filter', '.jkr-filter-label', '.jkr-ribbon',
         ),
-        safety_pad=ASCII_PRINTABLE + TYPO_PAD + CODE_PAD,
+        # '●' (U+25CF) is the ribbon's "● live" marker — keep it in the subset
+        # so it doesn't fall back to system monospace.
+        safety_pad=ASCII_PRINTABLE + TYPO_PAD + CODE_PAD + '●',
     ),
 
     # JetBrains Mono 700 — hero "LATEST" badge plus any bold inside

--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -424,12 +424,15 @@ class WordPressStaticGenerator:
         # Add noindex to thin archive/taxonomy pages (tags, categories)
         self.add_noindex_to_thin_pages(soup, current_url)
 
-        # Fix missing H1 on homepage
-        self.fix_homepage_h1(soup, current_url)
-
-        # Inject Direction A redesign sections on the homepage (hero strap,
-        # terminal stats block, filter bar, topic index). Skips paginated pages.
+        # Inject the homepage top band first: it emits the editorial
+        # <h1 class="jkr-headline">, which must be the page's single H1.
+        # fix_homepage_h1() below is a fallback that only converts the
+        # site-title to an H1 when none exists — running it after the inject
+        # means it correctly stands down, leaving exactly one H1.
         self.inject_homepage_redesign(soup, current_url)
+
+        # Fix missing H1 on homepage (fallback if the redesign didn't inject)
+        self.fix_homepage_h1(soup, current_url)
 
         # Fix byline: published + updated time elements with no separator render
         # as "By James May 29, 2017 June 1, 2026". Insert a separator + 'Updated'
@@ -2550,54 +2553,33 @@ document.addEventListener('DOMContentLoaded', function() {
 
             print(f"   ✅ Converted {old_tag_name}.site-title to H1 on homepage")
 
-    def _compute_homepage_stats(self):
-        """Return three columns of (key, value) pairs for the terminal block.
+    def _compute_ribbon_stats(self):
+        """Return the five momentum/credibility stats for the homepage ribbon.
 
-        Each stat is computed in isolation; if a source is unreachable the
-        stat falls back to '—' rather than breaking the rest of the build.
-        Cached on the instance so it only runs once per build even if the
-        homepage gets reprocessed.
+        Keeps posts·words·days-since-last·deploys/mo·lighthouse — the signals
+        worth surfacing above the fold. Each is computed in isolation and falls
+        back to '—' (or None for days) rather than breaking the build. Cached on
+        the instance so it only runs once per build.
         """
-        if hasattr(self, '_cached_homepage_stats'):
-            return self._cached_homepage_stats
+        if hasattr(self, '_cached_ribbon_stats'):
+            return self._cached_ribbon_stats
 
-        print("   📊 Computing homepage stats...")
+        print("   📊 Computing homepage ribbon stats...")
 
-        posts_count = self._stat_posts_count()
-        last_post = self._stat_last_post_age()
-        cats_count = self._stat_taxonomy_total('categories')
-        tags_count = self._stat_taxonomy_total('tags')
-        words_total = self._stat_words_total()
-        deploys_month = self._stat_deploys_this_month()
-        last_deploy = self._stat_last_deploy_age()
-        lighthouse_perf = self._stat_lighthouse_performance()
-
-        from datetime import datetime
-        try:
-            from config import Config
-            vexpert_start = Config.VEXPERT_START_YEAR
-        except (ImportError, AttributeError):
-            vexpert_start = 2020
-        vexpert_years = str(max(0, datetime.now().year - vexpert_start))
-
-        columns = (
-            (('posts.count', posts_count),
-             ('words.total', words_total),
-             ('last_post', last_post)),
-            (('categories', cats_count),
-             ('tags', tags_count),
-             ('vexpert.years', vexpert_years)),
-            (('deploys.month', deploys_month),
-             ('last_deploy', last_deploy),
-             ('lighthouse', lighthouse_perf)),
-        )
-        self._cached_homepage_stats = columns
+        stats = {
+            'posts_count': self._stat_posts_count(),
+            'words_total': self._stat_words_total(),
+            'days_since_last': self._stat_last_post_days(),
+            'deploys_month': self._stat_deploys_this_month(),
+            'lighthouse': self._stat_lighthouse_performance(),
+        }
+        self._cached_ribbon_stats = stats
         print(
-            f"   📊 Stats: posts={posts_count} words={words_total} last={last_post} "
-            f"cats={cats_count} tags={tags_count} vexpert={vexpert_years}y "
-            f"deploys={deploys_month} last-deploy={last_deploy} LH={lighthouse_perf}"
+            f"   📊 Ribbon: posts={stats['posts_count']} words={stats['words_total']} "
+            f"days={stats['days_since_last']} deploys={stats['deploys_month']} "
+            f"LH={stats['lighthouse']}"
         )
-        return columns
+        return stats
 
     def _stat_posts_count(self):
         try:
@@ -2634,6 +2616,33 @@ document.addEventListener('DOMContentLoaded', function() {
         except Exception as e:
             print(f"   ⚠️  last_post: {e}")
         return '—'
+
+    def _stat_last_post_days(self):
+        """Integer days since the most recent post, or None if unavailable.
+
+        The ribbon renders this as '{n}d since last post'; returning the raw
+        integer (vs. the '8d ago' string) lets the markup format it inline.
+        """
+        try:
+            r = self.session.get(
+                f'{self.wp_url}/wp-json/wp/v2/posts',
+                params={
+                    'per_page': 1, 'orderby': 'date', 'order': 'desc',
+                    'status': 'publish', '_fields': 'date_gmt',
+                },
+                timeout=15,
+            )
+            if r.status_code == 200:
+                data = r.json()
+                if data and data[0].get('date_gmt'):
+                    from datetime import datetime, timezone
+                    d = datetime.fromisoformat(data[0]['date_gmt'])
+                    if d.tzinfo is None:
+                        d = d.replace(tzinfo=timezone.utc)
+                    return max(0, (datetime.now(timezone.utc) - d).days)
+        except Exception as e:
+            print(f"   ⚠️  last_post days: {e}")
+        return None
 
     def _stat_taxonomy_total(self, taxonomy):
         """Count of categories/tags with at least one post."""
@@ -2819,12 +2828,13 @@ document.addEventListener('DOMContentLoaded', function() {
         return '—'
 
     def inject_homepage_redesign(self, soup, current_url):
-        """Inject Direction A (Refined Brutalist + terminal stats) sections on the homepage.
+        """Inject the homepage top band (Option B) + topic index.
 
-        Adds, between the existing entry-hero and the post grid:
-          - hero strap (editorial headline + stat row)
-          - terminal stats block (mac-style window, three columns, blinking prompt)
-          - filter bar (chips that link to /category/<slug>/)
+        Adds, above the post grid:
+          - top band: strap + filter on one row, the editorial <h1> headline,
+            and a single-line stats ribbon (posts · words · days-since-last ·
+            deploys/mo · lighthouse · ● live)
+          - featured hero (newest post promoted out of the grid)
         And appends a topic index after the post grid.
 
         Skips paginated homepage pages (/page/2/, /page/3/, ...).
@@ -2833,7 +2843,7 @@ document.addEventListener('DOMContentLoaded', function() {
             return
 
         # Idempotency guard — don't double-inject if process_html runs twice
-        if soup.find(class_='jkr-strap'):
+        if soup.find(class_='jkr-top'):
             return
 
         # Kadence renders the loop as a <ul class="kadence-posts-list ...">,
@@ -2854,81 +2864,20 @@ document.addEventListener('DOMContentLoaded', function() {
         # nearest multiple of 3 so the last row is always full.
         self._trim_grid_to_columns(posts_list, columns=3)
 
-        # ── 1. hero strap ───────────────────────────────────────────────
-        strap = soup.new_tag('section', attrs={'class': 'jkr-strap'})
-        strap_inner = soup.new_tag('div', attrs={'class': 'jkr-strap-inner'})
+        # ── 1. top band (Option B) ──────────────────────────────────────
+        # Strap + filter share one row; the editorial headline is the page's
+        # single <h1>; a one-line stats ribbon replaces the old terminal box.
+        top = soup.new_tag('header', attrs={'class': 'jkr-top'})
 
-        strap_left = soup.new_tag('div', attrs={'class': 'jkr-strap-left'})
-        meta = soup.new_tag('div', attrs={'class': 'jkr-strap-meta'})
-        meta.string = 'VMWARE VEXPERT · HOMELAB · INFRASTRUCTURE-AS-CODE'
-        strap_h2 = soup.new_tag('p', attrs={'class': 'jkr-strap-h'})
-        strap_h2.append(soup.new_string('Field notes from a homelab that costs'))
-        strap_h2.append(soup.new_tag('br'))
-        strap_h2.append(soup.new_string('real money to run.'))
-        strap_left.append(meta)
-        strap_left.append(strap_h2)
+        top_row = soup.new_tag('div', attrs={'class': 'jkr-top-row'})
+        strap = soup.new_tag('span', attrs={'class': 'jkr-strap'})
+        strap.string = 'VMWARE VEXPERT · HOMELAB · INFRASTRUCTURE-AS-CODE'
+        top_row.append(strap)
 
-        strap_inner.append(strap_left)
-        strap.append(strap_inner)
-
-        # ── 2. terminal stats block ─────────────────────────────────────
-        term_section = soup.new_tag('section', attrs={'class': 'jkr-term-wrap'})
-        term_inner = soup.new_tag('div', attrs={'class': 'jkr-term-inner'})
-        term = soup.new_tag('div', attrs={'class': 'jkr-term'})
-
-        term_head = soup.new_tag('div', attrs={'class': 'jkr-term-head'})
-        for _ in range(3):
-            term_head.append(soup.new_tag('span', attrs={'class': 'jkr-term-dot'}))
-        term_path = soup.new_tag('span', attrs={'class': 'jkr-term-path'})
-        term_path.string = 'jameskilby@blog ~ % cat blog.stats'
-        term_head.append(term_path)
-        term_live = soup.new_tag('span', attrs={'class': 'jkr-term-live'})
-        term_live.append(soup.new_tag('span', attrs={'class': 'jkr-term-live-dot'}))
-        term_live.append(soup.new_string(' live'))
-        term_head.append(term_live)
-        term.append(term_head)
-
-        term_body = soup.new_tag('div', attrs={'class': 'jkr-term-body'})
-        columns = self._compute_homepage_stats()
-        for col in columns:
-            col_div = soup.new_tag('div', attrs={'class': 'jkr-term-col'})
-            for k, v in col:
-                row = soup.new_tag('div', attrs={'class': 'jkr-term-row'})
-                k_el = soup.new_tag('span', attrs={'class': 'jkr-term-k'})
-                k_el.string = k
-                # Dot leaders are cosmetic; CSS draws them via flex+border, but we
-                # also keep an inline dot string for terminals/no-CSS fallback.
-                dots = soup.new_tag('span', attrs={'class': 'jkr-term-dots'})
-                dots.string = '.' * max(2, 26 - len(k) - len(v))
-                v_el = soup.new_tag('span', attrs={'class': 'jkr-term-v'})
-                v_el.string = v
-                row.append(k_el)
-                row.append(dots)
-                row.append(v_el)
-                col_div.append(row)
-            term_body.append(col_div)
-        term.append(term_body)
-
-        term_prompt = soup.new_tag('div', attrs={'class': 'jkr-term-prompt'})
-        arrow = soup.new_tag('span', attrs={'class': 'jkr-term-arrow'})
-        arrow.string = '$'
-        cursor = soup.new_tag('span', attrs={'class': 'jkr-term-cursor'})
-        cursor.string = '_'
-        term_prompt.append(arrow)
-        term_prompt.append(cursor)
-        term.append(term_prompt)
-
-        term_inner.append(term)
-        term_section.append(term_inner)
-
-        # ── 3. filter bar ───────────────────────────────────────────────
-        filter_bar = soup.new_tag('div', attrs={'class': 'jkr-filter'})
-        filter_inner = soup.new_tag('div', attrs={'class': 'jkr-filter-inner'})
+        nav = soup.new_tag('nav', attrs={'class': 'jkr-filter', 'aria-label': 'Filter posts'})
         filter_label = soup.new_tag('span', attrs={'class': 'jkr-filter-label'})
         filter_label.string = 'FILTER'
-        filter_inner.append(filter_label)
-
-        filter_chips = soup.new_tag('div', attrs={'class': 'jkr-filter-chips'})
+        nav.append(filter_label)
         # "All" lands the user back on the homepage; the rest go to category archives.
         chips = (
             ('All', '/'),
@@ -2938,14 +2887,60 @@ document.addEventListener('DOMContentLoaded', function() {
             ('AI', '/category/artificial-intelligence/'),
         )
         for label, href in chips:
-            cls = 'jkr-filter-chip jkr-filter-chip-active' if label == 'All' else 'jkr-filter-chip'
-            chip = soup.new_tag('a', href=href, attrs={'class': cls})
+            attrs = {'href': href}
+            if label == 'All':
+                attrs['class'] = 'is-active'
+            chip = soup.new_tag('a', attrs=attrs)
             chip.string = label
-            filter_chips.append(chip)
-        filter_inner.append(filter_chips)
+            nav.append(chip)
+        top_row.append(nav)
+        top.append(top_row)
 
-        filter_inner.append(soup.new_tag('span', attrs={'class': 'jkr-filter-spacer'}))
-        filter_bar.append(filter_inner)
+        # ── 2. editorial headline (the page's single <h1>) ──────────────
+        headline = soup.new_tag('h1', attrs={'class': 'jkr-headline'})
+        headline.string = 'Field notes from a homelab that costs real money to run.'
+        top.append(headline)
+
+        # ── 3. stats ribbon (replaces the terminal box) ─────────────────
+        stats = self._compute_ribbon_stats()
+        ribbon = soup.new_tag(
+            'div',
+            attrs={'class': 'jkr-ribbon', 'role': 'status', 'aria-label': 'Blog stats'},
+        )
+
+        def _ribbon_stat(prefix, value, suffix):
+            span = soup.new_tag('span')
+            if prefix:
+                span.append(soup.new_string(prefix))
+            bold = soup.new_tag('b')
+            bold.string = str(value)
+            span.append(bold)
+            if suffix:
+                span.append(soup.new_string(suffix))
+            return span
+
+        def _ribbon_dot():
+            dot = soup.new_tag('span', attrs={'class': 'jkr-r-dot'})
+            dot.string = '·'
+            return dot
+
+        days = stats['days_since_last']
+        days_label = f'{days}d' if days is not None else '—'
+
+        ribbon.append(_ribbon_stat('', stats['posts_count'], ' posts'))
+        ribbon.append(_ribbon_dot())
+        ribbon.append(_ribbon_stat('', stats['words_total'], ' words'))
+        ribbon.append(_ribbon_dot())
+        ribbon.append(_ribbon_stat('', days_label, ' since last post'))
+        ribbon.append(_ribbon_dot())
+        ribbon.append(_ribbon_stat('', stats['deploys_month'], ' deploys/mo'))
+        ribbon.append(_ribbon_dot())
+        ribbon.append(_ribbon_stat('lighthouse ', stats['lighthouse'], ''))
+
+        live = soup.new_tag('span', attrs={'class': 'jkr-r-live'})
+        live.string = '● live'
+        ribbon.append(live)
+        top.append(ribbon)
 
         # ── 4. topic index ──────────────────────────────────────────────
         topics = soup.new_tag('section', attrs={'class': 'jkr-topics'})
@@ -2987,19 +2982,16 @@ document.addEventListener('DOMContentLoaded', function() {
         topics.append(topics_grid)
 
         # ── insert ──────────────────────────────────────────────────────
-        # Strap → terminal → filter bar → hero all sit above the post grid.
-        # Each insert_before lands the node directly adjacent to posts_list,
-        # so insert in the desired final order: the last one inserted ends
-        # up closest to the grid. Hero is closest to the grid so it reads
-        # as "the top of the post stream", promoted from inside the loop.
-        posts_list.insert_before(strap)
-        posts_list.insert_before(term_section)
-        posts_list.insert_before(filter_bar)
+        # Top band → hero sit above the post grid. Each insert_before lands the
+        # node directly adjacent to posts_list, so the last one inserted ends up
+        # closest to the grid: the top band first, then the hero pulled up right
+        # above the post stream (and above the fold).
+        posts_list.insert_before(top)
         if hero is not None:
             posts_list.insert_before(hero)
         posts_list.insert_after(topics)
 
-        bits = ['strap', 'terminal', 'filter']
+        bits = ['top-band']
         if hero is not None:
             bits.append('hero')
         bits.append('topics')


### PR DESCRIPTION
Implements **PATCH-top-band-ribbon.md** from the JK Blog design project (imported via Claude Design).

## What changes

Reclaims the wasted space above the fold. The tall terminal stats box becomes a single-line **status ribbon**, the strap and filter share one row, and the featured hero is pulled up so it sits above the fold.

| Before | After (Option B) |
|---|---|
| Strap → full-width headline → 9-line terminal box → separate FILTER row (~1.8 screens) | Strap + filter on one row · headline · one-line stats ribbon · hero — one viewport band |
| 9 stats stacked in a bordered box with a dead right half | 5 stats inline in a thin ribbon; the other 4 dropped from the homepage |
| `$_` inert prompt on its own line | `● live` marker at the end of the ribbon |

**Stats kept:** `posts` · `words` · `days since last post` · `deploys/mo` · `lighthouse`.
**Dropped from homepage:** `categories`, `tags`, `vexpert.years`, `last_deploy` (low-signal here; the topic index already surfaces categories/tags).

## Implementation

**`scripts/wp_to_static_generator.py`**
- `inject_homepage_redesign()` emits `<header class="jkr-top">` — strap + `<nav class="jkr-filter">` on one row, the editorial `<h1 class="jkr-headline">`, and `<div class="jkr-ribbon">`. The old strap/terminal/filter builders are removed.
- **Single `<h1>`:** the inject now runs *before* `fix_homepage_h1()`. That fallback only converts the site-title to an `<h1>` when none exists, so it stands down once the headline h1 is present — and still acts as a fallback if the redesign can't inject (e.g. no posts list).
- `_compute_ribbon_stats()` replaces `_compute_homepage_stats()` (5 stats, instance-cached); new `_stat_last_post_days()` returns the integer the ribbon renders as `{n}d since last post`.

**`scripts/brutalist-theme.css`**
- Replaced the strap/terminal/filter rules with the Option B top-band CSS. A pure append (as the patch suggested) wasn't safe because `.jkr-strap` and `.jkr-filter` change meaning (section→inline span, block→inline nav) — leftover old properties would have applied. Updated the mobile + print blocks that referenced the removed classes. Hero / topics / card-hover rules untouched.

**`scripts/subset_fonts.py`** (not in the patch, but required)
- The strap/filter/ribbon now render in **JetBrains Mono** (were Anton). Added those selectors to the JetBrains Mono 400 subset and added `●` (U+25CF, the live marker) to its safety pad so it isn't dropped to a `.notdef`/system-font fallback. Removed the dead Anton selectors; `.jkr-headline` is covered by the existing `h1` tag selector.

## Acceptance (per the patch)
- `/` — strap + filter share the top row; exactly one `<h1>`; single-line 5-stat ribbon + `● live`; hero directly below. ✅ (structural test)
- Old multi-line terminal box gone; no categories/tags/vexpert/last_deploy on the homepage. ✅
- `/page/2/` unaffected (page-1 only). ✅ (verified — inject skips paginated)
- Mobile ≤640px: ribbon wraps, `● live` drops to its own line (CSS media query). 
- Headline uses `clamp()` — no CLS.

## Testing
- Structural test of the injected DOM: one `<h1 class="jkr-headline">`, ribbon = `75 posts · 180k words · 8d since last post · 60 deploys/mo · lighthouse 99/100  ● live`, order top-band → hero → grid, idempotency (no double-inject), `/page/2/` skipped, graceful `—` when days unknown.
- `py_compile` on all three scripts; CSS braces balanced; `tests/test_wp_faq_schema.py` (imports the generator) passes.

## ⚠️ Affects `public/`
The next build regenerates `public/index.html` with the new top band — the next auto-commit diff will show it.

## Notes
- `deploys/mo` reuses the existing `_stat_deploys_this_month()` (commits since the 1st of the month) exactly as the patch specifies — same value the old terminal block showed.
- `_stat_taxonomy_total()` / `_stat_last_deploy_age()` are now unused on the homepage path; left in place as generic helpers rather than expanding scope.
- Pairs with `PATCH-hero-and-meta.md` and `PATCH-author-and-fallback.md` (not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)