### PR TITLE
fix(search): force modal backgrounds past the global transparent reset

### DIFF
--- a/scripts/assets/js/search.js
+++ b/scripts/assets/js/search.js
@@ -156,9 +156,17 @@ console.log('[Search] Script loaded');
     function displayResults(results, query) {
         hideResults();
         
-        let html = `<div class="search-overlay" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.85); z-index: 99999; display: flex; flex-direction: column; align-items: center; justify-content: flex-start; padding: 20px; overflow-y: auto; animation: fadeIn 0.2s ease;" onclick="if(event.target===this) this.remove()">
-            <div style="background: #171613; border: 1px solid #33322e; border-radius: 0; max-width: 650px; width: 100%; max-height: 90vh; overflow-y: auto; box-shadow: 0 20px 60px rgba(0,0,0,0.7); animation: slideUp 0.3s ease; margin-top: 20px;">
-                <div style="padding: 20px; border-bottom: 1px solid #33322e; background: #1c1b17; position: sticky; top: 0; z-index: 10;">
+        // NOTE: backgrounds use inline !important on purpose. The theme ships a
+        // blanket reset — `div, section, aside, nav { background-color:
+        // transparent !important }` (brutalist-theme.css) — to neutralise
+        // WordPress block backgrounds. Because this overlay is built from divs,
+        // a plain inline background loses to that !important and the whole modal
+        // renders see-through over the page. An inline !important is the one
+        // author declaration that beats a stylesheet !important, so every div
+        // surface below (overlay, panel, header, result number badge) needs it.
+        let html = `<div class="search-overlay" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.85) !important; z-index: 99999; display: flex; flex-direction: column; align-items: center; justify-content: flex-start; padding: 20px; overflow-y: auto; animation: fadeIn 0.2s ease;" onclick="if(event.target===this) this.remove()">
+            <div style="background: #171613 !important; border: 1px solid #33322e; border-radius: 0; max-width: 650px; width: 100%; max-height: 90vh; overflow-y: auto; box-shadow: 0 20px 60px rgba(0,0,0,0.7); animation: slideUp 0.3s ease; margin-top: 20px;">
+                <div style="padding: 20px; border-bottom: 1px solid #33322e; background: #1c1b17 !important; position: sticky; top: 0; z-index: 10;">
                     <div style="display: flex; justify-content: space-between; align-items: flex-start; gap: 12px;">
                         <div style="flex: 1;">
                             <div style="font-size: 13px; color: #f6821f; font-weight: 600; text-transform: uppercase; letter-spacing: 0.12em; margin-bottom: 4px; font-family: 'JetBrains Mono', monospace;">Search Results</div>
@@ -183,7 +191,7 @@ console.log('[Search] Script loaded');
 
                 html += `<a href="` + safeUrl + `" style="display: block; padding: 16px; border-bottom: 1px solid #2a2925; text-decoration: none; color: inherit; transition: background-color 0.15s;" onmouseover="this.style.background='#232019'" onmouseout="this.style.background='transparent'">
                     <div style="display: flex; align-items: flex-start; gap: 10px;">
-                        <div style="flex-shrink: 0; width: 28px; height: 28px; background: #f6821f; border-radius: 0; display: flex; align-items: center; justify-content: center; color: #0a0a0a; font-size: 12px; font-weight: 700; font-family: 'JetBrains Mono', monospace;">` + (idx + 1) + `</div>
+                        <div style="flex-shrink: 0; width: 28px; height: 28px; background: #f6821f !important; border-radius: 0; display: flex; align-items: center; justify-content: center; color: #0a0a0a; font-size: 12px; font-weight: 700; font-family: 'JetBrains Mono', monospace;">` + (idx + 1) + `</div>
                         <div style="flex: 1; min-width: 0;">
                             <div style="font-size: 14px; font-weight: 600; color: #f5f3ee; margin-bottom: 4px; line-height: 1.3;">` + highlightedTitle + `</div>
                             <div style="font-size: 12px; color: #a8a59c; margin-bottom: 6px; line-height: 1.4; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;">` + highlightedDesc + `</div>


### PR DESCRIPTION
## The real cause of the see-through search results

PR #128 changed the panel colour but the modal was **still fully transparent** — the homepage showed straight through the results and text overlapped, unreadable.

Root cause is a blanket reset in `brutalist-theme.css`:

```css
/* Ensure all divs and sections have dark background by default */
div, section, aside, nav { background-color: transparent !important; }
```

It exists to neutralise WordPress/Kadence block backgrounds site-wide. But the search overlay is built entirely from `<div>`s, so their inline backgrounds lose to that `!important` and render transparent. Inline styles do **not** beat a stylesheet `!important`.

I confirmed this by driving the live site headlessly — the computed `background-color` of both the overlay and the panel was `rgba(0, 0, 0, 0)` despite the inline hex.

## Fix

An inline `!important` is the one author declaration that beats a stylesheet `!important`, so the four div surfaces are marked `!important`:

- overlay backdrop `rgba(0,0,0,0.85)`
- panel `#171613`
- header titlebar `#1c1b17`
- result number badge `#f6821f`

Result rows are `<a>` elements — the reset doesn't target those, so their hover is unaffected. A comment in `search.js` explains why the `!important`s are load-bearing so they aren't "cleaned up" later.

## Verification

Route-intercepted `search.js` on the live theme and re-measured — computed backgrounds are now `rgb(23,22,19)` / `rgb(28,27,23)` / `rgb(246,130,31)`, and the modal renders as a solid, opaque, readable card (screenshot captured locally).

## Landing in `public/`

Source-only change to `scripts/assets/js/search.js`. **This lands in `public/`** — `public/js/search.js` regenerates from it on the next pipeline build. Note: `/js/search.js` is served with a 186-day `max-age`, so returning visitors will need a hard refresh (or a cache purge) to pick it up — a separate cache-busting improvement is still worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)