### PR TITLE
fix(css): collapse the wasted-space archive hero on tag/category pages

### DIFF
--- a/scripts/brutalist-theme.css
+++ b/scripts/brutalist-theme.css
@@ -1233,6 +1233,25 @@ div, section, aside, nav {
 }
 .entry-hero .entry-hero-container-inner{padding-top:1rem !important}.entry-hero.page-hero-section .entry-header{min-height:auto !important}
 
+/* Archive hero (tag / category / author / date) — Kadence gives the title
+   band `min-height:200px` + centred layout, so a one-word term name like
+   "Ansible" sits in a tall empty banner above the post grid. Collapse it to a
+   compact, left-aligned header consistent with the breadcrumb and grid below.
+   page-hero-section (single posts) is already handled by the rule above. */
+.entry-hero.post-archive-hero-section .entry-header {
+  min-height: auto !important;
+  align-items: flex-start !important;
+  justify-content: flex-start !important;
+  text-align: left !important;
+}
+.entry-hero.post-archive-hero-section .entry-hero-container-inner {
+  padding-top: 1.5rem !important;
+  padding-bottom: 0 !important;
+}
+.entry-hero.post-archive-hero-section .page-title {
+  margin: 0 !important;
+}
+
 /* ── Similar Posts Carousel (Splide) ──────────────────────────────── */
 
 /* Title case instead of uppercase for carousel card titles */


### PR DESCRIPTION
## Problem

On tag/category (and author/date) archive pages, the top is mostly empty space — same complaint as the homepage. The culprit is Kadence's archive title band:

```css
.entry-hero-container-inner .entry-header { min-height: 200px; display:flex; align-items:center; justify-content:center; text-align:center; ... }
```

So a one-word term name like **"Ansible"** sits centered in a **200px-tall empty banner** between the breadcrumb and the post grid. The existing theme override only reset this for single-post `.page-hero-section`:

```css
.entry-hero.page-hero-section .entry-header { min-height: auto !important; }
```

…leaving every `.post-archive-hero-section` (all the archives) tall.

## Fix

A compact, left-aligned override for the archive hero in `brutalist-theme.css`:

```css
.entry-hero.post-archive-hero-section .entry-header {
  min-height: auto !important;
  align-items: flex-start !important;
  justify-content: flex-start !important;
  text-align: left !important;
}
.entry-hero.post-archive-hero-section .entry-hero-container-inner {
  padding-top: 1.5rem !important;
  padding-bottom: 0 !important;
}
.entry-hero.post-archive-hero-section .page-title { margin: 0 !important; }
```

- 3-class selector + `!important` beats Kadence's 2-class rule.
- Left-aligns the title to match the breadcrumb above and the post grid below (the rest of the brutalist layout is left-aligned).
- Covers **tag, category, author, and date** archives (all use `post-archive-hero-section`).

## Notes
- Verified archive pages are `non-transparent-header`, so tightening `padding-top` doesn't pull content under a fixed header.
- CSS-only; braces balanced. Affects `public/` on the next build.
- Independent of the open homepage PRs (#108 merged, #109) — different file region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)