### PR TITLE
feat(search): content-hash cache-bust the search.js reference

### DIFF
--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -4911,53 +4911,78 @@ document.addEventListener('DOMContentLoaded', function() {
             print(f"   ℹ️  No files to copy from {static_src}")
 
     # Match any <script> tag whose src is /js/search.js, regardless of
-    # attribute order or whitespace. The previous literal-substring guard
+    # attribute order or whitespace, and with an optional `?v=<hash>`
+    # cache-busting query. The previous literal-substring guard
     # (`'<script src="/js/search.js"' in html_content`) only matched when
     # `src` was the FIRST attribute on the tag — but html_transformer.py
     # later adds `defer` and `data-cfasync` before `src`. As a result every
     # rebuild's seeded HTML failed the duplicate check and got ANOTHER
     # script tag appended. Older posts accumulated 10–20+ duplicates.
+    # The `ver` group lets inject_search_script tell whether a seeded tag
+    # already carries the current content hash (skip) or a stale one (replace).
     _SEARCH_SCRIPT_TAG_RE = re.compile(
-        r'<script\b[^>]*\bsrc=(["\'])/js/search\.js\1[^>]*>\s*</script>',
+        r'<script\b[^>]*\bsrc=(["\'])/js/search\.js'
+        r'(?:\?v=(?P<ver>[^"\'\s>]+))?\1[^>]*>\s*</script>',
         re.IGNORECASE,
     )
+
+    def _search_script_version(self):
+        """Short content hash of the shipped search.js, for cache-busting.
+
+        /js/search.js is served with a ~186-day max-age and no version, so
+        returning visitors keep a stale copy long after a fix ships. Appending
+        `?v=<hash>` to the <script src> changes the URL only when the file's
+        bytes change, so the long cache lifetime stays but updates propagate
+        immediately. Returns '' if the file can't be read, in which case the
+        reference falls back to the plain unversioned path.
+        """
+        import hashlib
+        src = Path(__file__).parent / 'assets' / 'js' / 'search.js'
+        try:
+            return hashlib.blake2b(src.read_bytes(), digest_size=6).hexdigest()
+        except OSError:
+            return ''
 
     def inject_search_script(self):
         """Inject the search script into every HTML file exactly once.
 
-        Idempotent + self-healing: if existing duplicates are in the seeded
-        HTML (from the pre-fix bug above) we collapse them all to a single
-        canonical tag at the end of <body>.
+        Idempotent + self-healing: collapses any duplicate tags in seeded HTML
+        (from the pre-fix bug above) to a single canonical tag at the end of
+        <body>, and keeps the `?v=<hash>` cache-buster current — a tag carrying
+        a stale hash (or none) is replaced so returning visitors fetch the new
+        file instead of a long-cached copy.
         """
         print("📝 Injecting search script into HTML files...")
 
         injected_count = 0
+        updated_count = 0
         deduped_count = 0
-        canonical_tag = (
-            '<script src="/js/search.js" data-cfasync="false"></script>'
-        )
+        version = self._search_script_version()
+        src = '/js/search.js' + (f'?v={version}' if version else '')
+        canonical_tag = f'<script src="{src}" data-cfasync="false"></script>'
 
         for html_file in self.output_dir.rglob('*.html'):
             try:
                 with open(html_file, 'r', encoding='utf-8', errors='ignore') as f:
                     html_content = f.read()
 
-                # `findall` returns the capture group (quote char) per match,
-                # so its length is the count of <script ...src=/js/search.js>
-                # tags currently in the file.
-                existing_count = len(self._SEARCH_SCRIPT_TAG_RE.findall(html_content))
+                existing = list(self._SEARCH_SCRIPT_TAG_RE.finditer(html_content))
 
-                if existing_count > 1:
-                    # Strip every existing copy so we can re-add exactly one
-                    # at the canonical location below.
-                    html_content = self._SEARCH_SCRIPT_TAG_RE.sub('', html_content)
-                    existing_count = 0
-                    deduped_count += 1
-                elif existing_count == 1:
-                    # Exactly one tag — nothing to do; the existing tag's
-                    # attribute order may differ but it's already a working
-                    # reference to the same script.
+                # Exactly one tag already carrying the current hash → nothing to
+                # do. Attribute order may differ (html_transformer adds defer /
+                # data-cfasync), so we compare the version, not the whole tag.
+                if (len(existing) == 1 and version
+                        and existing[0].group('ver') == version):
                     continue
+
+                if existing:
+                    # Strip every existing copy (stale version and/or duplicates)
+                    # so we can re-add exactly one canonical tag below.
+                    html_content = self._SEARCH_SCRIPT_TAG_RE.sub('', html_content)
+                    if len(existing) > 1:
+                        deduped_count += 1
+                    else:
+                        updated_count += 1
 
                 if '</body>' in html_content:
                     html_content = html_content.replace(
@@ -4966,16 +4991,19 @@ document.addEventListener('DOMContentLoaded', function() {
                     )
                     with open(html_file, 'w', encoding='utf-8') as f:
                         f.write(html_content)
-                    injected_count += 1
+                    if not existing:
+                        injected_count += 1
             except Exception as e:
                 print(f"   ⚠️  Error injecting script into {html_file}: {str(e)}")
                 continue
 
         if deduped_count:
             print(f"   🧹 Collapsed duplicate search scripts in {deduped_count} files")
+        if updated_count:
+            print(f"   ♻️  Refreshed cache-bust hash in {updated_count} files")
         if injected_count > 0:
             print(f"   ✅ Injected search script into {injected_count} HTML files")
-        else:
+        elif not deduped_count and not updated_count:
             print("   ℹ️  No HTML files needed script injection")
     
     def generate_search_index(self):

--- a/tests/test_search_script_injection.py
+++ b/tests/test_search_script_injection.py
@@ -1,0 +1,107 @@
+"""Tests for the search-script injection + cache-busting in
+wp_to_static_generator.
+
+The generator copies /js/search.js and injects a single <script> reference
+into every page. /js/search.js is served with a ~186-day max-age and no
+version, so the reference carries a `?v=<content-hash>` cache-buster: the URL
+changes only when the file's bytes change, so returning visitors pick up fixes
+immediately while the long cache lifetime is preserved.
+
+inject_search_script only touches self.output_dir, self._SEARCH_SCRIPT_TAG_RE
+and self._search_script_version(), so we exercise it against a lightweight
+stub rather than constructing the full (WordPress-dependent) generator.
+"""
+
+import types
+
+import pytest
+
+from wp_to_static_generator import WordPressStaticGenerator as G
+
+RE = G._SEARCH_SCRIPT_TAG_RE
+VER = 'abc123def456'
+BODY = "<html><body><p>hi</p></body></html>"
+
+
+def _tag(src):
+    return f'<script src="{src}" data-cfasync="false"></script>'
+
+
+def _seed(tag):
+    return BODY.replace('</body>', f'{tag}\n</body>')
+
+
+def _run(tmp_path, files, version=VER):
+    for name, content in files.items():
+        (tmp_path / name).write_text(content)
+    stub = types.SimpleNamespace(
+        output_dir=tmp_path,
+        _SEARCH_SCRIPT_TAG_RE=RE,
+        _search_script_version=lambda: version,
+    )
+    G.inject_search_script(stub)
+    return {name: (tmp_path / name).read_text() for name in files}
+
+
+def _count(html):
+    return len(list(RE.finditer(html)))
+
+
+def test_injects_versioned_tag_into_bare_page(tmp_path):
+    out = _run(tmp_path, {'a.html': BODY})['a.html']
+    assert _count(out) == 1
+    assert f'/js/search.js?v={VER}' in out
+
+
+def test_idempotent_when_version_current(tmp_path):
+    seeded = _seed(_tag(f'/js/search.js?v={VER}'))
+    out = _run(tmp_path, {'b.html': seeded})['b.html']
+    assert out == seeded  # byte-identical, no rewrite
+
+
+def test_idempotent_with_reordered_attributes(tmp_path):
+    # html_transformer adds defer / data-cfasync before src; a current-version
+    # tag must still be recognised so we don't rewrite it every build.
+    tag = f'<script defer data-cfasync="false" src="/js/search.js?v={VER}"></script>'
+    seeded = _seed(tag)
+    out = _run(tmp_path, {'b.html': seeded})['b.html']
+    assert out == seeded
+
+
+def test_stale_version_is_replaced(tmp_path):
+    stale = _seed(_tag('/js/search.js?v=0000deadbeef'))
+    out = _run(tmp_path, {'c.html': stale})['c.html']
+    assert _count(out) == 1
+    assert '0000deadbeef' not in out
+    assert f'?v={VER}' in out
+
+
+def test_unversioned_legacy_tag_is_upgraded(tmp_path):
+    legacy = _seed(_tag('/js/search.js'))
+    out = _run(tmp_path, {'c.html': legacy})['c.html']
+    assert _count(out) == 1
+    assert f'?v={VER}' in out
+
+
+def test_duplicates_collapse_to_single_current_tag(tmp_path):
+    dup = BODY.replace(
+        '</body>',
+        _tag('/js/search.js')
+        + '<script defer src="/js/search.js?v=oldish" data-cfasync="false"></script>\n</body>',
+    )
+    out = _run(tmp_path, {'d.html': dup})['d.html']
+    assert _count(out) == 1
+    assert f'?v={VER}' in out
+
+
+def test_empty_version_falls_back_to_unversioned(tmp_path):
+    out = _run(tmp_path, {'e.html': BODY}, version='')['e.html']
+    assert _count(out) == 1
+    assert 'src="/js/search.js"' in out
+    assert '?v=' not in out
+
+
+def test_version_helper_hashes_real_file():
+    ver = G._search_script_version(types.SimpleNamespace())
+    # 6-byte blake2b digest -> 12 hex chars; empty only if the file is missing.
+    assert ver == '' or (len(ver) == 12 and all(c in '0123456789abcdef' for c in ver))


### PR DESCRIPTION
## Why

`/js/search.js` is served with a **~186-day `max-age`** and no version string. Returning visitors keep a stale copy long after a fix ships — which is exactly why the transparent-results fix (#129) didn't reach anyone until a hard refresh. Every future `search.js` change has the same problem.

## What

Append `?v=<hash>` to the injected `<script src>`, where the hash is a short BLAKE2b digest of the shipped `search.js` bytes. The URL changes **only when the file's contents change**, so the long cache lifetime is preserved but updates propagate immediately (Cloudflare varies its cache key by the query string; the static file is unaffected).

`inject_search_script` keeps that query current on every build:
- a seeded tag with a **stale** hash (or none) is **replaced**;
- **duplicates** still collapse to a single tag;
- a tag already on the **current** hash is left **byte-identical** — compared by extracted version, not full string, so `html_transformer`'s attribute reordering (`defer` / `data-cfasync` before `src`) doesn't cause rewrite churn;
- falls back to the plain unversioned path if the file can't be read.

The tag-matching regex now recognises an optional `?v=…` query so the dedup/idempotency logic keeps working.

## Tests

New `tests/test_search_script_injection.py` (8 cases): fresh inject, idempotency incl. reordered attributes, stale-version replace, unversioned-legacy upgrade, duplicate collapse, empty-version fallback, and the real-file hash shape. Full suite: **119 passed**.

## Landing in `public/`

Source-only change to `scripts/wp_to_static_generator.py` that **affects generated HTML in `public/`** — the next pipeline build stamps the versioned `<script src="/js/search.js?v=…">` into every page. First deploy after merge re-references every page's search script once (expected in the auto-commit diff); subsequent builds are no-ops unless `search.js` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)