### PR TITLE
fix(incremental): stamp watermark at build start in UTC, not build end

### DIFF
--- a/scripts/incremental_builder.py
+++ b/scripts/incremental_builder.py
@@ -9,7 +9,7 @@ import hashlib
 import re
 import threading
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 # Matches individual post URLs: /YYYY/MM/slug/ or /YYYY/MM/slug (slug must be non-empty)
 # Distinguishes posts from monthly archives (/YYYY/MM/) and year archives (/YYYY/).
@@ -23,11 +23,24 @@ class IncrementalBuilder:
     # invalidates the whole cache and forces a full rebuild.
     FINGERPRINT_FILES = ('config.py', 'wp_to_static_generator.py')
 
+    # Overlap subtracted from the stored watermark when querying WordPress,
+    # absorbing clock skew between the runner and the WP host. Re-fetching a
+    # few recently-modified posts is cheap — has_changed()'s content-hash
+    # check skips regeneration when nothing actually changed.
+    WATERMARK_OVERLAP = timedelta(minutes=5)
+
     def __init__(self, cache_file='.build-cache.json'):
         self.cache_file = Path(cache_file)
         # mark_processed() is called from ThreadPoolExecutor workers in
         # wp_to_static_generator.py — guard all cache mutation/serialisation.
         self._lock = threading.Lock()
+        # Watermark for the NEXT build's modified_after filter. Captured at
+        # construction (before any posts are fetched), NOT at finalize time —
+        # a post edited in WordPress while the 10–40 min build is running is
+        # older than an end-of-build stamp, so the next incremental run would
+        # have skipped it forever. UTC with explicit offset so runner/WP
+        # timezone or DST divergence can't shift the window.
+        self._build_started_at = datetime.now(timezone.utc)
         self.cache = self._load_cache()
         self._check_environment_fingerprint()
 
@@ -122,6 +135,21 @@ class IncrementalBuilder:
             return 'posts'  # Individual posts: /YYYY/MM/slug/
         return 'pages'  # Home, WP pages, archives, etc.
     
+    def _modified_after_param(self, last_build):
+        """Watermark minus WATERMARK_OVERLAP, as ISO8601 for modified_after.
+
+        Legacy caches hold naive local-time stamps (pre-UTC fix) — treat
+        those as runner-local so the one build that straddles the change
+        behaves exactly as before.
+        """
+        try:
+            stamp = datetime.fromisoformat(last_build)
+        except (ValueError, TypeError):
+            return last_build
+        if stamp.tzinfo is None:
+            stamp = stamp.astimezone()
+        return (stamp - self.WATERMARK_OVERLAP).isoformat()
+
     def get_changed_posts(self, session, wp_url):
         """Get only posts modified since last build"""
         last_build = self.cache.get('last_build_time')
@@ -132,10 +160,10 @@ class IncrementalBuilder:
             return self._get_all_posts(session, wp_url)
         
         print(f"🔄 Incremental build - checking posts modified since {last_build}")
-        
+
         # Use WordPress API's modified_after parameter
         params = {
-            'modified_after': last_build,
+            'modified_after': self._modified_after_param(last_build),
             'per_page': 100,
             'status': 'publish'
         }
@@ -214,9 +242,9 @@ class IncrementalBuilder:
 
         if not last_build or cached_count == 0:
             return self._get_all_pages(session, wp_url)
-        
+
         params = {
-            'modified_after': last_build,
+            'modified_after': self._modified_after_param(last_build),
             'per_page': 100,
             'status': 'publish'
         }
@@ -303,18 +331,29 @@ class IncrementalBuilder:
         
         try:
             last_full_date = datetime.fromisoformat(last_full)
-            days_since = (datetime.now() - last_full_date).days
+            if last_full_date.tzinfo is None:
+                # Legacy naive local-time stamp — anchor it before comparing
+                # against the aware UTC clock (naive - aware raises TypeError,
+                # which used to force an archive rebuild every run).
+                last_full_date = last_full_date.astimezone()
+            days_since = (datetime.now(timezone.utc) - last_full_date).days
             return days_since >= 1
         except (ValueError, TypeError):
             return True
     
     def finalize_build(self, is_full_build=False):
-        """Mark build complete and save cache"""
-        self.cache['last_build_time'] = datetime.now().isoformat()
-        
+        """Mark build complete and save cache.
+
+        Stamps the build START time (see __init__), not now() — anything
+        modified in WordPress after fetching began, including during the
+        build itself, stays newer than the watermark and is picked up by
+        the next incremental run.
+        """
+        self.cache['last_build_time'] = self._build_started_at.isoformat()
+
         if is_full_build:
