### PR TITLE
feat: live homelab power endpoint + blog widget

### DIFF
--- a/_worker.template.js
+++ b/_worker.template.js
@@ -210,6 +210,18 @@ export default {
     }
     // ────────────────────────────────────────────────────────────────────────
 
+    // ── Homelab live power widget ────────────────────────────────────────────
+    // POST (from Home Assistant, token-gated) stores the latest wattage plus a
+    // rolling ~30-min history in KV; GET (public, same-origin) returns it for
+    // the blog widget. Both must run before the GET-only guard and shouldCache.
+    if (path === '/api/power' && request.method === 'POST') {
+      return handlePowerPost(request, env);
+    }
+    if (path === '/api/power' && request.method === 'GET') {
+      return handlePowerGet(env);
+    }
+    // ────────────────────────────────────────────────────────────────────────
+
     // Only cache GET requests
     if (request.method !== 'GET') {
       return env.ASSETS.fetch(request);
@@ -654,6 +666,91 @@ async function handlePlausibleEvent(request) {
   if (ct) respHeaders.set('Content-Type', ct);
 
   return new Response(upstream.body, { status: upstream.status, headers: respHeaders });
+}
+// ───────────────────────────────────────────────────────────────────────────
+
+// ── Homelab live power widget ────────────────────────────────────────────────
+// Reuses the HTML_CACHE KV binding under a single `power:latest` key. Home
+// Assistant POSTs the current whole-homelab wattage every ~30s; the worker
+// appends it to a rolling history and re-PUTs with a 180s TTL. If HA stops
+// pushing, the key expires and GET reports `stale`, so the widget can show
+// "offline" instead of a frozen number. The write is gated by POWER_TOKEN
+// (mirrors the PURGE_TOKEN pattern); the read is public and same-origin, so
+// no CORS and no HA token ever reaches the browser.
+const POWER_KEY = 'power:latest';
+const POWER_TTL = 180;          // seconds — ~6 missed 30s pushes before stale
+const POWER_HISTORY_MAX = 60;   // samples kept — ~30 min at one / 30s
+
+/**
+ * Store the latest homelab wattage. POST from Home Assistant, token-gated.
+ * Body: { "w": <number watts> }. Timestamps are stamped server-side so the
+ * widget never depends on HA's clock.
+ */
+async function handlePowerPost(request, env) {
+  const token = request.headers.get('X-Power-Token');
+  if (!env.POWER_TOKEN || token !== env.POWER_TOKEN) {
+    return new Response('Forbidden', { status: 403, headers: { 'Cache-Control': 'no-store' } });
+  }
+  if (!env.HTML_CACHE) {
+    return new Response('KV unavailable', { status: 503, headers: { 'Cache-Control': 'no-store' } });
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch (_) {
+    return new Response('Bad JSON body', { status: 400, headers: { 'Cache-Control': 'no-store' } });
+  }
+  const watts = Number(body.w);
+  if (!Number.isFinite(watts) || watts < 0 || watts > 100000) {
+    return new Response('Bad "w" value', { status: 400, headers: { 'Cache-Control': 'no-store' } });
+  }
+
+  const ts = new Date().toISOString();
+  let history = [];
+  try {
+    const prev = await env.HTML_CACHE.get(POWER_KEY, { type: 'json' });
+    if (prev && Array.isArray(prev.history)) history = prev.history;
+  } catch (_) {
+    // corrupt/absent previous value — start a fresh history
+  }
+  history.push({ t: ts, w: watts });
+  if (history.length > POWER_HISTORY_MAX) {
+    history = history.slice(history.length - POWER_HISTORY_MAX);
+  }
+
+  await env.HTML_CACHE.put(
+    POWER_KEY,
+    JSON.stringify({ w: watts, ts, history }),
+    { expirationTtl: POWER_TTL }
+  );
+
+  return new Response(JSON.stringify({ ok: true, w: watts, ts }), {
+    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }
+  });
+}
+
+/**
+ * Return the latest homelab wattage + rolling history for the blog widget.
+ * Public, same-origin GET. Returns `{ ok:false, stale:true }` (still HTTP 200)
+ * when there's no fresh reading, so the widget shows "offline" without errors.
+ */
+async function handlePowerGet(env) {
+  const headers = {
+    'Content-Type': 'application/json',
+    // Short edge/browser cache — the widget polls every 30s and KV is only
+    // eventually consistent, so 15s smooths load without feeling stale.
+    'Cache-Control': 'public, max-age=15',
+    'X-Robots-Tag': 'noindex'
+  };
+  if (!env.HTML_CACHE) {
+    return new Response(JSON.stringify({ ok: false, stale: true }), { status: 200, headers });
+  }
+  const record = await env.HTML_CACHE.get(POWER_KEY, { type: 'json' });
+  if (!record) {
+    return new Response(JSON.stringify({ ok: false, stale: true }), { status: 200, headers });
+  }
+  return new Response(JSON.stringify({ ok: true, ...record }), { status: 200, headers });
 }
 // ───────────────────────────────────────────────────────────────────────────
 

--- a/docs/homelab-power-widget.html
+++ b/docs/homelab-power-widget.html
@@ -1,0 +1,118 @@
+<!--
+  Homelab live-power widget for jameskilby.co.uk
+  ------------------------------------------------
+  Paste this whole block into a WordPress "Custom HTML" block (or a reusable
+  block / template part). It is fully self-contained: no external scripts,
+  fonts, or styles, so it passes the site CSP (script-src 'self' 'unsafe-inline',
+  connect-src 'self'). It polls the same-origin /api/power endpoint every 30s.
+
+  Data comes from Home Assistant, which POSTs the whole-homelab wattage to
+  /api/power; the Cloudflare Pages worker (_worker.template.js) stores it in KV
+  and serves it here. If HA stops pushing, the endpoint reports `stale` and the
+  widget shows "offline" rather than a frozen number.
+-->
+<div id="homelab-power" class="hp" aria-live="polite">
+  <div class="hp-row">
+    <span class="hp-dot" aria-hidden="true"></span>
+    <span class="hp-label">Homelab power draw</span>
+  </div>
+  <div class="hp-value"><span class="hp-watts">—</span><span class="hp-unit">W</span></div>
+  <svg class="hp-spark" viewBox="0 0 240 48" preserveAspectRatio="none" aria-hidden="true">
+    <polyline class="hp-spark-line" fill="none" points="" />
+  </svg>
+  <div class="hp-foot"><span class="hp-status">connecting…</span></div>
+</div>
+
+<style>
+  .hp {
+    --hp-accent: #22c55e;
+    --hp-fg: #111827;
+    --hp-muted: #6b7280;
+    --hp-bg: #ffffff;
+    --hp-border: #e5e7eb;
+    max-width: 320px;
+    padding: 1rem 1.15rem;
+    border: 1px solid var(--hp-border);
+    border-radius: 12px;
+    background: var(--hp-bg);
+    color: var(--hp-fg);
+    font-family: inherit;
+    line-height: 1.2;
+  }
+  .hp-row { display: flex; align-items: center; gap: 0.5rem; }
+  .hp-label { font-size: 0.8rem; letter-spacing: 0.02em; color: var(--hp-muted); text-transform: uppercase; }
+  .hp-dot {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--hp-accent);
+    box-shadow: 0 0 0 0 var(--hp-accent);
+    animation: hp-pulse 2s infinite;
+  }
+  .hp-value { display: flex; align-items: baseline; gap: 0.3rem; margin: 0.35rem 0 0.5rem; }
+  .hp-watts { font-size: 2.6rem; font-weight: 700; font-variant-numeric: tabular-nums; }
+  .hp-unit { font-size: 1.1rem; font-weight: 600; color: var(--hp-muted); }
+  .hp-spark { width: 100%; height: 48px; display: block; }
+  .hp-spark-line { stroke: var(--hp-accent); stroke-width: 2; vector-effect: non-scaling-stroke; }
+  .hp-foot { margin-top: 0.5rem; font-size: 0.75rem; color: var(--hp-muted); }
+  .hp.is-offline { --hp-accent: #9ca3af; }
+  .hp.is-offline .hp-dot { animation: none; }
+  @keyframes hp-pulse {
+    0%   { box-shadow: 0 0 0 0 rgba(34,197,94,0.5); }
+    70%  { box-shadow: 0 0 0 6px rgba(34,197,94,0); }
+    100% { box-shadow: 0 0 0 0 rgba(34,197,94,0); }
+  }
+  @media (prefers-color-scheme: dark) {
+    .hp { --hp-fg: #f3f4f6; --hp-muted: #9ca3af; --hp-bg: #111827; --hp-border: #374151; }
+  }
+</style>
+
+<script>
+(function () {
+  var el = document.getElementById('homelab-power');
+  if (!el) return;
+  var wattsEl  = el.querySelector('.hp-watts');
+  var lineEl   = el.querySelector('.hp-spark-line');
+  var statusEl = el.querySelector('.hp-status');
+  var SVG_W = 240, SVG_H = 48, PAD = 3;
+
+  function drawSpark(history) {
+    if (!history || history.length < 2) { lineEl.setAttribute('points', ''); return; }
+    var vals = history.map(function (p) { return p.w; });
+    var min = Math.min.apply(null, vals), max = Math.max.apply(null, vals);
+    var range = (max - min) || 1;
+    var n = vals.length;
+    var pts = vals.map(function (w, i) {
+      var x = PAD + (i / (n - 1)) * (SVG_W - 2 * PAD);
+      var y = SVG_H - PAD - ((w - min) / range) * (SVG_H - 2 * PAD);
+      return x.toFixed(1) + ',' + y.toFixed(1);
+    });
+    lineEl.setAttribute('points', pts.join(' '));
+  }
+
+  function fmt(w) { return Math.round(w).toLocaleString('en-GB'); }
+
+  function render(data) {
+    if (!data || data.ok === false || data.stale) {
+      el.classList.add('is-offline');
+      statusEl.textContent = 'offline';
+      return;
+    }
+    el.classList.remove('is-offline');
+    wattsEl.textContent = fmt(data.w);
+    drawSpark(data.history);
+    statusEl.textContent = 'live · updates every 30s';
+  }
+
+  function poll() {
+    fetch('/api/power', { headers: { 'Accept': 'application/json' } })
+      .then(function (r) { return r.json(); })
+      .then(render)
+      .catch(function () {
+        el.classList.add('is-offline');
+        statusEl.textContent = 'offline';
+      });
+  }
+
+  poll();
+  setInterval(poll, 30000);
+})();
+</script>

--- a/scripts/assets/js/search.js
+++ b/scripts/assets/js/search.js
@@ -63,13 +63,20 @@ console.log('[Search] Script loaded');
                 e.preventDefault();
                 focusSearch();
             }
+            if (e.key === 'Escape') {
+                hideResults();
+            }
         });
     }
 
     function focusSearch() {
         const input = document.getElementById('blog-search-input');
         if (input) {
-            input.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            // CSS prefers-reduced-motion can't override an explicit JS
+            // behavior option — gate it here.
+            const reduceMotion = window.matchMedia
+                && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            input.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'center' });
             input.focus();
         }
     }

