### PR TITLE
perf: fix stale-image reuse, browser cache TTLs, and build waste

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -449,21 +449,12 @@ jobs:
           WEBP_AFTER=$(find ./static-output/wp-content/uploads -type f -name "*.webp" | wc -l | xargs)
           echo "✅ Copied $((AVIF_AFTER - AVIF_BEFORE)) AVIF and $((WEBP_AFTER - WEBP_BEFORE)) WebP files from previous build"
 
-          # Replace originals with previously-optimized versions if they are smaller
-          REPLACED=0
-          find ./static-output/wp-content/uploads -type f \( -name "*.png" -o -name "*.jpg" -o -name "*.jpeg" \) | while read new_img; do
-            rel_path="${new_img#./static-output/}"
-            old_img="public/$rel_path"
-            if [ -f "$old_img" ]; then
-              new_size=$(stat -f%z "$new_img" 2>/dev/null || stat -c%s "$new_img" 2>/dev/null)
-              old_size=$(stat -f%z "$old_img" 2>/dev/null || stat -c%s "$old_img" 2>/dev/null)
-              if [ "$old_size" -lt "$new_size" ]; then
-                cp "$old_img" "$new_img"
-                REPLACED=$((REPLACED + 1))
-              fi
-            fi
-          done
-          echo "✅ Reused $REPLACED optimized original images from previous build"
+          # NOTE: originals are intentionally NOT copied from the previous
+          # build. Nothing in the pipeline recompresses originals in place,
+          # so a size difference between public/ and static-output can only
+          # mean the image was replaced in WordPress under the same filename
+          # — copying the old (smaller) file back served stale content and
+          # the rsynced derivatives above then never regenerated.
 
           # Count how many images still need modern formats
           TOTAL_IMAGES=$(find ./static-output/wp-content/uploads -type f \( -name "*.png" -o -name "*.jpg" -o -name "*.jpeg" \) | wc -l | xargs)
@@ -766,7 +757,11 @@ jobs:
             # scripts (generate_changelog.py, generate_stats_page.py). Their
             # .br/.gz sidecars in public/ are always stale because the scripts
             # update the source files AFTER the main Brotli pass.
