### PR TITLE
fix(homepage): editorial headline + canonical SEO h1; reliable lighthouse stat

### DIFF
--- a/scripts/subset_fonts.py
+++ b/scripts/subset_fonts.py
@@ -126,7 +126,9 @@ FONT_SPECS = (
         class_selectors=(
             '.site-title', '.entry-title',
             '.jkr-eyebrow', '.jkr-topic-count',
-            # .jkr-headline is an <h1> (covered by the tag selector above).
+            # .jkr-headline is the visible editorial headline — a <p> in Anton,
+            # so it needs an explicit selector (not covered by the h1 tags).
+            '.jkr-headline',
         ),
     ),
 

--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -2815,16 +2815,24 @@ document.addEventListener('DOMContentLoaded', function() {
             return []
 
     def _stat_lighthouse_performance(self):
-        try:
-            history = self.output_dir / 'changelog' / 'lighthouse-history.json'
-            if history.exists():
-                data = json.loads(history.read_text(encoding='utf-8'))
-                if isinstance(data, list) and data:
-                    perf = data[-1].get('performance')
-                    if isinstance(perf, (int, float)):
-                        return f'{int(perf)}/100'
-        except Exception as e:
-            print(f"   ⚠️  lighthouse: {e}")
+        # Prefer the build's own changelog copy, but fall back to the committed
+        # public/ copy: on a full rebuild static-output/changelog isn't
+        # populated until generate_changelog runs later in the pipeline, which
+        # would leave the ribbon showing '—' despite a real score existing.
+        candidates = [
+            self.output_dir / 'changelog' / 'lighthouse-history.json',
+            Path('public') / 'changelog' / 'lighthouse-history.json',
+        ]
+        for history in candidates:
+            try:
+                if history.exists():
+                    data = json.loads(history.read_text(encoding='utf-8'))
+                    if isinstance(data, list) and data:
+                        perf = data[-1].get('performance')
+                        if isinstance(perf, (int, float)):
+                            return f'{int(perf)}/100'
+            except Exception as e:
+                print(f"   ⚠️  lighthouse ({history}): {e}")
         return '—'
 
     def inject_homepage_redesign(self, soup, current_url):
@@ -2896,8 +2904,21 @@ document.addEventListener('DOMContentLoaded', function() {
         top_row.append(nav)
         top.append(top_row)
 
-        # ── 2. editorial headline (the page's single <h1>) ──────────────
-        headline = soup.new_tag('h1', attrs={'class': 'jkr-headline'})
+        # ── 2. headline ─────────────────────────────────────────────────
+        # Visible headline is the editorial line (a <p>, for design voice). The
+        # page's actual <h1> is a screen-reader-only canonical title: it keeps
+        # the keyword-rich heading fix_seo_issues.py wants (HOMEPAGE_TITLE)
+        # without that pass overwriting the editorial copy. Exactly one <h1>.
+        try:
+            from config import Config
+            seo_title = Config.HOMEPAGE_TITLE
+        except (ImportError, AttributeError):
+            seo_title = 'James Kilby — VMware, Homelab & Cloud Infrastructure Notes'
+        seo_h1 = soup.new_tag('h1', attrs={'class': 'screen-reader-text jkr-sr-title'})
+        seo_h1.string = seo_title
+        top.append(seo_h1)
+
+        headline = soup.new_tag('p', attrs={'class': 'jkr-headline'})
         headline.string = 'Field notes from a homelab that costs real money to run.'
         top.append(headline)
 


### PR DESCRIPTION
Follow-ups to the top-band ribbon (#108), after watching it deploy live. Two things deviated from the patch's intent.

## 1. Headline vs SEO `<h1>` conflict

The patch designed the `<h1>` to be the editorial line *"Field notes from a homelab that costs real money to run."* But an existing, deliberate SEO pass — `fix_seo_issues.py::fix_homepage_h1` — force-locks the homepage `<h1>` to `Config.HOMEPAGE_TITLE` (*"James Kilby — VMware, Homelab & Cloud Infrastructure Notes"*). It runs after the generator and overwrote the editorial copy on deploy.

**Resolution (chosen: keep both):** separate the visible-design role from the SEO role.
- Visible headline → `<p class="jkr-headline">` carrying the editorial line.
- The page's single `<h1>` → a **screen-reader-only** canonical title (`class="screen-reader-text jkr-sr-title"`) carrying `HOMEPAGE_TITLE`.

The SEO pass finds that `<h1>`, sees its text already equals `HOMEPAGE_TITLE`, and leaves it untouched. Result: keyword-rich heading kept for SEO, editorial copy preserved for design, still exactly one `<h1>`. `.screen-reader-text` is already hidden by the shipped theme CSS (`clip`/`position:absolute`/`1px`), verified in the deployed output.

`subset_fonts.py`: `.jkr-headline` is now a `<p>` (no longer caught by the `h1` tag selector), so it's added back to the Anton 400 subset.

## 2. `lighthouse —` in the ribbon

The deployed ribbon showed `lighthouse —`, while the old terminal block showed `96/100`. The helper is byte-identical — it reads `static-output/changelog/lighthouse-history.json`, which isn't populated until `generate_changelog` runs later in a full build. Added a fallback to the always-present committed `public/changelog/lighthouse-history.json` so the real score shows reliably regardless of build type.

## Testing
- Structural test: exactly one `<h1>` (the screen-reader canonical title = `HOMEPAGE_TITLE`); visible `<p class="jkr-headline">` = editorial line; simulated SEO pass leaves the `<h1>` unchanged; ribbon intact.
- Lighthouse helper returns a real score (`94/100`) when `output_dir` is empty (fallback path).
- `py_compile` on both scripts; `tests/test_wp_faq_schema.py` passes.

## ⚠️ Affects `public/`
Next build regenerates `public/index.html`: visible editorial headline restored, hidden canonical h1 for SEO, and the ribbon's real lighthouse score.

🤖 Generated with [Claude Code](https://claude.com/claude-code)