### PR TITLE
feat(chrome): JK monogram logo lockup + relocate footer socials to header

### DIFF
--- a/scripts/brutalist-theme.css
+++ b/scripts/brutalist-theme.css
@@ -1851,3 +1851,89 @@ body:not(.single) .posted-on time ~ time {
     margin-left: 0;
   }
 }
+
+/* ── Header logo lockup · relocated social · slim footer ──────────────
+   Injected by brand_and_relocate_social() in wp_to_static_generator.py.
+   Logo = the locked JK monogram (.jk-mark); socials move from the footer
+   into the header (desktop) + mobile drawer; the footer slims to a
+   logo + copyright line. */
+
+/* JK monogram lockup in the header branding */
+.jk-brand-lockup {
+  display: inline-flex !important;
+  align-items: center;
+  gap: 0.7rem;
+  text-decoration: none !important;
+}
+.jk-mark { display: block; flex: 0 0 auto; }
+.jk-brand-lockup .site-title-wrap {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  line-height: 1;
+}
+.jk-brand-lockup .site-title { margin: 0 !important; }
+.jk-brand-sub {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--gray-light, #7a766c);
+  margin-top: 0.34rem;
+  white-space: nowrap;
+}
+@media (max-width: 768px) { .jk-brand-sub { display: none; } }
+
+/* Social cluster — header (desktop) + mobile drawer */
+.jk-social { display: inline-flex; align-items: center; gap: 0.4rem; }
+.jk-social-header { margin-left: 1.5rem; }
+.jk-social-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--gray-mid, #262625);
+  color: #c8c5bd !important;
+  text-decoration: none !important;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+.jk-social-link:hover,
+.jk-social-link:focus {
+  border-color: var(--accent-orange) !important;
+  color: var(--accent-orange) !important;
+  opacity: 1 !important;
+}
+.jk-social-link svg { height: 16px; width: auto; fill: currentColor; display: block; }
+.jk-social-drawer { margin-top: 2rem; gap: 0.5rem; }
+
+/* Slim footer: hide the now-empty Kadence top-footer band; the bottom band
+   carries a logo + copyright row. */
+.site-top-footer-wrap { display: none !important; }
+.jk-footer-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem 1.5rem;
+  flex-wrap: wrap;
+  width: 100%;
+}
+.jk-footer-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  text-decoration: none !important;
+}
+.jk-footer-name {
+  font-family: "Anton", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--text-light) !important;
+  font-size: 1.05rem;
+}
+.jk-footer-copy {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  color: var(--gray-light, #7a766c);
+}

--- a/scripts/subset_fonts.py
+++ b/scripts/subset_fonts.py
@@ -129,6 +129,8 @@ FONT_SPECS = (
             # .jkr-headline is the visible editorial headline — a <p> in Anton,
             # so it needs an explicit selector (not covered by the h1 tags).
             '.jkr-headline',
+            # Slim-footer wordmark (Anton).
+            '.jk-footer-name',
         ),
     ),
 
@@ -148,10 +150,12 @@ FONT_SPECS = (
             # Homepage top band (Option B): strap, filter and stats ribbon all
             # render in JetBrains Mono.
             '.jkr-strap', '.jkr-filter', '.jkr-filter-label', '.jkr-ribbon',
+            # Header brand subline + slim-footer copyright line.
+            '.jk-brand-sub', '.jk-footer-copy',
         ),
-        # '●' (U+25CF) is the ribbon's "● live" marker — keep it in the subset
-        # so it doesn't fall back to system monospace.
-        safety_pad=ASCII_PRINTABLE + TYPO_PAD + CODE_PAD + '●',
+        # '●' (U+25CF) the ribbon live marker; '©' (U+00A9) the footer copyright
+        # — both outside ASCII, kept so they don't fall back to system mono.
+        safety_pad=ASCII_PRINTABLE + TYPO_PAD + CODE_PAD + '●©',
     ),
 
     # JetBrains Mono 700 — hero "LATEST" badge plus any bold inside