-            case "$rel" in changelog/*|stats/*) STALE=$((STALE + 1)); continue;; esac
+            # HTML sidecars are skipped too: static-output HTML holds absolute
+            # URLs while public/ holds the staging-converted relative form, so
+            # the cmp below could never match — and HTML is compressed only in
+            # the final public/ pass now (see the recompress step).
+            case "$rel" in changelog/*|stats/*|*.html.br|*.html.gz) STALE=$((STALE + 1)); continue;; esac
 
             # Derive the uncompressed original path
             original="${target%.br}"
@@ -786,9 +781,15 @@ jobs:
           echo "   ♻️  Reused $REUSED compressed files from previous build (skipped $STALE stale)"
         fi
 
-        # Run compression — produces .br and .gz alongside each original
-        # Files with existing newer .br/.gz will be skipped automatically
-        python3 scripts/brotli_compress.py ./static-output || {
+        # Run compression — produces .br and .gz alongside each original.
+        # Files with existing newer .br/.gz will be skipped automatically.
+        # --skip-html: convert_to_staging.py rewrites every HTML file after
+        # this step (absolute → relative URLs), which invalidated the just-
+        # built sidecars and forced the final recompress to redo the whole
+        # HTML corpus at q11 — HTML was compressed twice per build. HTML is
+        # now compressed once, in the final public/ pass. Missing HTML
+        # sidecars are fine for the validators (missing .br is a soft skip).
+        python3 scripts/brotli_compress.py ./static-output --skip-html || {
           echo "⚠️  Compression failed (non-blocking)"
           echo "BROTLI_COUNT=0" >> $GITHUB_ENV
           echo "GZIP_COUNT=0" >> $GITHUB_ENV
@@ -1036,18 +1037,17 @@ jobs:
         echo "📊 Generating stats page..."
         PLAUSIBLE_SHARE_LINK="${{ secrets.PLAUSIBLE_SHARE_LINK }}" python3 scripts/generate_stats_page.py || echo "⚠️  Stats page generation failed (non-blocking)"
 
-        # Recompress the WHOLE tree, not just changelog/stats. The main Brotli
-        # pass ran on static-output BEFORE the "Prepare output for deployment"
-        # step rewrote HTML/CSS in place — convert_to_staging.py converts
-        # absolute → relative URLs and only writes files it actually changes.
-        # Every rewritten file's .br/.gz sidecar is now stale (it still encodes
-        # the absolute-URL bytes the validators checked). A full-tree pass
-        # regenerates exactly those changed sidecars — brotli_compress.py skips
-        # any file whose .br is already newer than its source (mtime check) — and
-        # also covers the just-generated changelog/stats pages and security.txt.
-        # Without this, Cloudflare would serve precompressed HTML that no longer
-        # matches the deployed source.
-        echo "🗜️  Recompressing files changed after the main Brotli pass (URL rewrite, changelog, stats)..."
+        # Compress the WHOLE tree, not just changelog/stats. This is the ONLY
+        # pass that compresses HTML: the main Brotli pass ran on static-output
+        # with --skip-html because convert_to_staging.py rewrites HTML
+        # (absolute → relative URLs) during "Prepare output for deployment",
+        # which would invalidate any HTML sidecars built earlier. Non-HTML
+        # files keep their pass-1 sidecars — brotli_compress.py skips any file
+        # whose .br is already newer than its source (mtime check) — and this
+        # pass also covers the just-generated changelog/stats pages and
+        # security.txt. If this step fails, HTML ships without sidecars and
+        # Cloudflare compresses on the fly (slower, but never mismatched).
+        echo "🗜️  Compressing HTML + files changed after the main Brotli pass (URL rewrite, changelog, stats)..."
         python3 scripts/brotli_compress.py public/ || echo "⚠️  Recompression failed (non-blocking)"
       continue-on-error: true
 
@@ -1170,11 +1170,11 @@ jobs:
     
     # Soft-404 KV cleanup step removed — the worker's isKnownContentPath
     # guard (see _worker.template.js) prevents new ghost entries at write
-    # time, and the "Purge all HTML from KV cache" step below already wipes
-    # everything on each deploy. scripts/purge_soft404_kv_cache.py is kept
-    # in the repo for emergency ad-hoc use.
+    # time (it runs BEFORE the KV lookup, so even a stale ghost entry is
+    # never served). scripts/purge_soft404_kv_cache.py is kept in the repo
+    # for emergency ad-hoc use.
 
-    - name: Purge all HTML from KV cache
+    - name: Purge changed HTML from KV cache
       id: kv_purge
       if: success()
       env:
@@ -1188,7 +1188,7 @@ jobs:
         # and we skip the wait entirely — the existing deployment is still live.
         PUSHED_SHA: ${{ steps.commit_push.outputs.pushed_sha }}
       run: |
-        echo "🗑️ Purging all HTML entries from Workers KV cache..."
+        echo "🗑️ Purging changed HTML entries from Workers KV cache..."
 
         if [ -z "${{ secrets.CACHE_PURGE_TOKEN }}" ]; then
           echo "ℹ️  CACHE_PURGE_TOKEN not set, skipping KV cache purge"
@@ -1197,8 +1197,15 @@ jobs:
         fi
 
         if [ -z "$PUSHED_SHA" ]; then
-          echo "ℹ️  No new commit was pushed — previous deployment still live, purging immediately."
-        elif [ -n "$CLOUDFLARE_API_TOKEN" ] && [ -n "$CLOUDFLARE_ACCOUNT_ID" ]; then
+          # Nothing was committed, so every KV entry is still byte-identical
+          # to what Pages serves — purging would only force cold-cache MISSes.
+          # (If a previous run's purge failed and you need a manual flush:
+          # scripts/purge_html_kv_cache.py, or POST /.purge?all=true.)
+          echo "ℹ️  No new commit was pushed — public/ unchanged, skipping KV purge."
+          exit 0
+        fi
+
+        if [ -n "$CLOUDFLARE_API_TOKEN" ] && [ -n "$CLOUDFLARE_ACCOUNT_ID" ]; then
           echo "⏳ Waiting for Cloudflare Pages deployment of ${PUSHED_SHA:0:7} to complete..."
           MAX_ATTEMPTS=18   # 18 × 10s = 180s max
           ATTEMPT=0
@@ -1260,18 +1267,77 @@ jobs:
           sleep 30
         fi
 
-        RESPONSE=$(curl -s -w "\n%{http_code}" \
-          -X POST "https://jameskilby.co.uk/.purge?all=true" \
-          -H "X-Purge-Token: ${{ secrets.CACHE_PURGE_TOKEN }}")
+        # Selective purge: only pages whose rendered bytes changed in the
+        # pushed commit need purging — every other KV entry is still
+        # byte-identical to what Pages now serves (KV values are raw HTML
+        # bodies; worker headers/TTLs are applied at serve time, so even a
+        # worker change doesn't invalidate them). Previously every deploy
+        # wiped the whole namespace, forcing a cold MISS for every page's
+        # next visitor. Above MAX_SELECTIVE changed pages (site-wide CSS/
+        # template rewrites) purge-all is fewer requests, so fall back.
+        MAX_SELECTIVE=30
+        CHANGED_HTML=$(git diff-tree --no-commit-id --name-only -r "$PUSHED_SHA" -- public/ | grep '\.html$' || true)
+        CHANGED_COUNT=$(printf '%s' "$CHANGED_HTML" | grep -c . || true)
 
-        HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-        BODY=$(echo "$RESPONSE" | sed '$d')
+        PURGE_METHOD="selective"
+        PURGED_COUNT=0
+        if [ "$CHANGED_COUNT" -eq 0 ]; then
+          echo "ℹ️  No HTML files changed in ${PUSHED_SHA:0:7} — nothing to purge."
+          PURGE_METHOD="none"
+        elif [ "$CHANGED_COUNT" -gt "$MAX_SELECTIVE" ]; then
+          echo "ℹ️  $CHANGED_COUNT HTML files changed (> $MAX_SELECTIVE) — using purge-all."
+          PURGE_METHOD="all"
+        fi
 
-        if [ "$HTTP_CODE" = "200" ]; then
-          PURGED_COUNT=$(echo "$BODY" | jq -r '.count // 0')
-          echo "✅ Purged $PURGED_COUNT entries from KV cache"
-        else
-          echo "⚠️  Purge-all failed (HTTP $HTTP_CODE): $BODY"
+        if [ "$PURGE_METHOD" = "selective" ]; then
+          echo "🎯 Selectively purging $CHANGED_COUNT changed HTML page(s)..."
+          OK=0
+          FAILED=0
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            rel="${f#public/}"
+            # The worker keys the KV cache on the raw request pathname, and
+            # isKnownContentPath accepts both slash forms — so a page can be
+            # cached under /dir and /dir/. Purge both variants.
+            case "$rel" in
+              index.html)   paths="/ /index.html" ;;
+              */index.html) d="/${rel%/index.html}"; paths="$d $d/" ;;
+              *)            paths="/$rel" ;;
+            esac
+            for p in $paths; do
+              CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+                -X POST "https://jameskilby.co.uk/.purge?path=$p" \
+                -H "X-Purge-Token: ${{ secrets.CACHE_PURGE_TOKEN }}")
+              if [ "$CODE" = "200" ]; then
+                OK=$((OK + 1))
+              else
+                echo "   ⚠️  Purge failed for $p (HTTP $CODE)"
+                FAILED=$((FAILED + 1))
+              fi
+            done
+          done <<< "$CHANGED_HTML"
+          PURGED_COUNT=$OK
+          echo "✅ Purged $OK path variant(s), $FAILED failed"
+          if [ "$FAILED" -gt 0 ]; then
+            echo "⚠️  Some selective purges failed — falling back to purge-all for safety."
+            PURGE_METHOD="all"
+          fi
+        fi
+
+        if [ "$PURGE_METHOD" = "all" ]; then
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -X POST "https://jameskilby.co.uk/.purge?all=true" \
+            -H "X-Purge-Token: ${{ secrets.CACHE_PURGE_TOKEN }}")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            PURGED_COUNT=$(echo "$BODY" | jq -r '.count // 0')
+            echo "✅ Purged $PURGED_COUNT entries from KV cache"
+          else
+            echo "⚠️  Purge-all failed (HTTP $HTTP_CODE): $BODY"
+          fi
         fi
 
         # Add to summary