-            self.cache['last_full_build'] = datetime.now().isoformat()
-        
+            self.cache['last_full_build'] = self._build_started_at.isoformat()
+
         self._save_cache()
         print(f"💾 Build cache saved to {self.cache_file}")
     

--- a/tests/test_incremental_builder.py
+++ b/tests/test_incremental_builder.py
@@ -95,3 +95,54 @@ def test_remove_stale_entries(builder):
     assert removed == 1
     assert '/2026/01/keep/' in builder.cache['posts']
     assert '/2026/01/drop/' not in builder.cache['posts']
+
+
+def test_watermark_is_build_start_in_utc(tmp_path):
+    # The modified_after watermark must be the time fetching BEGAN, not the
+    # time the build finished — a post edited mid-build is older than an
+    # end-of-build stamp and would be skipped forever. It must also carry
+    # an explicit UTC offset so runner/WP timezone drift can't shift it.
+    from datetime import datetime, timezone
+
+    before = datetime.now(timezone.utc)
+    b = IncrementalBuilder(cache_file=str(tmp_path / 'cache.json'))
+    after_init = datetime.now(timezone.utc)
+
+    b.finalize_build(is_full_build=True)
+
+    stamp = datetime.fromisoformat(b.cache['last_build_time'])
+    assert stamp.tzinfo is not None
+    assert before <= stamp <= after_init  # start-of-build, not finalize time
+    assert b.cache['last_full_build'] == b.cache['last_build_time']
+
+
+def test_modified_after_param_subtracts_overlap(builder):
+    from datetime import datetime
+
+    param = builder._modified_after_param('2026-07-01T12:00:00+00:00')
+    stamp = datetime.fromisoformat(param)
+    assert stamp == datetime.fromisoformat('2026-07-01T11:55:00+00:00')
+
+
+def test_modified_after_param_handles_legacy_naive_stamp(builder):
+    # Pre-fix caches hold naive local-time stamps; they must parse (as
+    # runner-local), gain an offset, and still get the overlap.
+    from datetime import datetime, timedelta
+
+    param = builder._modified_after_param('2026-07-01T12:00:00')
+    stamp = datetime.fromisoformat(param)
+    assert stamp.tzinfo is not None
+    naive_local = datetime.fromisoformat('2026-07-01T12:00:00').astimezone()
+    assert stamp == naive_local - timedelta(minutes=5)
+
+
+def test_should_rebuild_archives_accepts_legacy_naive_stamp(builder):
+    # A recent naive last_full_build must NOT force a rebuild — the old
+    # naive-minus-aware TypeError path silently rebuilt archives every run.
+    from datetime import datetime
+
+    builder.cache['last_full_build'] = datetime.now().isoformat()
+    assert builder.should_rebuild_archives() is False
+
+    builder.cache['last_full_build'] = '2020-01-01T00:00:00+00:00'
+    assert builder.should_rebuild_archives() is True


### PR DESCRIPTION
Fixes performance audit finding #4: the incremental build's blind window.

## The bug

`finalize_build()` set `last_build_time = datetime.now().isoformat()` at the **end** of the build, in **naive local time**. Two problems:

1. **Permanent blind window** — a post edited in WordPress while the 10–40 min build is running has a `modified` date *older* than the end-of-build stamp, so the next run's `modified_after` filter excludes it. It stays excluded on every subsequent incremental build, until a `config.py`/generator change happens to force a full rebuild.
2. **Timezone drift** — WordPress interprets the naive stamp in its own context; any runner/WP timezone or DST divergence widens or shifts the window.

## The fix

- The watermark is captured at `IncrementalBuilder` **construction** (before any posts are fetched) as an aware UTC timestamp; `finalize_build()` stamps that value. Anything edited after fetching began — including mid-build — stays newer than the watermark and is picked up next run.
- A 5-minute `WATERMARK_OVERLAP` is subtracted at query time to absorb clock skew between the runner and the WP host. Over-fetching is cheap: `has_changed()`'s content-hash check already skips regeneration when nothing actually changed.
- **Legacy caches**: existing naive stamps are treated as runner-local (`astimezone()`), so the one build that straddles this change behaves exactly as before. `should_rebuild_archives()` also anchors legacy naive `last_full_build` values before comparing — the naive-minus-aware `TypeError` path would otherwise have silently forced an archive rebuild every run.
- `incremental_builder.py` is not in `FINGERPRINT_FILES`, so deploying this does **not** invalidate the existing build cache.

## Testing

100 tests pass — 4 new: watermark is start-of-build and tz-aware, overlap subtraction, legacy naive stamp parsing, and `should_rebuild_archives` accepting legacy stamps without forcing a rebuild.

No files in `public/` are affected by this PR (build-time behaviour only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)