### PR TITLE
fix(theme): critical-CSS gaps, dynamic-ID purge allowlist, a11y tweaks

### DIFF
--- a/scripts/assets/js/search.js
+++ b/scripts/assets/js/search.js
@@ -63,13 +63,20 @@ console.log('[Search] Script loaded');
                 e.preventDefault();
                 focusSearch();
             }
+            if (e.key === 'Escape') {
+                hideResults();
+            }
         });
     }
 
     function focusSearch() {
         const input = document.getElementById('blog-search-input');
         if (input) {
-            input.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            // CSS prefers-reduced-motion can't override an explicit JS
+            // behavior option — gate it here.
+            const reduceMotion = window.matchMedia
+                && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            input.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'center' });
             input.focus();
         }
     }

--- a/scripts/brutalist-theme.css
+++ b/scripts/brutalist-theme.css
@@ -28,6 +28,11 @@
   --bg-dark: #0a0a0a;
   --text-light: #fafafa;
   --accent-orange: #f6821f;
+  /* Alias used by the jkr/jk homepage-redesign rules (var(--accent, …)).
+     Previously undefined, so their hex fallbacks always fired and a
+     palette change here silently didn't propagate. Resolves at use time,
+     so the print block's --accent-orange override follows automatically. */
+  --accent: var(--accent-orange);
   --gray-mid: #404040;
   /* Body copy (.entry-content p et al) renders in this on --bg-dark.
      #666666 was ~3.4:1 against #0a0a0a — below the WCAG AA 4.5:1 minimum
@@ -43,6 +48,10 @@ body {
   font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
   line-height: 1.6;
   position: relative;
+  /* .alignfull's width:100vw includes the scrollbar on Windows/Linux,
+     producing a permanent horizontal scrollbar. clip (unlike hidden)
+     doesn't create a scroll container, so position:sticky still works. */
+  overflow-x: clip;
 }
 
 body::before {
@@ -157,7 +166,9 @@ a:hover {
   text-decoration: underline !important;
 }
 
-a:focus {
+/* :focus-visible, not :focus — mouse clicks shouldn't paint focus rings
+   on every link; keyboard/assistive navigation still gets them. */
+a:focus-visible {
   outline: 2px solid var(--accent-orange);
   outline-offset: 2px;
 }
@@ -1478,6 +1489,24 @@ div, section, aside, nav {
   }
 }
 
+/* ── Reduced motion ───────────────────────────────────────────────── */
+/* Zero out decorative motion (card hover translates, hero lifts, the
+   search overlay's fadeIn/slideUp) for users who ask for it. !important
+   also defeats the inline animation styles search.js injects. The
+   smooth scrollIntoView is gated in search.js itself — the CSS
+   scroll-behavior property doesn't override an explicit JS behavior
+   option. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* ── Print Stylesheet ─────────────────────────────────────────────── */
 @media print {
   /* Reset to light background for printing */
@@ -1508,6 +1537,7 @@ div, section, aside, nav {
   .site-footer,
   .breadcrumb-navigation,
   .blog-search-container,
+  #blog-search-container,
   .utterances,
   .related-posts-section,
   .social-share-section,
@@ -1620,6 +1650,10 @@ div, section, aside, nav {
   color: #f5f3ee !important;
   opacity: 1 !important;
 }
+.jk-search:focus-visible {
+  outline: 2px solid var(--accent-orange);
+  outline-offset: 2px;
+}
 .jk-search kbd {
   font-family: "JetBrains Mono", monospace;
   font-size: 0.72rem;
@@ -1639,12 +1673,16 @@ div, section, aside, nav {
    Single-post pages are scoped out via :not(.single).
    ============================================================ */
 
-/* 1. Sentence-case Inter titles on archive cards (NOT on single post). */
+/* 1. Sentence-case system-stack titles on archive cards (NOT on single
+   post). Inter was declared here but never shipped as a @font-face, so
+   every visitor got the -apple-system fallback anyway — the explicit
+   stack just stops a machine with Inter installed rendering differently
+   from the live site. Ship a subset Inter before re-adding it here. */
 body:not(.single) .loop-entry .entry-title,
 body:not(.single) .loop-entry .entry-title a,
 body:not(.single) .entry-list-item .entry-title,
 body:not(.single) .entry-list-item .entry-title a {
-  font-family: "Inter", -apple-system, "Segoe UI", sans-serif !important;
+  font-family: -apple-system, "Segoe UI", sans-serif !important;
   font-size: 1.3rem !important;
   font-weight: 600 !important;
   text-transform: none !important;
@@ -1834,7 +1872,8 @@ body:not(.single) .posted-on time ~ time {
   color: #b8b5ad;
 }
 .jkr-hero-title {
-  font-family: 'Inter', -apple-system, 'Segoe UI', sans-serif !important;
+  /* Inter is not shipped — see the archive-card titles note above. */
+  font-family: -apple-system, 'Segoe UI', sans-serif !important;
   font-size: clamp(1.75rem, 3vw, 2.5rem) !important;
   line-height: 1.1 !important;
   font-weight: 600 !important;
@@ -1844,7 +1883,7 @@ body:not(.single) .posted-on time ~ time {
   text-transform: none !important;
 }
 .jkr-hero-excerpt {
-  font-family: 'Inter', -apple-system, 'Segoe UI', sans-serif;
+  font-family: -apple-system, 'Segoe UI', sans-serif;
   font-size: 1rem;
   line-height: 1.65;
   color: #a8a59c;

--- a/scripts/extract_critical_css.py
+++ b/scripts/extract_critical_css.py
@@ -9,6 +9,7 @@ This significantly improves First Contentful Paint (FCP) by 30-50%.
 """
 
 import sys
+from collections import Counter
 from pathlib import Path
 from bs4 import BeautifulSoup
 import re
@@ -57,30 +58,39 @@ class CriticalCSSExtractor:
         """Process a single HTML file"""
         try:
             with open(file_path, 'r', encoding='utf-8') as f:
-                html = f.read()
+                original_html = f.read()
 
             # Pre-parse cleanup: strip accumulated noscript fallbacks and
             # deduplicate <link> tags by href so BeautifulSoup sees a clean doc.
-            html = self._dedup_head_links(html)
+            html = self._dedup_head_links(original_html)
 
             soup = BeautifulSoup(html, 'html.parser')
 
             # Extract critical CSS
             critical_css = self._extract_critical_css(soup, file_path)
 
-            if not critical_css:
-                return False
+            inlined = False
+            if critical_css:
+                inlined = self._inline_critical_css(soup, critical_css, file_path)
 
-            # Inline critical CSS
-            if self._inline_critical_css(soup, critical_css, file_path):
-                # Convert external CSS to async preload
-                self._convert_css_to_preload(soup)
+            # Convert external CSS to async preload even when there was
+            # nothing to inline — a page whose async-eligible sheets match no
+            # critical selectors must still not ship them render-blocking,
+            # and the dedup/noscript self-healing must still persist. The
+            # old early-return on empty critical_css skipped both, leaving
+            # such pages render-blocking forever.
+            self._convert_css_to_preload(soup)
 
-                # Save modified HTML
+            # Write only when the document actually changed. Comparing
+            # against the original as BS4 would serialize it means
+            # formatting-only parse differences don't force rewrites on
+            # every run.
+            output = str(soup)
+            if output != str(BeautifulSoup(original_html, 'html.parser')):
                 with open(file_path, 'w', encoding='utf-8') as f:
-                    f.write(str(soup))
-
-                self.css_inlined += 1
+                    f.write(output)
+                if inlined:
+                    self.css_inlined += 1
                 return True
 
             return False
@@ -152,9 +162,13 @@ class CriticalCSSExtractor:
 
         return critical_css
 
-    # Stylesheets that stay render-blocking (mirrors _convert_to_async's
-    # EXCLUDED): their above-fold rules are already applied at first paint, so
-    # inlining them into the critical block is duplication that wastes the cap.
+    # Stylesheets that stay render-blocking. Single source of truth, used in
+    # two places: _extract_matching_css_rules skips them (their above-fold
+    # rules are already applied at first paint, so inlining them into the
+    # critical block is duplication that wastes the cap) and
+    # _convert_css_to_preload leaves them synchronous (brutalist-theme ships
+    # the @font-face declarations; consolidated-inline-styles is theming
+    # layered above critical CSS).
     RENDER_BLOCKING_CSS = ('brutalist-theme', 'fonts.css', 'consolidated-inline-styles')
 
     def _extract_matching_css_rules(self, soup, selectors, file_path=None):
@@ -532,15 +546,26 @@ class CriticalCSSExtractor:
         survived the dedup pass as-is) also receive a fresh noscript without
         the double-counting that occurred when noscripts were added in step 2
         *and* again in a former "step 3".
+
+        Returns True when the document semantically changed. A noscript that
+        is stripped in step 1 and re-added identically in step 3 does NOT
+        count — idempotent runs must report unchanged so callers don't
+        rewrite every file on every build.
         """
-        EXCLUDED = ('brutalist-theme', 'fonts.css', 'consolidated-inline-styles')
+        EXCLUDED = self.RENDER_BLOCKING_CSS
+        modified = False
 
         # ── Step 1: strip residual noscript blocks ───────────────────────
-        # _dedup_head_links already removed them from the raw string, but
-        # do a belt-and-suspenders BS4 cleanup for safety.
+        # _dedup_head_links already removed them from the raw string (when
+        # the caller ran it), but do a belt-and-suspenders BS4 cleanup for
+        # safety. Remember what was removed, keyed by href, so step 3 can
+        # tell a restoring re-add from a genuine change.
+        stripped = Counter()
         if soup.head:
             for ns in list(soup.head.find_all('noscript')):
-                if ns.find('link'):
+                inner = ns.find('link')
+                if inner:
+                    stripped[inner.get('href', '')] += 1
                     ns.decompose()
 
         # ── Step 2: convert stylesheet links → preload+onload ────────────
@@ -556,6 +581,7 @@ class CriticalCSSExtractor:
             link['rel'] = 'preload'
             link['as'] = 'style'
             link['onload'] = "this.onload=null;this.rel='stylesheet'"
+            modified = True
 
         # ── Step 3: add exactly one noscript per async-CSS preload link ───
         # This covers three cases:
@@ -564,6 +590,7 @@ class CriticalCSSExtractor:
         #   c) Plain preload-as-style links (no onload) left over from the old
         #      _externalize_critical_css bug — upgrade them to include onload
         #      so they actually apply the stylesheet at runtime.
+        added = Counter()
         if soup.head:
             for link in list(soup.head.find_all('link')):
                 rel  = link.get('rel') or []
@@ -575,6 +602,7 @@ class CriticalCSSExtractor:
                 # Upgrade plain preload to async onload if missing.
                 if not link.get('onload'):
                     link['onload'] = "this.onload=null;this.rel='stylesheet'"
+                    modified = True
                 noscript = soup.new_tag('noscript')
                 fallback = soup.new_tag('link')
                 fallback['rel'] = 'stylesheet'
@@ -583,6 +611,13 @@ class CriticalCSSExtractor:
                     fallback['media'] = link['media']
                 noscript.append(fallback)
                 link.insert_after(noscript)
+                added[href] += 1
+
+        # Noscript churn only counts when the set actually changed.
+        if added != stripped:
+            modified = True
+
+        return modified
 
 
 def main():

--- a/scripts/html_transformer.py
+++ b/scripts/html_transformer.py
@@ -488,14 +488,22 @@ class HTMLTransformer:
     def _apply_critical_css(self, soup, file_path):
         """Extract and inline critical CSS, convert stylesheets to async preload."""
         critical_css = self.critical_css._extract_critical_css(soup)
-        if not critical_css:
-            return False
 
-        if self.critical_css._inline_critical_css(soup, critical_css, file_path):
-            self.critical_css._convert_css_to_preload(soup)
+        modified = False
+        if critical_css and self.critical_css._inline_critical_css(
+                soup, critical_css, file_path):
             self.critical_css.css_inlined += 1
-            return True
-        return False
+            modified = True
+
+        # Convert stylesheets to async preload even when nothing was inlined
+        # — a page whose async-eligible sheets match no critical selectors
+        # must still not ship them render-blocking. The old early-return on
+        # empty critical_css left such pages render-blocking forever and
+        # stopped the noscript self-healing from persisting.
+        if self.critical_css._convert_css_to_preload(soup):
+            modified = True
+
+        return modified
 
     # WP-shipped stylesheets that survive the generator pass: small ones get
     # inlined here so they don't cost a separate request. wp_to_static_generator

--- a/scripts/optimize_css.py
+++ b/scripts/optimize_css.py
@@ -203,6 +203,17 @@ class CSSOptimizer:
         'pop-animated', 'splide-initial',
     })
 
+    # IDs created by JavaScript at runtime — same rationale as
+    # _DYNAMIC_CLASSES, but for id selectors. search.js injects the search
+    # box into <main> on load, so its ids never appear in the served HTML;
+    # without this allowlist the optimizer stripped the
+    # #blog-search-input::placeholder / cancel-button rules and part of the
+    # search restyle silently never shipped.
+    # Source of truth: `grep -oE 'id="[^"]+"' scripts/assets/js/search.js`.
+    _DYNAMIC_IDS = frozenset({
+        'blog-search-container', 'blog-search-input',
+    })
+
     def _is_selector_used(self, selector_text, used_selectors):
         """Check if a CSS selector is used in HTML.
 
@@ -258,10 +269,12 @@ class CSSOptimizer:
 
                 # If the compound references at least one class that is in
                 # HTML *or* in the dynamic-class allowlist, OR at least one
-                # id that is in HTML, this compound is matchable.
+                # id that is in HTML *or* in the dynamic-id allowlist, this
+                # compound is matchable.
                 if (any(f'.{c}' in used_selectors for c in classes)
                         or any(c in self._DYNAMIC_CLASSES for c in classes)
-                        or any(f'#{i}' in used_selectors for i in ids)):
+                        or any(f'#{i}' in used_selectors for i in ids)
+                        or any(i in self._DYNAMIC_IDS for i in ids)):
                     continue
 
                 # No referenced class/id matches → this compound (and the

--- a/tests/test_extract_critical_css.py
+++ b/tests/test_extract_critical_css.py
@@ -108,3 +108,56 @@ def test_cached_extraction_matches_uncached(tmp_path):
         ex._minify_css(r) for r in ex._parse_css_rules(css, {'p', 'h1'})
     )
     assert out == direct
+
+
+def test_empty_extraction_still_converts_to_preload(tmp_path):
+    # A page whose async-eligible sheets match no critical selectors must
+    # STILL get them converted to preload — the old early-return on empty
+    # critical CSS left such pages render-blocking forever.
+    (tmp_path / 'widgets.css').write_text('.only-footer-thing{color:red}',
+                                          encoding='utf-8')
+    page = tmp_path / 'index.html'
+    page.write_text(
+        '<html><head><link rel="stylesheet" href="/widgets.css"></head>'
+        '<body><main><h1>t</h1></main></body></html>',
+        encoding='utf-8')
+    ex = CriticalCSSExtractor()
+    ex.public_dir = tmp_path
+
+    assert ex.process_file(page) is True
+    out = page.read_text(encoding='utf-8')
+    assert 'rel="preload"' in out
+    assert 'noscript' in out
+
+
+def test_convert_css_to_preload_is_idempotent(tmp_path):
+    # Running process_file twice must report no change the second time —
+    # a strip+identical-re-add of noscripts is not a modification, so the
+    # pipeline doesn't rewrite (and recompress) every file every build.
+    (tmp_path / 'widgets.css').write_text('.x{color:red}', encoding='utf-8')
+    page = tmp_path / 'index.html'
+    page.write_text(
+        '<html><head><link rel="stylesheet" href="/widgets.css"></head>'
+        '<body><main><h1>t</h1></main></body></html>',
+        encoding='utf-8')
+    ex = CriticalCSSExtractor()
+    ex.public_dir = tmp_path
+
+    assert ex.process_file(page) is True
+    first_pass = page.read_text(encoding='utf-8')
+    assert ex.process_file(page) is False
+    assert page.read_text(encoding='utf-8') == first_pass
+
+
+def test_excluded_tuple_is_single_source():
+    # RENDER_BLOCKING_CSS drives both the extraction skip and the preload
+    # conversion — guard against the two lists drifting apart again by
+    # checking the conversion path leaves a render-blocking sheet alone.
+    from bs4 import BeautifulSoup as BS
+    soup = BS('<html><head>'
+              '<link rel="stylesheet" href="/assets/css/brutalist-theme.css">'
+              '</head><body></body></html>', 'html.parser')
+    ex = CriticalCSSExtractor()
+    assert ex._convert_css_to_preload(soup) is False
+    link = soup.find('link')
+    assert link['rel'] == ['stylesheet']

--- a/tests/test_optimize_css.py
+++ b/tests/test_optimize_css.py
@@ -1,0 +1,36 @@
+"""Tests for the unused-CSS remover's dynamic allowlists.
+
+The optimizer decides "is this selector used?" from the served HTML, which
+can't see classes/ids that JavaScript creates at runtime. Regressions here
+are silent — the rule just never ships (that's how the #blog-search-input
+placeholder styling from the search restyle disappeared).
+"""
+
+from optimize_css import CSSOptimizer
+
+
+def _used(selector, used_selectors=frozenset()):
+    return CSSOptimizer()._is_selector_used(selector, used_selectors)
+
+
+def test_dynamic_ids_survive_purge():
+    # search.js injects these ids after load — they never appear in HTML.
+    assert _used('#blog-search-input::placeholder') is True
+    assert _used('#blog-search-input::-webkit-search-cancel-button') is True
+    assert _used('#blog-search-container') is True
+
+
+def test_unknown_id_is_still_dropped():
+    assert _used('#no-such-element') is False
+
+
+def test_dynamic_classes_survive_purge():
+    assert _used('.show-drawer') is True
+    assert _used('.header-is-fixed .site-header', {'.site-header'}) is True
+
+
+def test_static_selectors_follow_html_usage():
+    assert _used('.present', {'.present'}) is True
+    assert _used('.absent') is False
+    # Pure element selectors are always kept.
+    assert _used('p > a') is True


### PR DESCRIPTION
Three follow-ups from the theme audit: the two `extract_critical_css.py` gaps flagged in #115's review, the CSS-purge allowlist bug that silently dropped part of the #114 search restyle, and the small theme accessibility batch.

## 1. Critical-CSS gaps (follow-ups to #115)

- **Empty extraction no longer skips conversion.** A page whose async-eligible sheets match no critical selectors hit the early-return and kept those sheets **render-blocking forever** (and the noscript self-healing never persisted). Both `process_file` and `html_transformer._apply_critical_css` now always run `_convert_css_to_preload`.
- **Honest change-reporting.** `_convert_css_to_preload` returns whether the document *semantically* changed — a strip+identical-re-add of noscript fallbacks doesn't count (tracked by href `Counter`), so idempotent runs don't rewrite (and recompress) every file every build. `process_file` writes only when the serialized output differs from the original.
- **Single source of truth**: `EXCLUDED` now references `RENDER_BLOCKING_CSS` instead of being a hand-synced duplicate tuple; fixed the comment naming the nonexistent `_convert_to_async`.

## 2. `optimize_css.py`: `_DYNAMIC_IDS` allowlist

The purge had a class allowlist but no id allowlist, and `search.js` injects `#blog-search-input` / `#blog-search-container` at runtime — so the `#blog-search-input::placeholder` and cancel-button rules from commit 1f5365248a were verifiably stripped from the shipped CSS and never rendered. Now allowlisted, with a pointer to the grep that regenerates the list.

## 3. Theme accessibility/UX tweaks

- **`prefers-reduced-motion`**: global reduce block (`!important` also defeats the search overlay's inline `fadeIn`/`slideUp`); `search.js` gates its smooth `scrollIntoView` on the same media query (CSS `scroll-behavior` can't override an explicit JS behavior option).
- **Escape closes the search results overlay** (was click-backdrop/× only).
- **`a:focus` → `a:focus-visible`** — no more focus rings on mouse clicks; `.jk-search` gains an explicit `:focus-visible` outline.
- **Print**: hide-list now includes `#blog-search-container` (JS injects an id, not a class — the search box printed).
- **`--accent` defined** as an alias of `--accent-orange` — the jkr rules' `var(--accent, …)` fallbacks always fired, so `:root` palette changes silently didn't propagate. Resolves at use time, so the print override follows automatically.
- **Dropped unshipped "Inter"** from the archive-card/hero font stacks — no Inter `@font-face` exists, so every visitor already got `-apple-system`; the explicit stack just stops a machine with Inter installed rendering differently from the live site. (Deliberately *not* substituting Space Grotesk — zero visual change to what actually renders.)
- **`body { overflow-x: clip }`** — `.alignfull`'s `100vw` caused a permanent horizontal scrollbar on scrollbar-visible platforms; `clip` (unlike `hidden`) doesn't create a scroll container, so `position: sticky` keeps working.

Deferred from the audit's theme list (separate cleanup, touches the generator and forces a full rebuild): deleting dead `critical-mobile.css` + its injection path, and the unreferenced `fonts.css` artifact.

## Files that land in `public/`

⚠️ `scripts/brutalist-theme.css` (inlined into every page + `public/assets/css/`) and `scripts/assets/js/search.js` (→ `public/js/search.js`) both change — the next auto-commit will touch every HTML file.

## Testing

111 tests pass — 7 new: empty-extraction still converts, idempotent second run reports unchanged and produces byte-identical output, render-blocking sheets untouched by conversion, and a new `tests/test_optimize_css.py` covering the dynamic id/class allowlists (`optimize_css` previously had no coverage). `node --check` passes on search.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)