@@ -1279,7 +1345,7 @@ jobs:
         echo "## 🗑️ KV Cache Purged" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "- **Entries Purged:** ${PURGED_COUNT:-unknown}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Method:** Purge all" >> $GITHUB_STEP_SUMMARY
+        echo "- **Method:** $PURGE_METHOD ($CHANGED_COUNT HTML files changed)" >> $GITHUB_STEP_SUMMARY
       continue-on-error: true
 
     # Cloudflare zone HTTP cache purge for HTML removed — verified via live

--- a/_headers
+++ b/_headers
@@ -40,10 +40,11 @@
 # default and browsers couldn't soft-cache repeat visits.
 # `/2*` is greedy and catches every year-prefixed post URL; no other
 # top-level path on this site starts with `/2`.
-# Cloudflare Pages applies _headers rules AFTER worker responses,
-# so this also overrides the worker's smart-TTL Cache-Control —
-# `_headers` is the single source of truth for the browser cache
-# budget. The worker's KV cache continues to use its own absolute-
+# NOTE: Cloudflare Pages does NOT layer _headers rules onto Response
+# objects built by _worker.js — only env.ASSETS.fetch() results get
+# them. The worker mirrors this 300s browser budget itself via
+# BROWSER_HTML_CACHE_CONTROL in _worker.template.js; keep the two in
+# sync. The worker's KV cache continues to use its own absolute-
 # expiry TTLs independently.
 /2*
   Cache-Control: public, max-age=300, must-revalidate
@@ -74,17 +75,21 @@
   ! X-Frame-Options
   ! Permissions-Policy
 
-# Pipeline-emitted CSS — long cache but allow revalidation since
-# brutalist-theme.css / consolidated-inline-styles.min.css are not
-# content-hashed and may be re-emitted with new contents.
+# Pipeline-emitted CSS/JS — brutalist-theme.css, per-page critical CSS
+# and search/UI JS are NOT content-hashed and are re-emitted with new
+# contents across builds, and no purge step covers these prefixes. A
+# year-long max-age (without a revalidation directive) meant repeat
+# visitors could hold stale styling/behaviour for up to a year after a
+# design change. One hour bounds that window; bump back up only if
+# filenames gain content hashes.
 /assets/css/*
-  Cache-Control: public, max-age=31536000
+  Cache-Control: public, max-age=3600
   ! Content-Security-Policy
   ! X-Frame-Options
   ! Permissions-Policy
 
 /assets/js/*
-  Cache-Control: public, max-age=31536000
+  Cache-Control: public, max-age=3600
   ! Content-Security-Policy
   ! X-Frame-Options
   ! Permissions-Policy

--- a/_worker.template.js
+++ b/_worker.template.js
@@ -34,6 +34,15 @@ const PATH_MANIFEST = PATH_MANIFEST_RAW ? new Set(PATH_MANIFEST_RAW) : null;
 // same as before, fail-open.
 const CSP_FROM_HEADERS = /*__CSP_FROM_HEADERS_START__*/null/*__CSP_FROM_HEADERS_END__*/;
 