--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -434,6 +434,11 @@ class WordPressStaticGenerator:
         # Fix missing H1 on homepage (fallback if the redesign didn't inject)
         self.fix_homepage_h1(soup, current_url)
 
+        # Brutalist header/footer chrome (every page): JK monogram logo lockup,
+        # relocate the footer social icons into the header (+ mobile drawer),
+        # and slim the footer to a logo + copyright line.
+        self.brand_and_relocate_social(soup)
+
         # Fix byline: published + updated time elements with no separator render
         # as "By James May 29, 2017 June 1, 2026". Insert a separator + 'Updated'
         # label, and hide the updated date if it renders identical to published.
@@ -1828,6 +1833,98 @@ document.addEventListener('DOMContentLoaded', function() {
             self._brutalist_css_synced = True
         except OSError as e:
             print(f"   ⚠️  Failed to sync brutalist theme CSS: {e}")
+
+    # Locked JK monogram (designed in the JK Blog design project): black tile,
+    # orange rule, Anton "JK" reversed out in the accent. {s} = pixel size.
+    # Depends on the Anton webfont, which is loaded site-wide.
+    JK_LOGO_SVG = (
+        '<svg class="jk-mark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"'
+        ' width="{s}" height="{s}" role="img" aria-label="JK — James Kilby" focusable="false">'
+        '<rect x="4" y="4" width="92" height="92" fill="#0a0a0a" stroke="#f6821f" stroke-width="5"></rect>'
+        '<text x="50" y="52" text-anchor="middle" dominant-baseline="central"'
+        ' font-family="Anton, sans-serif" font-size="56" fill="#f6821f" letter-spacing="-2">JK</text>'
+        '</svg>'
+    )
+
+    def _jk_mark(self, size=40):
+        """Return a freshly-parsed JK monogram <svg> tag at the given pixel size."""
+        return BeautifulSoup(self.JK_LOGO_SVG.format(s=size), 'html.parser').find('svg')
+
+    def brand_and_relocate_social(self, soup):
+        """Header logo lockup + relocate footer socials + slim footer (every page).
+
+        The header and footer are global Kadence structures, so this runs on
+        every page. Each step is independent and guarded — a markup shift in one
+        area can't break the others.
+        """
+        for step in (self._inject_brand_logo, self._relocate_social, self._slim_footer):
+            try:
+                step(soup)
+            except Exception as e:
+                print(f"   ⚠️  {step.__name__}: {e}")
+
+    def _inject_brand_logo(self, soup):
+        """Prepend the JK monogram to each .brand and add a mono subline → lockup."""
+        for brand in soup.select('.site-branding a.brand'):
+            if brand.find(class_='jk-mark'):
+                continue  # idempotent
+            brand['class'] = brand.get('class', []) + ['jk-brand-lockup']
+            brand.insert(0, self._jk_mark(40))  # mark sits left of the wordmark
+            title_wrap = brand.find(class_='site-title-wrap')
+            if title_wrap and not title_wrap.find(class_='jk-brand-sub'):
+                sub = soup.new_tag('span', attrs={'class': 'jk-brand-sub'})
+                sub.string = 'VMware · Homelab · Infrastructure'
+                title_wrap.append(sub)
+
+    def _relocate_social(self, soup):
+        """Move the footer social icons into the header (and mobile drawer)."""
+        anchors = soup.select('.footer-social a')
+        if not anchors:
+            return
+        socials = []
+        for a in anchors:
+            svg = a.find('svg')
+            if not svg:
+                continue
+            socials.append((a.get('aria-label', ''), a.get('href', '#'), str(svg)))
+        if not socials:
+            return
+
+        def cluster(extra_cls):
+            items = ''.join(
+                f'<a class="jk-social-link" href="{href}" aria-label="{label}"'
+                f' rel="noopener noreferrer" target="_blank">{svg}</a>'
+                for label, href, svg in socials
+            )
+            return BeautifulSoup(f'<div class="jk-social {extra_cls}">{items}</div>',
+                                 'html.parser')
+
+        header_right = soup.find(class_='site-header-main-section-right')
+        if header_right:
+            header_right.append(cluster('jk-social-header'))
+        drawer = soup.find(class_='drawer-content')
+        if drawer:
+            drawer.append(cluster('jk-social-drawer'))
+
+        # Drop the now-empty Kadence footer social widget.
+        widget = soup.find(class_='footer-social')
+        if widget:
+            widget.decompose()
+
+    def _slim_footer(self, soup):
+        """Add a logo + copyright line to the footer credit area."""
+        info = soup.find(class_='footer-html-inner') or soup.find(class_='site-info-inner')
+        if not info or info.find(class_='jk-footer-row'):
+            return
+        year = datetime.now().year
+        row = BeautifulSoup(
+            '<div class="jk-footer-row">'
+            '<a class="jk-footer-brand" href="/" aria-label="James Kilby — home">'
+            f'{self.JK_LOGO_SVG.format(s=26)}<span class="jk-footer-name">James Kilby</span></a>'
+            f'<span class="jk-footer-copy">© {year} James Kilby · VMware vExpert</span>'
+            '</div>',
+            'html.parser')
+        info.append(row)
 
     def add_brutalist_theme_css(self, soup):
         """Add brutalist theme CSS with critical mobile CSS inlined"""


### PR DESCRIPTION
## What & why

The footer's Kadence "filled" social icons (X / LinkedIn / GitHub) sat centred in an otherwise-empty band at the very bottom and didn't fit the brutalist theme; the header "logo" was just plain **James Kilby** text.

Per the chosen direction: **socials → header**, **footer slimmed to logo + copyright**, and the **header logo becomes the locked JK monogram** designed in the JK Blog design project (black tile, orange `#f6821f` rule, Anton "JK").

Header and footer are global Kadence structures, so `brand_and_relocate_social()` runs on every page. Each step is independently guarded so a markup shift in one area can't break the others.

## Changes (`wp_to_static_generator.py`)
- **Logo lockup** — prepend the JK monogram (one self-contained inline SVG, depends only on the already-loaded Anton webfont) to each `.brand`, forming `[JK] JAMES KILBY` + a mono `VMware · Homelab · Infrastructure` subline. Applied to both desktop and mobile branding.
- **Relocate socials** — move the three icons out of the footer into the **desktop header** (top-right, next to nav) **and** the **mobile drawer**, restyled as small bordered square buttons (matching the homepage filter chips). Original icon SVGs are reused so their geometry is preserved; size/colour come from CSS. The empty Kadence `.footer-social` widget is removed.
- **Slim footer** — hide the now-empty top-footer band; the bottom band gets a `[JK] James Kilby   © <year> James Kilby · VMware vExpert` row.

## CSS (`brutalist-theme.css`)
New block for `.jk-brand-lockup` / `.jk-mark` / `.jk-brand-sub`, `.jk-social*`, and `.jk-footer-*`. Desktop socials live in the main header (auto-hidden on mobile by Kadence); the drawer copy covers mobile.

## Fonts (`subset_fonts.py`)
`.jk-brand-sub` / `.jk-footer-copy` (JetBrains Mono) and `.jk-footer-name` (Anton) get explicit subset selectors, and **`©` (U+00A9)** joins the JetBrains Mono safety pad so the copyright glyph isn't dropped to system mono (same class of fix as the ribbon's `●`).

## Testing
Ran the transforms against the **real deployed homepage and a tag page**:
- JK lockup on both desktop + mobile branding ✅
- 3 socials in the header **and** 3 in the mobile drawer ✅
- footer `.footer-social` removed; footer logo + copyright row added ✅
- idempotent (re-running doesn't duplicate) ✅

`py_compile` on all three scripts; CSS braces balanced; `tests/test_wp_faq_schema.py` passes.

## ⚠️ Affects `public/`
Header + footer change on **every page** on the next build. Since this is a `brutalist-theme.css` change too, it relies on #111's content-based CSS sync (merged) to deploy on a normal incremental build.

## Not included
The favicon/OG image still use the old assets — the JK mark is designed to double as both (the design project shows a favicon ramp). Happy to wire that up as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)