--- a/scripts/brutalist-theme.css
+++ b/scripts/brutalist-theme.css
@@ -28,6 +28,11 @@
   --bg-dark: #0a0a0a;
   --text-light: #fafafa;
   --accent-orange: #f6821f;
+  /* Alias used by the jkr/jk homepage-redesign rules (var(--accent, …)).
+     Previously undefined, so their hex fallbacks always fired and a
+     palette change here silently didn't propagate. Resolves at use time,
+     so the print block's --accent-orange override follows automatically. */
+  --accent: var(--accent-orange);
   --gray-mid: #404040;
   /* Body copy (.entry-content p et al) renders in this on --bg-dark.
      #666666 was ~3.4:1 against #0a0a0a — below the WCAG AA 4.5:1 minimum
@@ -43,6 +48,10 @@ body {
   font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
   line-height: 1.6;
   position: relative;
+  /* .alignfull's width:100vw includes the scrollbar on Windows/Linux,
+     producing a permanent horizontal scrollbar. clip (unlike hidden)
+     doesn't create a scroll container, so position:sticky still works. */
+  overflow-x: clip;
 }
 
 body::before {
@@ -157,7 +166,9 @@ a:hover {
   text-decoration: underline !important;
 }
 
-a:focus {
+/* :focus-visible, not :focus — mouse clicks shouldn't paint focus rings
+   on every link; keyboard/assistive navigation still gets them. */
+a:focus-visible {
   outline: 2px solid var(--accent-orange);
   outline-offset: 2px;
 }
@@ -1478,6 +1489,24 @@ div, section, aside, nav {
   }
 }
 
+/* ── Reduced motion ───────────────────────────────────────────────── */
+/* Zero out decorative motion (card hover translates, hero lifts, the
+   search overlay's fadeIn/slideUp) for users who ask for it. !important
+   also defeats the inline animation styles search.js injects. The
+   smooth scrollIntoView is gated in search.js itself — the CSS
+   scroll-behavior property doesn't override an explicit JS behavior
+   option. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* ── Print Stylesheet ─────────────────────────────────────────────── */
 @media print {
   /* Reset to light background for printing */
@@ -1508,6 +1537,7 @@ div, section, aside, nav {
   .site-footer,
   .breadcrumb-navigation,
   .blog-search-container,
+  #blog-search-container,
   .utterances,
   .related-posts-section,
   .social-share-section,
@@ -1620,6 +1650,10 @@ div, section, aside, nav {
   color: #f5f3ee !important;
   opacity: 1 !important;
 }
+.jk-search:focus-visible {
+  outline: 2px solid var(--accent-orange);
+  outline-offset: 2px;
+}
 .jk-search kbd {
   font-family: "JetBrains Mono", monospace;
   font-size: 0.72rem;
@@ -1639,12 +1673,16 @@ div, section, aside, nav {
    Single-post pages are scoped out via :not(.single).
    ============================================================ */
 
-/* 1. Sentence-case Inter titles on archive cards (NOT on single post). */
+/* 1. Sentence-case system-stack titles on archive cards (NOT on single
+   post). Inter was declared here but never shipped as a @font-face, so
+   every visitor got the -apple-system fallback anyway — the explicit
+   stack just stops a machine with Inter installed rendering differently
+   from the live site. Ship a subset Inter before re-adding it here. */
 body:not(.single) .loop-entry .entry-title,
 body:not(.single) .loop-entry .entry-title a,
 body:not(.single) .entry-list-item .entry-title,
 body:not(.single) .entry-list-item .entry-title a {
-  font-family: "Inter", -apple-system, "Segoe UI", sans-serif !important;
+  font-family: -apple-system, "Segoe UI", sans-serif !important;
   font-size: 1.3rem !important;
   font-weight: 600 !important;
   text-transform: none !important;
@@ -1834,7 +1872,8 @@ body:not(.single) .posted-on time ~ time {
   color: #b8b5ad;
 }
 .jkr-hero-title {
-  font-family: 'Inter', -apple-system, 'Segoe UI', sans-serif !important;
+  /* Inter is not shipped — see the archive-card titles note above. */
+  font-family: -apple-system, 'Segoe UI', sans-serif !important;
   font-size: clamp(1.75rem, 3vw, 2.5rem) !important;
   line-height: 1.1 !important;
   font-weight: 600 !important;
@@ -1844,7 +1883,7 @@ body:not(.single) .posted-on time ~ time {
   text-transform: none !important;
 }
 .jkr-hero-excerpt {
-  font-family: 'Inter', -apple-system, 'Segoe UI', sans-serif;
+  font-family: -apple-system, 'Segoe UI', sans-serif;
   font-size: 1rem;
   line-height: 1.65;
   color: #a8a59c;

--- a/scripts/extract_critical_css.py
+++ b/scripts/extract_critical_css.py
@@ -9,6 +9,7 @@ This significantly improves First Contentful Paint (FCP) by 30-50%.
 """
 
 import sys
+from collections import Counter
 from pathlib import Path
 from bs4 import BeautifulSoup
 import re
@@ -57,30 +58,39 @@ class CriticalCSSExtractor:
         """Process a single HTML file"""
         try:
             with open(file_path, 'r', encoding='utf-8') as f:
-                html = f.read()
+                original_html = f.read()
 
             # Pre-parse cleanup: strip accumulated noscript fallbacks and
             # deduplicate <link> tags by href so BeautifulSoup sees a clean doc.
-            html = self._dedup_head_links(html)
+            html = self._dedup_head_links(original_html)
 
             soup = BeautifulSoup(html, 'html.parser')
 
             # Extract critical CSS
             critical_css = self._extract_critical_css(soup, file_path)
 
-            if not critical_css:
-                return False
+            inlined = False
+            if critical_css:
+                inlined = self._inline_critical_css(soup, critical_css, file_path)
 
-            # Inline critical CSS
-            if self._inline_critical_css(soup, critical_css, file_path):
-                # Convert external CSS to async preload
-                self._convert_css_to_preload(soup)
+            # Convert external CSS to async preload even when there was
+            # nothing to inline — a page whose async-eligible sheets match no
+            # critical selectors must still not ship them render-blocking,
+            # and the dedup/noscript self-healing must still persist. The
+            # old early-return on empty critical_css skipped both, leaving
+            # such pages render-blocking forever.
+            self._convert_css_to_preload(soup)
 
-                # Save modified HTML
+            # Write only when the document actually changed. Comparing
+            # against the original as BS4 would serialize it means
+            # formatting-only parse differences don't force rewrites on
+            # every run.
+            output = str(soup)
+            if output != str(BeautifulSoup(original_html, 'html.parser')):
                 with open(file_path, 'w', encoding='utf-8') as f:
-                    f.write(str(soup))
-
-                self.css_inlined += 1
+                    f.write(output)
+                if inlined:
+                    self.css_inlined += 1
                 return True
 
             return False
@@ -152,9 +162,13 @@ class CriticalCSSExtractor:
 
         return critical_css
 
-    # Stylesheets that stay render-blocking (mirrors _convert_to_async's
-    # EXCLUDED): their above-fold rules are already applied at first paint, so
-    # inlining them into the critical block is duplication that wastes the cap.
+    # Stylesheets that stay render-blocking. Single source of truth, used in
+    # two places: _extract_matching_css_rules skips them (their above-fold
+    # rules are already applied at first paint, so inlining them into the
+    # critical block is duplication that wastes the cap) and
+    # _convert_css_to_preload leaves them synchronous (brutalist-theme ships
+    # the @font-face declarations; consolidated-inline-styles is theming
+    # layered above critical CSS).
     RENDER_BLOCKING_CSS = ('brutalist-theme', 'fonts.css', 'consolidated-inline-styles')
 
     def _extract_matching_css_rules(self, soup, selectors, file_path=None):
@@ -532,15 +546,26 @@ class CriticalCSSExtractor:
         survived the dedup pass as-is) also receive a fresh noscript without
         the double-counting that occurred when noscripts were added in step 2
         *and* again in a former "step 3".
+
+        Returns True when the document semantically changed. A noscript that
+        is stripped in step 1 and re-added identically in step 3 does NOT
+        count — idempotent runs must report unchanged so callers don't
+        rewrite every file on every build.
         """
-        EXCLUDED = ('brutalist-theme', 'fonts.css', 'consolidated-inline-styles')
+        EXCLUDED = self.RENDER_BLOCKING_CSS
+        modified = False
 
         # ── Step 1: strip residual noscript blocks ───────────────────────
-        # _dedup_head_links already removed them from the raw string, but
-        # do a belt-and-suspenders BS4 cleanup for safety.
+        # _dedup_head_links already removed them from the raw string (when
+        # the caller ran it), but do a belt-and-suspenders BS4 cleanup for
+        # safety. Remember what was removed, keyed by href, so step 3 can
+        # tell a restoring re-add from a genuine change.
+        stripped = Counter()
         if soup.head:
             for ns in list(soup.head.find_all('noscript')):
-                if ns.find('link'):
+                inner = ns.find('link')
+                if inner:
+                    stripped[inner.get('href', '')] += 1
                     ns.decompose()
 
         # ── Step 2: convert stylesheet links → preload+onload ────────────
@@ -556,6 +581,7 @@ class CriticalCSSExtractor:
             link['rel'] = 'preload'
             link['as'] = 'style'
             link['onload'] = "this.onload=null;this.rel='stylesheet'"
+            modified = True
 
         # ── Step 3: add exactly one noscript per async-CSS preload link ───
         # This covers three cases:
@@ -564,6 +590,7 @@ class CriticalCSSExtractor:
         #   c) Plain preload-as-style links (no onload) left over from the old
         #      _externalize_critical_css bug — upgrade them to include onload
         #      so they actually apply the stylesheet at runtime.
+        added = Counter()
         if soup.head:
             for link in list(soup.head.find_all('link')):
                 rel  = link.get('rel') or []
@@ -575,6 +602,7 @@ class CriticalCSSExtractor:
                 # Upgrade plain preload to async onload if missing.
                 if not link.get('onload'):
                     link['onload'] = "this.onload=null;this.rel='stylesheet'"
+                    modified = True
                 noscript = soup.new_tag('noscript')
                 fallback = soup.new_tag('link')
                 fallback['rel'] = 'stylesheet'
@@ -583,6 +611,13 @@ class CriticalCSSExtractor:
                     fallback['media'] = link['media']
                 noscript.append(fallback)
                 link.insert_after(noscript)
+                added[href] += 1
+
+        # Noscript churn only counts when the set actually changed.
+        if added != stripped:
+            modified = True
+
+        return modified
 
 
 def main():

--- a/scripts/html_transformer.py
+++ b/scripts/html_transformer.py
@@ -488,14 +488,22 @@ class HTMLTransformer:
     def _apply_critical_css(self, soup, file_path):
         """Extract and inline critical CSS, convert stylesheets to async preload."""
         critical_css = self.critical_css._extract_critical_css(soup)
-        if not critical_css:
-            return False
 
-        if self.critical_css._inline_critical_css(soup, critical_css, file_path):
-            self.critical_css._convert_css_to_preload(soup)
+        modified = False
+        if critical_css and self.critical_css._inline_critical_css(
+                soup, critical_css, file_path):
             self.critical_css.css_inlined += 1
-            return True
-        return False
+            modified = True
+
+        # Convert stylesheets to async preload even when nothing was inlined
+        # — a page whose async-eligible sheets match no critical selectors
+        # must still not ship them render-blocking. The old early-return on
+        # empty critical_css left such pages render-blocking forever and
+        # stopped the noscript self-healing from persisting.
+        if self.critical_css._convert_css_to_preload(soup):
+            modified = True
+
+        return modified
 
     # WP-shipped stylesheets that survive the generator pass: small ones get
     # inlined here so they don't cost a separate request. wp_to_static_generator

--- a/scripts/optimize_css.py
+++ b/scripts/optimize_css.py
@@ -203,6 +203,17 @@ class CSSOptimizer:
         'pop-animated', 'splide-initial',
     })
 
+    # IDs created by JavaScript at runtime — same rationale as
+    # _DYNAMIC_CLASSES, but for id selectors. search.js injects the search
+    # box into <main> on load, so its ids never appear in the served HTML;
+    # without this allowlist the optimizer stripped the
+    # #blog-search-input::placeholder / cancel-button rules and part of the
+    # search restyle silently never shipped.
+    # Source of truth: `grep -oE 'id="[^"]+"' scripts/assets/js/search.js`.
+    _DYNAMIC_IDS = frozenset({
+        'blog-search-container', 'blog-search-input',
+    })
+
     def _is_selector_used(self, selector_text, used_selectors):
         """Check if a CSS selector is used in HTML.
 
@@ -258,10 +269,12 @@ class CSSOptimizer:
 
                 # If the compound references at least one class that is in
                 # HTML *or* in the dynamic-class allowlist, OR at least one
-                # id that is in HTML, this compound is matchable.
+                # id that is in HTML *or* in the dynamic-id allowlist, this
+                # compound is matchable.
                 if (any(f'.{c}' in used_selectors for c in classes)
                         or any(c in self._DYNAMIC_CLASSES for c in classes)
-                        or any(f'#{i}' in used_selectors for i in ids)):
+                        or any(f'#{i}' in used_selectors for i in ids)
+                        or any(i in self._DYNAMIC_IDS for i in ids)):
                     continue
 
                 # No referenced class/id matches → this compound (and the

--- a/tests/test_extract_critical_css.py
+++ b/tests/test_extract_critical_css.py
@@ -108,3 +108,56 @@ def test_cached_extraction_matches_uncached(tmp_path):
         ex._minify_css(r) for r in ex._parse_css_rules(css, {'p', 'h1'})
     )
     assert out == direct
+
+
+def test_empty_extraction_still_converts_to_preload(tmp_path):
+    # A page whose async-eligible sheets match no critical selectors must
+    # STILL get them converted to preload — the old early-return on empty
+    # critical CSS left such pages render-blocking forever.
+    (tmp_path / 'widgets.css').write_text('.only-footer-thing{color:red}',
+                                          encoding='utf-8')
+    page = tmp_path / 'index.html'
+    page.write_text(
+        '<html><head><link rel="stylesheet" href="/widgets.css"></head>'
+        '<body><main><h1>t</h1></main></body></html>',
+        encoding='utf-8')
+    ex = CriticalCSSExtractor()
+    ex.public_dir = tmp_path
+
+    assert ex.process_file(page) is True
+    out = page.read_text(encoding='utf-8')
+    assert 'rel="preload"' in out
+    assert 'noscript' in out
+
+
+def test_convert_css_to_preload_is_idempotent(tmp_path):
+    # Running process_file twice must report no change the second time —
+    # a strip+identical-re-add of noscripts is not a modification, so the
+    # pipeline doesn't rewrite (and recompress) every file every build.
+    (tmp_path / 'widgets.css').write_text('.x{color:red}', encoding='utf-8')
+    page = tmp_path / 'index.html'
+    page.write_text(
+        '<html><head><link rel="stylesheet" href="/widgets.css"></head>'
+        '<body><main><h1>t</h1></main></body></html>',
+        encoding='utf-8')
+    ex = CriticalCSSExtractor()
+    ex.public_dir = tmp_path
+
+    assert ex.process_file(page) is True
+    first_pass = page.read_text(encoding='utf-8')
+    assert ex.process_file(page) is False
+    assert page.read_text(encoding='utf-8') == first_pass
+
+
+def test_excluded_tuple_is_single_source():
+    # RENDER_BLOCKING_CSS drives both the extraction skip and the preload
+    # conversion — guard against the two lists drifting apart again by
+    # checking the conversion path leaves a render-blocking sheet alone.
+    from bs4 import BeautifulSoup as BS
+    soup = BS('<html><head>'
+              '<link rel="stylesheet" href="/assets/css/brutalist-theme.css">'
+              '</head><body></body></html>', 'html.parser')
+    ex = CriticalCSSExtractor()
+    assert ex._convert_css_to_preload(soup) is False
+    link = soup.find('link')
+    assert link['rel'] == ['stylesheet']

--- a/tests/test_optimize_css.py
+++ b/tests/test_optimize_css.py
@@ -1,0 +1,36 @@
+"""Tests for the unused-CSS remover's dynamic allowlists.
+
+The optimizer decides "is this selector used?" from the served HTML, which
+can't see classes/ids that JavaScript creates at runtime. Regressions here
+are silent — the rule just never ships (that's how the #blog-search-input
+placeholder styling from the search restyle disappeared).
+"""
+
+from optimize_css import CSSOptimizer
+
+
+def _used(selector, used_selectors=frozenset()):
+    return CSSOptimizer()._is_selector_used(selector, used_selectors)
+
+
+def test_dynamic_ids_survive_purge():
+    # search.js injects these ids after load — they never appear in HTML.
+    assert _used('#blog-search-input::placeholder') is True
+    assert _used('#blog-search-input::-webkit-search-cancel-button') is True
+    assert _used('#blog-search-container') is True
+
+
+def test_unknown_id_is_still_dropped():
+    assert _used('#no-such-element') is False
+
+
+def test_dynamic_classes_survive_purge():
+    assert _used('.show-drawer') is True
+    assert _used('.header-is-fixed .site-header', {'.site-header'}) is True
+
+
+def test_static_selectors_follow_html_usage():
+    assert _used('.present', {'.present'}) is True
+    assert _used('.absent') is False
+    # Pure element selectors are always kept.
+    assert _used('p > a') is True


### PR DESCRIPTION
Adds a live homelab power figure to the site, fed by Home Assistant.

## What's here
- **`/api/power` route** in the Pages Advanced Mode worker (`_worker.template.js`):
  - `POST` (token-gated via new `POWER_TOKEN`, mirrors the `PURGE_TOKEN` pattern) — stores the current wattage plus a rolling ~30-min history in the `HTML_CACHE` KV under `power:latest` (180s TTL).
  - `GET` (public, same-origin) — returns it, or `{stale:true}` when there's no fresh reading, so the widget shows "offline" instead of a frozen number.
  - No HA token ever reaches the browser; reads are same-origin so no CORS.
- **`docs/homelab-power-widget.html`** — self-contained, dependency-free widget (inline SVG sparkline, theme-aware, offline state) to paste into a WordPress Custom HTML block. Passes the site CSP (`script-src 'unsafe-inline'`, `connect-src 'self'`).

## Deploy notes
- Set `POWER_TOKEN` in the Cloudflare Pages dashboard (Settings → Environment variables → Production), same value as HA's `blog_power_token`. Also add it to local `.dev.vars`.
- No new KV namespace — reuses the existing `HTML_CACHE` binding under a `power:` key prefix.
- ~2,880 writes/day at 30s cadence; well within Workers KV free limits. KV is eventually consistent, so "live" means ~30–90s.

Pairs with jameskilbynet/HomeAssistant#1 (the HA push side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)