### PR TITLE
perf(critical-css): only inline from async sheets, not inline styles

### DIFF
--- a/scripts/extract_critical_css.py
+++ b/scripts/extract_critical_css.py
@@ -146,31 +146,36 @@ class CriticalCSSExtractor:
 
         return critical_css
 
+    # Stylesheets that stay render-blocking (mirrors _convert_to_async's
+    # EXCLUDED): their above-fold rules are already applied at first paint, so
+    # inlining them into the critical block is duplication that wastes the cap.
+    RENDER_BLOCKING_CSS = ('brutalist-theme', 'fonts.css', 'consolidated-inline-styles')
+
     def _extract_matching_css_rules(self, soup, selectors, file_path=None):
-        """Extract CSS rules that match the given selectors"""
+        """Extract critical rules — only from the stylesheets that load ASYNC.
+
+        Only async-converted external sheets need their above-fold rules
+        inlined. Inline <style> blocks and the render-blocking sheets
+        (RENDER_BLOCKING_CSS) are already applied before first paint, so
+        scanning them just duplicates CSS into the critical <style> and blows
+        the byte cap — crowding out the async rules that genuinely prevent
+        FOUC. So we skip both.
+        """
         critical_rules = []
 
-        # Find all style tags
-        for style_tag in soup.find_all('style'):
-            if style_tag.string:
-                css_content = style_tag.string
-                rules = self._parse_css_rules(css_content, selectors)
-                critical_rules.extend(rules)
-
-        # Find all external CSS files and extract their rules
         for link in soup.find_all('link', rel='stylesheet'):
             href = link.get('href', '')
-            if href:
-                css_path = self._resolve_css_path(href)
-                if css_path and css_path.exists():
-                    try:
-                        with open(css_path, 'r', encoding='utf-8') as f:
-                            css_content = f.read()
-                            rules = self._parse_css_rules(css_content, selectors)
-                            critical_rules.extend(rules)
-                    except Exception as e:
-                        # Silently skip if we can't read the file
-                        pass
+            if not href or any(x in href for x in self.RENDER_BLOCKING_CSS):
+                continue
+            css_path = self._resolve_css_path(href)
+            if css_path and css_path.exists():
+                try:
+                    with open(css_path, 'r', encoding='utf-8') as f:
+                        rules = self._parse_css_rules(f.read(), selectors)
+                        critical_rules.extend(rules)
+                except Exception:
+                    # Silently skip if we can't read the file
+                    pass
 
         # Minify each rule separately, then keep whole rules until the size
         # cap is reached. Each entry in critical_rules is a complete,

