### PR TITLE
fix(review): 44px mobile tap targets + gate the /test endpoint

### DIFF
--- a/_worker.template.js
+++ b/_worker.template.js
@@ -227,8 +227,14 @@ export default {
       return env.ASSETS.fetch(request);
     }
     
-    // Handle test endpoint
+    // Handle test endpoint — gated by PURGE_TOKEN, same as /diagnostic and
+    // /trace (#17). It only confirms the Advanced Mode worker is live, but
+    // there's no reason to expose that publicly.
     if (path === '/test') {
+      const token = request.headers.get('X-Purge-Token');
+      if (!env.PURGE_TOKEN || token !== env.PURGE_TOKEN) {
+        return new Response('Unauthorized', { status: 401 });
+      }
       return new Response(JSON.stringify({
         message: 'Pages Functions are working!',
         timestamp: new Date().toISOString(),

--- a/scripts/brutalist-theme.css
+++ b/scripts/brutalist-theme.css
@@ -1357,6 +1357,25 @@ div, section, aside, nav {
 .jkr-filter a.is-active { background: var(--accent, #f6821f); color: #0a0a0a; border-color: var(--accent, #f6821f); font-weight: 600; }
 .jkr-filter a:hover:not(.is-active) { border-color: var(--accent, #f6821f); color: #f5f3ee; }
 
+/* ── Touch targets (WCAG 2.5.5) ────────────────────────────────────────────
+   On phones the topic-filter chips (~23px tall) and social icons (34px) fall
+   short of the 44px minimum touch target. Grow them on small viewports only —
+   desktop keeps its compact, dense chrome. Padding is left to the base rules;
+   min-height + flex centering does the work without shifting the text. */
+@media (max-width: 768px) {
+  .jkr-filter a {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+  .jk-social-link {
+    width: 44px;
+    height: 44px;
+  }
+}
+
 /* headline — tighter, capped measure so the right gutter isn't dead space */
 .jkr-headline {
   font-family: "Anton", sans-serif;


### PR DESCRIPTION
Two low-risk follow-ups from the site review.

### Mobile tap targets (WCAG 2.5.5)
Topic-filter chips (~30px) and header social icons (34px) were under the 44px minimum touch target on phones. Grow both to 44px under `max-width:768px` **only** — desktop keeps its compact, dense chrome. Verified on a 390px viewport: chips go 30px → 44px with text unshifted; still on-brand (bordered, mono, orange).

### Gate `/test`
`/test` returned 200 publicly. It only confirms the Advanced Mode worker is live, but there's no reason to expose that. Now gated behind `PURGE_TOKEN` like `/diagnostic` and `/trace` — unauthenticated requests return 401.

### Notes
- Both land in `public/` on the next build (theme inlined into HTML; worker copied to `public/_worker.js`).
- Worker passes `node --check`.
- **Not** included: the "trim 36 KB critical CSS" item — see the review thread; that 36 KB is the *whole* brutalist theme inlined by deliberate design, so it's a larger architectural change (critical/async split + FOUC testing), not a config tweak. Recommending we confirm real CrUX field LCP first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)