+// Browser cache budget for HTML — matches the `_headers` `/*.html` and `/2*`
+// rules (max-age=300, must-revalidate). Kept separate from the smart KV TTL
+// (getTTL): `_headers` rules are NOT layered onto worker-built Responses, so
+// this header is what browsers actually see on HIT/MISS. A short browser
+// window keeps deploys and KV purges meaningful for repeat visitors;
+// revalidation after 300s rides the ETag/Last-Modified 304 path, which is
+// cheap. The KV/edge caches keep their own longer absolute-expiry TTLs.
+const BROWSER_HTML_CACHE_CONTROL = 'public, max-age=300, must-revalidate';
+
 /**
  * Is this path a known content URL?
  *
@@ -261,7 +270,6 @@ async function handleKVCache(request, env, ctx, path, hostname) {
     const cachedMeta = (cachedRes && cachedRes.metadata) || {};
 
     if (cached) {
-      const ttl = getTTL(path);
       const etag = await computeETag(cached);
       const lastModified = cachedMeta.cached_at
         ? new Date(cachedMeta.cached_at).toUTCString()
@@ -280,7 +288,7 @@ async function handleKVCache(request, env, ctx, path, hostname) {
           headers: {
             'ETag': etag,
             'Last-Modified': lastModified,
-            'Cache-Control': `public, max-age=${ttl}`,
+            'Cache-Control': BROWSER_HTML_CACHE_CONTROL,
             'X-Cache-Status': 'HIT-304',
             'X-Worker': 'advanced-worker-kv',
             ...getSecurityHeaders(hostname)
@@ -291,7 +299,7 @@ async function handleKVCache(request, env, ctx, path, hostname) {
       return new Response(cached, {
         headers: {
           'Content-Type': 'text/html; charset=utf-8',
-          'Cache-Control': `public, max-age=${ttl}`,
+          'Cache-Control': BROWSER_HTML_CACHE_CONTROL,
           'ETag': etag,
           'Last-Modified': lastModified,
           'X-Cache-Status': 'HIT',
@@ -344,7 +352,7 @@ async function handleKVCache(request, env, ctx, path, hostname) {
         headers: {
           'ETag': etag,
           'Last-Modified': lastModified,
-          'Cache-Control': `public, max-age=${ttl}`,
+          'Cache-Control': BROWSER_HTML_CACHE_CONTROL,
           'X-Cache-Status': 'MISS-304',
           'X-Worker': 'advanced-worker-kv',
           ...getSecurityHeaders(hostname)
@@ -355,7 +363,7 @@ async function handleKVCache(request, env, ctx, path, hostname) {
       status: response.status,
       headers: {
         'Content-Type': 'text/html; charset=utf-8',
-        'Cache-Control': `public, max-age=${ttl}`,
+        'Cache-Control': BROWSER_HTML_CACHE_CONTROL,
         'ETag': etag,
         'Last-Modified': lastModified,
         'X-Cache-Status': 'MISS',
@@ -396,6 +404,9 @@ async function handleCacheAPI(request, env, ctx, path, hostname = '') {
 
   if (response) {
     const newHeaders = new Headers(response.headers);
+    // The stored copy carries the smart edge TTL — swap in the browser
+    // budget before serving (same split as the KV path).
+    newHeaders.set('Cache-Control', BROWSER_HTML_CACHE_CONTROL);
     newHeaders.set('X-Cache-Status', 'HIT');
     newHeaders.set('X-Worker', 'advanced-worker-cache-api');
 
@@ -417,16 +428,11 @@ async function handleCacheAPI(request, env, ctx, path, hostname = '') {
     const responseToCache = response.clone();
     const newHeaders = new Headers(responseToCache.headers);
 
-    // Always apply our smart TTL (Cache-Control) to HTML, overriding any
-    // upstream default. The previous `if (!has(...))` guard was meant to
-    // respect the `_headers /*.html` rule (max-age=300), but that rule only
-    // matches literal `.html` paths — pretty-URL post permalinks like
-    // `/2017/05/foo/` skipped it entirely and inherited Cloudflare Pages'
-    // `max-age=0, must-revalidate` default, leaving browsers unable to
-    // soft-cache repeat visits. Aligning the browser cache with the smart
-    // KV TTL gives readers proper local caching without violating the
-    // "absolute-expiry, view-counts don't reset the clock" invariant
-    // (browser cache is a separate clock from the KV cache).
+    // The stored copy keeps the smart TTL — caches.default uses the
+    // response's Cache-Control for edge retention, so this is what gives
+    // the fallback path its 5min/15min/1hr lifetimes. Browsers get the
+    // separate 300s budget below (Pages' `_headers` rules do not apply to
+    // worker-built Responses, so this header is what clients actually see).
     newHeaders.set('Cache-Control', `public, max-age=${getTTL(path)}`);
 
     newHeaders.set('X-Cache-Status', 'MISS');
@@ -437,7 +443,7 @@ async function handleCacheAPI(request, env, ctx, path, hostname = '') {
     Object.entries(securityHeaders).forEach(([key, value]) => {
       newHeaders.set(key, value);
     });
-    
+
     const cachedResponse = new Response(responseToCache.body, {
       status: responseToCache.status,
       headers: newHeaders
@@ -451,9 +457,11 @@ async function handleCacheAPI(request, env, ctx, path, hostname = '') {
         .catch(err => console.error('Cache API write failed:', err))
     );
 
+    const clientHeaders = new Headers(newHeaders);
+    clientHeaders.set('Cache-Control', BROWSER_HTML_CACHE_CONTROL);
     return new Response(response.body, {
       status: response.status,
-      headers: newHeaders
+      headers: clientHeaders
     });
   }
   

--- a/scripts/brotli_compress.py
+++ b/scripts/brotli_compress.py
@@ -24,16 +24,22 @@ except ImportError:
     sys.exit(1)
 
 class BrotliCompressor:
-    def __init__(self, public_dir, quality=11):
+    def __init__(self, public_dir, quality=11, skip_extensions=None):
         """
         Initialize Brotli compressor
-        
+
         Args:
             public_dir: Path to public directory
             quality: Compression quality (0-11, default 11 for max compression)
+            skip_extensions: iterable of suffixes (e.g. ('.html',)) to leave
+                uncompressed in this run. Used by the deploy workflow's first
+                pass: convert_to_staging.py rewrites every HTML file after
+                that pass, so compressing HTML there was pure wasted q11 work
+                — the final public/ pass covers HTML instead.
         """
         self.public_dir = Path(public_dir)
         self.quality = quality
+        self.skip_extensions = {e.lower() for e in (skip_extensions or ())}
         self.stats = {
             'files_processed': 0,
             'files_compressed': 0,
@@ -62,6 +68,8 @@ class BrotliCompressor:
         """Check if file should be compressed"""
         # Check extension
         if file_path.suffix.lower() not in self.compressible_extensions:
+            return False
+        if file_path.suffix.lower() in self.skip_extensions:
             return False
         
         # Skip already compressed files
@@ -153,6 +161,8 @@ class BrotliCompressor:
     def should_compress_gzip(self, file_path):
         """Check if file should be gzip compressed"""
         if file_path.suffix.lower() not in self.compressible_extensions:
+            return False
+        if file_path.suffix.lower() in self.skip_extensions:
             return False
         if file_path.suffix in ('.br', '.gz'):
             return False
@@ -328,28 +338,36 @@ class BrotliCompressor:
             print(f"   Average compression: {gz_ratio:.1f}%")
 
 def main():
-    if len(sys.argv) < 2:
-        print("Usage: python3 brotli_compress.py <public_directory> [quality]")
+    skip_html = '--skip-html' in sys.argv[1:]
+    args = [a for a in sys.argv[1:] if a != '--skip-html']
+
+    if not args:
+        print("Usage: python3 brotli_compress.py <public_directory> [quality] [--skip-html]")
         print("\nArguments:")
         print("  public_directory  Path to the static site directory (e.g., ./public)")
         print("  quality          Compression quality 0-11 (default: 11, max compression)")
+        print("  --skip-html      Leave .html files uncompressed (for passes that run")
+        print("                   before a later step rewrites HTML)")
         print("\nExample:")
         print("  python3 brotli_compress.py ./public")
         print("  python3 brotli_compress.py ./public 9  # Faster compression")
         sys.exit(1)
-    
-    public_dir = sys.argv[1]
-    quality = int(sys.argv[2]) if len(sys.argv) > 2 else 11
-    
+
+    public_dir = args[0]
+    quality = int(args[1]) if len(args) > 1 else 11
+
     if not Path(public_dir).exists():
         print(f"❌ Error: Directory '{public_dir}' does not exist")
         sys.exit(1)
-    
+
     if quality < 0 or quality > 11:
         print(f"❌ Error: Quality must be between 0 and 11 (got {quality})")
         sys.exit(1)
-    
-    compressor = BrotliCompressor(public_dir, quality)
+
+    compressor = BrotliCompressor(
+        public_dir, quality,
+        skip_extensions=('.html',) if skip_html else None
+    )
     compressor.compress_directory()
     
     print("\n✅ Brotli + Gzip compression complete!")

--- a/scripts/enhance_html_performance.py
+++ b/scripts/enhance_html_performance.py
@@ -9,6 +9,26 @@ from pathlib import Path
 from bs4 import BeautifulSoup
 import re
 
+try:
+    from config import Config
+    _SITE_ORIGIN = Config.TARGET_DOMAIN.rstrip('/')
+except ImportError:
+    _SITE_ORIGIN = 'https://jameskilby.co.uk'
+
+
+def normalize_self_href(href):
+    """Map absolute same-site URLs to their relative form.
+
+    Different pipeline stages leave hrefs in different forms — e.g.
+    restore_seeded_urls keeps `/wp-content/...` link hrefs relative but
+    absolutifies srcset/imagesrcset. Comparing hrefs without normalising
+    made duplicate detection miss existing tags (two identical LCP
+    preloads shipped on every page).
+    """
+    if href and href.startswith(_SITE_ORIGIN + '/'):
+        return href[len(_SITE_ORIGIN):]
+    return href
+
 
 class HTMLPerformanceEnhancer:
     """Enhance HTML files with performance optimizations"""
@@ -382,7 +402,15 @@ class HTMLPerformanceEnhancer:
                             self._pick_lcp_preload(first_img)
                         )
 
-                        existing = soup.find('link', rel='preload', href=preload_href)
+                        # Compare normalised hrefs — preload_href derives from
+                        # the (absolutified) srcset while an existing preload's
+                        # href may be relative; an exact-string find misses it.
+                        target = normalize_self_href(preload_href)
+                        existing = next(
+                            (lnk for lnk in soup.find_all('link', rel='preload')
+                             if normalize_self_href(lnk.get('href', '')) == target),
+                            None
+                        )
                         if not existing:
                             preload = soup.new_tag('link')
                             preload['rel'] = 'preload'

--- a/scripts/extract_critical_css.py
+++ b/scripts/extract_critical_css.py
@@ -30,6 +30,12 @@ class CriticalCSSExtractor:
         # inline so the browser doesn't pay a render-blocking round-trip for
         # critical CSS. Measured: p90 page produces ~15 KB of critical CSS.
         self.max_inline_critical = 16384
+        # Tokenized stylesheets keyed by path — the extractor runs once per
+        # HTML page, and without this every page re-read and re-tokenized
+        # every linked sheet (N pages × M sheets), the dominant cost of the
+        # critical-CSS phase. Plain dict: worst case under the thread pool
+        # is a duplicate parse, never a wrong result.
+        self._sheet_cache = {}
 
     def process_all_files(self):
         """Process all HTML files in the public directory"""
@@ -169,13 +175,9 @@ class CriticalCSSExtractor:
                 continue
             css_path = self._resolve_css_path(href)
             if css_path and css_path.exists():
-                try:
-                    with open(css_path, 'r', encoding='utf-8') as f:
-                        rules = self._parse_css_rules(f.read(), selectors)
-                        critical_rules.extend(rules)
-                except Exception:
-                    # Silently skip if we can't read the file
-                    pass
+                nodes = self._get_sheet_nodes(css_path)
+                if nodes:
+                    critical_rules.extend(self._filter_rules(nodes, selectors))
 
         # Minify each rule separately, then keep whole rules until the size
         # cap is reached. Each entry in critical_rules is a complete,
@@ -203,24 +205,37 @@ class CriticalCSSExtractor:
     def _parse_css_rules(self, css_content, critical_selectors):
         """Parse CSS and extract rules matching critical selectors.
 
+        Thin wrapper over _tokenize_css_rules (selector-independent, cached
+        per stylesheet via _get_sheet_nodes) + _filter_rules (cheap per-page
+        matching). Kept as the single entry point for raw CSS strings.
+        """
+        return self._filter_rules(self._tokenize_css_rules(css_content),
+                                  critical_selectors)
+
+    def _tokenize_css_rules(self, css_content, _strip_comments=True):
+        """Tokenize CSS into (selector, body) nodes — no selector matching.
+
         Uses a brace-depth tokenizer rather than a regex so that nested
         at-rules (@media, @supports) and minified CSS are handled correctly.
 
-        Strategy:
-          - @keyframes / @font-face blocks are skipped entirely (their inner
-            tokens are not selector-based and would produce false matches).
-          - @media / @supports / @layer blocks are recursed into; only the
-            matching inner rules are kept, wrapped in the at-rule header.
-          - @import / @charset / @namespace end with ';' before the next '{';
-            these are skipped by detecting the semicolon first.
-          - Regular rules are tested against critical_selectors and included
-            when they match.
-        """
-        # Strip comments before parsing so that '{' / '}' inside comments
-        # don't confuse the depth tracker.
-        css_content = re.sub(r'/\*.*?\*/', '', css_content, flags=re.DOTALL)
+        Node shapes:
+          - Plain rule: (selector, block_content_str)
+          - Conditional group (@media, @supports, @layer …):
+            (at_selector, [inner nodes]) — body is a list, recursed into.
 