--- a/tests/test_extract_critical_css.py
+++ b/tests/test_extract_critical_css.py
@@ -1,5 +1,11 @@
 """Tests for critical-CSS extraction — above all that the size cap can never
-produce unbalanced braces (the pre-2026-06 slice-at-15000-chars bug)."""
+produce unbalanced braces (the pre-2026-06 slice-at-15000-chars bug).
+
+Critical CSS is extracted only from the external stylesheets that get
+converted to async loading; inline <style> blocks and the render-blocking
+sheets are already applied at first paint, so they're skipped (see
+CriticalCSSExtractor.RENDER_BLOCKING_CSS). These tests therefore feed CSS via
+an external <link>, which also exercises _resolve_css_path."""
 
 from bs4 import BeautifulSoup
 
@@ -18,44 +24,57 @@ def _brace_depth_ok(css: str) -> bool:
     return depth == 0
 
 
-def _soup(css: str) -> BeautifulSoup:
-    return BeautifulSoup(
-        f'<html><head><style>{css}</style></head>'
-        f'<body><main><h1>t</h1><p>x</p></main></body></html>',
+def _extract(css: str, selectors, tmp_path, file_path=None):
+    """Write css to an external sheet, link it, and run the extractor."""
+    (tmp_path / 'styles.css').write_text(css, encoding='utf-8')
+    soup = BeautifulSoup(
+        '<html><head><link rel="stylesheet" href="/styles.css"></head>'
+        '<body><main><h1>t</h1><p>x</p></main></body></html>',
         'html.parser')
-
-
-def test_small_input_passes_through():
     ex = CriticalCSSExtractor()
-    out = ex._extract_matching_css_rules(_soup('p{color:red}h1{margin:0}'), {'p', 'h1'})
+    ex.public_dir = tmp_path
+    return ex, ex._extract_matching_css_rules(soup, selectors, file_path)
+
+
+def test_small_input_passes_through(tmp_path):
+    ex, out = _extract('p{color:red}h1{margin:0}', {'p', 'h1'}, tmp_path)
     assert 'color:red' in out
     assert 'margin:0' in out
     assert ex.css_truncated == 0
 
 
-def test_truncation_keeps_braces_balanced():
+def test_render_blocking_sheets_are_skipped(tmp_path):
+    # brutalist-theme.css loads render-blocking, so its rules must NOT be
+    # re-inlined into the critical block.
+    (tmp_path / 'brutalist-theme.css').write_text('p{color:red}', encoding='utf-8')
+    soup = BeautifulSoup(
+        '<html><head><link rel="stylesheet" href="/brutalist-theme.css"></head>'
+        '<body><main><p>x</p></main></body></html>',
+        'html.parser')
     ex = CriticalCSSExtractor()
+    ex.public_dir = tmp_path
+    assert ex._extract_matching_css_rules(soup, {'p'}) == ''
+
+
+def test_truncation_keeps_braces_balanced(tmp_path):
     # Enough rules to blow the cap, with the boundary landing inside @media.
     rules = ''.join(f'p{{padding:{i}px;color:#0{i % 10}{i % 10}}}' for i in range(300))
     media = '@media (max-width:600px){' + ''.join(f'h1{{margin:{i}px}}' for i in range(600)) + '}'
-    out = ex._extract_matching_css_rules(_soup(rules + media), {'p', 'h1'}, 'test.html')
+    ex, out = _extract(rules + media, {'p', 'h1'}, tmp_path, 'test.html')
 
     assert 0 < len(out) <= ex.max_critical_css
     assert _brace_depth_ok(out), 'truncated critical CSS has unbalanced braces'
     assert ex.css_truncated == 1
 
 
-def test_media_query_rules_are_wrapped():
-    ex = CriticalCSSExtractor()
-    out = ex._extract_matching_css_rules(
-        _soup('@media (max-width:600px){h1{margin:0}}'), {'h1'})
+def test_media_query_rules_are_wrapped(tmp_path):
+    ex, out = _extract('@media (max-width:600px){h1{margin:0}}', {'h1'}, tmp_path)
     assert '@media' in out
     assert _brace_depth_ok(out)
 
 
-def test_keyframes_are_skipped():
-    ex = CriticalCSSExtractor()
-    out = ex._extract_matching_css_rules(
-        _soup('@keyframes spin{from{opacity:0}to{opacity:1}}p{color:red}'), {'p'})
+def test_keyframes_are_skipped(tmp_path):
+    ex, out = _extract('@keyframes spin{from{opacity:0}to{opacity:1}}p{color:red}',
+                       {'p'}, tmp_path)
     assert '@keyframes' not in out
     assert 'color:red' in out


### PR DESCRIPTION
## The warning

The build logs this on the homepage (and was getting worse):
```
⚠️  Critical CSS over 15000B cap: dropped 198/289 rules (28829B)
```

## Root cause

`_extract_matching_css_rules` scanned **all inline `<style>` blocks** (Kadence's large per-page CSS) **and every external sheet**, then re-inlined the matches into a fresh `<style id="critical-css">`. But:
- inline `<style>` blocks are **already applied at first paint** (they stay in the page), and
- the render-blocking sheets (`brutalist-theme.css`, `fonts.css`, `consolidated-inline-styles`) are **already applied at first paint** too.

So re-inlining them was pure **duplication** that blew the 15 KB byte cap and crowded out the rules that *do* need inlining: the above-fold rules from the sheets being converted to **async** loading (the only ones that would otherwise FOUC).

A per-source measurement on the live homepage confirmed it — the bulk (~28 KB / 167 rules) was the inline `<style>` blocks.

## Fix

Scan **only the async-bound external stylesheets** — skip inline `<style>` and `RENDER_BLOCKING_CSS`. 

**This is safe / no FOUC change:** nothing is removed from the page; the skipped rules still load via their render-blocking source. The 15 KB critical budget simply goes to the rules that genuinely need it instead of duplicating already-applied CSS.

Measured before/after on the live homepage (build-time simulation):

| | dropped |
|---|---|
| before | ~44 KB (320 rules) |
| after | ~16 KB (127 rules) |

…and the *kept* rules are now the meaningful async ones, not duplicated inline CSS.

## Tests
Updated `tests/test_extract_critical_css.py` to feed CSS via an external `<link>` (the real path — also exercises `_resolve_css_path`) and added a test asserting render-blocking sheets are skipped. All 5 pass.

## Residual (not addressed here)
After this, ~16 KB of *genuine* async Kadence rules still exceed the 15 KB cap and get dropped. That's pre-existing and low-risk (the render-blocking `brutalist-theme.css` covers the visible styling). Fully eliminating it would mean tightening the above-fold selector heuristic (it currently matches some non-above-fold rules, e.g. `footer.min.css`) or nudging the cap — happy to take that on as a follow-up if you want the warning gone entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)