### PR TITLE
fix(theme): raise body-text contrast to WCAG AA

### DIFF
--- a/scripts/brutalist-theme.css
+++ b/scripts/brutalist-theme.css
@@ -29,7 +29,11 @@
   --text-light: #fafafa;
   --accent-orange: #f6821f;
   --gray-mid: #404040;
-  --gray-light: #666666;
+  /* Body copy (.entry-content p et al) renders in this on --bg-dark.
+     #666666 was ~3.4:1 against #0a0a0a — below the WCAG AA 4.5:1 minimum
+     for normal text. #949494 is ~6.5:1 on #0a0a0a and stays ≥5:1 on the
+     lighter card surfaces (#1a1a1a/#262625). Keep it ≥ #8f8f8f. */
+  --gray-light: #949494;
 }
 
 /* Apply noise texture to body */
@@ -1484,6 +1488,9 @@ div, section, aside, nav {
     --text-muted: #333;
     --accent-orange: #000;
     --border-subtle: #ccc;
+    /* The screen value is tuned for the dark background — on white it
+       would be ~3:1. Pin body-copy gray dark for print (~9.7:1). */
+    --gray-light: #444;
   }
 
   body {


### PR DESCRIPTION
Fixes the high-severity accessibility finding from the theme audit: all article body copy (`.entry-content p`, `.entry-summary p`, plus `.entry-meta`) renders in `--gray-light: #666666`, which is **3.45:1** against the `#0a0a0a` background — below the WCAG AA 4.5:1 minimum for normal text, on the main reading surface of every post.

## Change

One token bump plus a print guard in `scripts/brutalist-theme.css`:

| Context | Old | New |
|---|---|---|
| `#0a0a0a` page background | 3.45:1 ❌ | **6.53:1** ✅ |
| `#1a1a1a` cards | — | 5.74:1 ✅ |
| `#262625` surfaces | — | 4.99:1 ✅ |
| Print (white) | 5.7:1 | **9.74:1** ✅ (pinned `#444`) |

- `--gray-light: #666666` → `#949494` — same neutral hue, just lighter, so no palette clash with the warm-gray accents (`#7a766c`/`#a8a59c`) used in the redesigned sections.
- The `@media print` `:root` override flips the background to white but didn't override this token — the lighter screen value would have printed at ~3:1, so print pins `--gray-light: #444`.

Verified all 19 `var(--gray-light)` usages are `color:` declarations (none are backgrounds/borders where lightening could reduce contrast the other way).

Not changed (borderline, separate concern): `.jkr-topic-count`'s literal `#7a766c` (~4.4:1 at 0.8rem) and the stale `var(--gray-light, #7a766c)` fallbacks flagged in the audit's palette-drift finding.

## Files that land in `public/`

⚠️ `scripts/brutalist-theme.css` is inlined into every page's HTML and emitted at `public/assets/css/brutalist-theme.css` — the next auto-commit will touch every HTML file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)