-        rules = []
+        Skipped entirely:
+          - @keyframes / @font-face blocks (their inner tokens are not
+            selector-based and would produce false matches downstream).
+          - @import / @charset / @namespace — they end with ';' before the
+            next '{'; detected by finding the semicolon first.
+        """
+        if _strip_comments:
+            # Strip comments before parsing so that '{' / '}' inside comments
+            # don't confuse the depth tracker. Recursive calls receive block
+            # content that is already comment-free.
+            css_content = re.sub(r'/\*.*?\*/', '', css_content, flags=re.DOTALL)
+
+        nodes = []
         i = 0
         n = len(css_content)
 
@@ -270,16 +285,56 @@ class CriticalCSSExtractor:
                     # Keyframes / font-face: skip entirely.
                     continue
 
-                # Conditional group rules (@media, @supports, @layer …):
-                # recurse and keep only the matching inner rules.
-                inner = self._parse_css_rules(block_content, critical_selectors)
+                nodes.append(
+                    (selector,
+                     self._tokenize_css_rules(block_content,
+                                              _strip_comments=False))
+                )
+            else:
+                nodes.append((selector, block_content))
+
+        return nodes
+
+    def _filter_rules(self, nodes, critical_selectors):
+        """Render the tokenized nodes that match critical_selectors.
+
+        Conditional group rules keep only their matching inner rules,
+        wrapped back in the at-rule header. Source order is preserved.
+        """
+        rules = []
+        for selector, body in nodes:
+            if isinstance(body, list):
+                inner = self._filter_rules(body, critical_selectors)
                 if inner:
                     rules.append(f"{selector}{{{''.join(inner)}}}")
-            else:
-                if self._is_critical_selector(selector, critical_selectors):
-                    rules.append(f"{selector}{{{block_content}}}")
-
+            elif self._is_critical_selector(selector, critical_selectors):
+                rules.append(f"{selector}{{{body}}}")
         return rules
+
+    def _get_sheet_nodes(self, css_path):
+        """Tokenized top-level nodes for a stylesheet, cached per file.
+
+        Keyed on (mtime_ns, size) so a sheet rewritten mid-run (earlier
+        pipeline stages run before this one, but belt-and-braces) is
+        re-tokenized rather than served stale.
+        """
+        try:
+            stat = css_path.stat()
+        except OSError:
+            return None
+        cache_key = str(css_path)
+        fingerprint = (stat.st_mtime_ns, stat.st_size)
+        cached = self._sheet_cache.get(cache_key)
+        if cached and cached[0] == fingerprint:
+            return cached[1]
+        try:
+            with open(css_path, 'r', encoding='utf-8') as f:
+                nodes = self._tokenize_css_rules(f.read())
+        except Exception:
+            # Silently skip if we can't read the file
+            return None
+        self._sheet_cache[cache_key] = (fingerprint, nodes)
+        return nodes
 
     def _is_critical_selector(self, selector, critical_selectors):
         """Check if a CSS selector matches critical selectors"""

--- a/scripts/html_transformer.py
+++ b/scripts/html_transformer.py
@@ -28,7 +28,7 @@ from bs4 import BeautifulSoup
 sys.path.insert(0, str(Path(__file__).parent))
 
 from fix_seo_issues import SEOFixer
-from enhance_html_performance import HTMLPerformanceEnhancer
+from enhance_html_performance import HTMLPerformanceEnhancer, normalize_self_href
 from convert_images_to_picture import ImageToPictureConverter
 from extract_critical_css import CriticalCSSExtractor
 from minify_html import minify_html
@@ -269,7 +269,10 @@ class HTMLTransformer:
 
         head_body = re.sub(r'<link\b[^>]*/?\s*>', _revert_preload, head_body, flags=re.IGNORECASE)
 
-        # 3. Deduplicate <link> tags by href
+        # 3. Deduplicate <link> tags by href. Keys are normalised so an
+        # absolute same-site href and its relative form count as the same
+        # resource — exact-string keys let e.g. a relative and an
+        # absolutified copy of the same LCP preload both survive.
         seen_hrefs = set()
 
         def _dedup(m):
@@ -277,7 +280,7 @@ class HTMLTransformer:
             href_m = re.search(r'\bhref=["\']([^"\']+)["\']', tag, re.IGNORECASE)
             if not href_m:
                 return tag
-            href = href_m.group(1)
+            href = normalize_self_href(href_m.group(1))
             if href in seen_hrefs:
                 return ''
             seen_hrefs.add(href)

--- a/scripts/optimize_images.py
+++ b/scripts/optimize_images.py
@@ -130,10 +130,16 @@ class ImageOptimizer:
         avif_path = image_path.with_suffix('.avif')
         webp_path = image_path.with_suffix('.webp')
 
-        # If both modern formats exist on disk, skip (trust the files)
+        # If both modern formats exist on disk, skip — but only when the
+        # source hash still matches the cache. Derivatives rsynced from the
+        # previous build can belong to an older image published under the
+        # same filename; without this check they would never be regenerated.
         if avif_path.exists() and webp_path.exists():
-            # Populate cache if missing so future runs are fast
             cache_key = str(image_path.relative_to(self.public_dir))
+            cached_hash = self.optimization_cache.get(cache_key, {}).get('hash', '')
+            if cached_hash and cached_hash != self.get_image_hash(image_path):
+                return True
+            # Populate cache if missing so future runs are fast
             if cache_key not in self.optimization_cache:
                 entry = {
                     'hash': self.get_image_hash(image_path),

--- a/tests/test_extract_critical_css.py
+++ b/tests/test_extract_critical_css.py
@@ -78,3 +78,33 @@ def test_keyframes_are_skipped(tmp_path):
                        {'p'}, tmp_path)
     assert '@keyframes' not in out
     assert 'color:red' in out
+
+
+def test_sheet_cache_reuses_parse_and_invalidates_on_rewrite(tmp_path):
+    # One extractor instance processes every page — the tokenized sheet must
+    # be parsed once and reused, but a rewritten file must not serve stale
+    # nodes (keyed on mtime_ns + size).
+    sheet = tmp_path / 't.css'
+    sheet.write_text('h1{color:red}', encoding='utf-8')
+    ex = CriticalCSSExtractor()
+    ex.public_dir = tmp_path
+
+    first = ex._get_sheet_nodes(sheet)
+    assert first is ex._get_sheet_nodes(sheet), 'second read should hit the cache'
+
+    # Different size guarantees a new fingerprint even on coarse mtime clocks.
+    sheet.write_text('h2{margin:0;padding:0}', encoding='utf-8')
+    fresh = ex._get_sheet_nodes(sheet)
+    assert fresh is not first
+    assert fresh[0][0] == 'h2'
+
+
+def test_cached_extraction_matches_uncached(tmp_path):
+    # _parse_css_rules (raw string path) and the cached sheet path must
+    # produce identical output for the same CSS + selector set.
+    css = 'p{color:red}@media (max-width:600px){h1{margin:0}.skip{x:1}}'
+    ex, out = _extract(css, {'p', 'h1'}, tmp_path)
+    direct = ''.join(
+        ex._minify_css(r) for r in ex._parse_css_rules(css, {'p', 'h1'})
+    )
+    assert out == direct

--- a/tests/test_html_transformer.py
+++ b/tests/test_html_transformer.py
@@ -99,3 +99,17 @@ class TestDeepCleanHead:
         html = _wrap('<title>t</title>', body)
         out = HTMLTransformer._deep_clean_head(html)
         assert '<noscript>kept in body</noscript>' in out
+
+
+def test_normalize_self_href_maps_absolute_same_site_to_relative():
+    # Guards the duplicate-LCP-preload fix: an absolutified srcset-derived
+    # href and an existing relative preload must compare equal.
+    from enhance_html_performance import normalize_self_href
+
+    assert (normalize_self_href('https://jameskilby.co.uk/wp-content/a.avif')
+            == '/wp-content/a.avif')
+    assert normalize_self_href('/wp-content/a.avif') == '/wp-content/a.avif'
+    # Domain-only hrefs (preconnect) and external URLs are left alone.
+    assert (normalize_self_href('https://jameskilby.co.uk')
+            == 'https://jameskilby.co.uk')
+    assert normalize_self_href('https://utteranc.es/x.js') == 'https://utteranc.es/x.js'


### PR DESCRIPTION
Stacked on #115 (branched from `fix/critical-css-skip-duplicates` because both touch `scripts/extract_critical_css.py`). Merge #115 first — GitHub will retarget this PR to `main` when the base branch is deleted.

Fixes the top three performance findings from the pipeline audit.

## 1. Stale images could be served forever (high)

Two compounding bugs meant an image replaced in WordPress under the same filename kept serving its old version indefinitely:

- **Workflow**: the "replace originals with previously-optimized versions if smaller" step copied the previous build's image over the freshly generated one on any size difference. Nothing in the pipeline recompresses originals in place anymore (optipng/jpegoptim are installed but never invoked), so a size difference can *only* mean the content changed — the step was purely the stale bug and is removed.
- **`optimize_images.py`**: `should_optimize_image()` returned False whenever both `.avif` + `.webp` existed on disk, *before* the hash comparison — and the workflow rsyncs the previous build's derivatives in first, so changed images were never re-derived. The cached-hash check now runs before that early return.

## 2. Browser cache TTLs (medium)

- **`_headers`**: `/assets/css/*` and `/assets/js/*` drop from `max-age=31536000` to `3600`. These files (theme CSS, per-page critical CSS, search JS) are not content-hashed, change across builds, and no purge step covers them — repeat visitors could hold stale styling for up to a year after a design change.
- **`_worker.template.js`**: HTML responses (KV HIT/MISS, 304s, Cache-API fallback) now send a fixed `public, max-age=300, must-revalidate` browser budget instead of the smart KV TTL. Cloudflare Pages never layers `_headers` rules onto worker-built Responses, so the `/2*` 300s rule never actually applied — browsers were caching older posts for a full hour past deploys and KV purges. KV/edge retention keeps the smart 5min/15min/1hr TTLs; revalidation rides the existing ETag/Last-Modified 304 path. Also fixed the `_headers` `/2*` comment that claimed the opposite layering behaviour.

## 3. Build waste (medium)

- **Double Brotli**: every HTML file was q11-compressed twice per build — once in static-output (then invalidated when `convert_to_staging.py` rewrote URLs) and again in public/. The first pass now runs `--skip-html` (new flag on `brotli_compress.py`); the final public/ pass is the single HTML compression. Missing HTML `.br` at validation time is a soft skip, and a failed final pass now degrades to on-the-fly compression instead of serving *mismatched* sidecars.
- **Selective KV purge**: every deploy wiped the entire `HTML_CACHE` namespace, forcing a site-wide cold cache. Now only pages whose rendered bytes changed in the pushed commit are purged (both slash forms, via the worker's existing `/.purge?path=`), falling back to purge-all above 30 changed files or on any per-path failure. No-op builds skip the purge entirely. (KV values are raw HTML bodies — worker headers/TTLs apply at serve time — so worker-only changes don't require a flush.)
- **Critical CSS re-parsing**: the extractor re-read and re-tokenized every linked stylesheet for every HTML page (N pages × M sheets). Parsing is now split into a selector-independent tokenizer cached per file (mtime+size fingerprint) plus a cheap per-page filter. `_parse_css_rules` is kept as a wrapper, so existing behaviour/tests are unchanged.
- **Duplicate LCP preloads**: every page shipped two byte-identical high-priority image preloads because the dedupe compared exact href strings while `restore_seeded_urls.py` leaves link hrefs relative but absolutifies srcsets. Both `add_preload_hints` and `_clean_head`'s dedupe now compare origin-normalized hrefs (same-site absolute → relative; external and domain-only hrefs untouched).

## Files that land in `public/`

⚠️ `_worker.template.js` (copied to `public/_worker.js`) and `_headers` (copied to `public/_headers`) change with this PR — the next auto-commit diff will show the new `BROWSER_HTML_CACHE_CONTROL` constant, Cache-Control header changes on HTML responses, and the asset TTL drop.

## Testing

- 100 unit tests pass (3 new: sheet-cache reuse/invalidation, cached-vs-uncached extraction equivalence, href normalization).
- Functional smoke tests: `--skip-html` leaves HTML uncompressed while CSS gets sidecars; duplicate-LCP-preload scenario (relative existing preload + absolutified srcset) now yields exactly one preload.
- Workflow YAML validated; `node --check` passes on the worker template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)