### PR TITLE
ci(crux): wire up scheduled Chrome UX Report field-data capture

### DIFF
--- a/.github/workflows/crux-field-data.yml
+++ b/.github/workflows/crux-field-data.yml
@@ -1,0 +1,80 @@
+name: CrUX Field Data
+
+# Captures real Core Web Vitals field data (Chrome UX Report, trailing 28 days)
+# for the origin and key URLs, and commits the snapshot to data/crux-latest.json.
+#
+# Why a separate, scheduled workflow: CrUX only returns data once an origin/URL
+# has enough real Chrome traffic. The site may be below that threshold today, so
+# this runs weekly (and on demand) and starts recording the moment field data
+# appears — which is the only signal worth tuning performance against (Lighthouse
+# is a throttled lab estimate). Runs on a GitHub-hosted runner; the CrUX REST API
+# is public, so it does NOT need the self-hosted WordPress runner.
+#
+# Requires the CRUX_API_KEY repository secret (free, no OAuth):
+# https://goo.gle/crux-api-key
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Mondays 06:17 UTC — offset off the hour to avoid the scheduler rush.
+    - cron: '17 6 * * 1'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: crux-field-data
+  cancel-in-progress: false
+
+jobs:
+  fetch:
+    name: Fetch CrUX field data
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install "requests==2.34.2"
+
+      - name: Query Chrome UX Report (mobile origin + key URLs)
+        env:
+          CRUX_API_KEY: ${{ secrets.CRUX_API_KEY }}
+        run: |
+          if [ -z "$CRUX_API_KEY" ]; then
+            echo "::error::CRUX_API_KEY secret is not set. Add it under Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+          mkdir -p data
+          python3 scripts/fetch_crux_metrics.py \
+            --form-factor PHONE \
+            --url https://jameskilby.co.uk/lab/ \
+            --out data/crux-latest.json | tee crux-output.txt
+
+      - name: Publish to run summary
+        if: always()
+        run: |
+          {
+            echo '## CrUX field data (PHONE, trailing 28 days)'
+            echo '```'
+            cat crux-output.txt 2>/dev/null || echo '(no output)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit snapshot if changed
+        run: |
+          if git diff --quiet -- data/crux-latest.json; then
+            echo "No change in CrUX field data — nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/crux-latest.json
+          git commit -m "chore(crux): update field-data snapshot [skip ci]"
+          git push

--- a/data/crux-latest.json
+++ b/data/crux-latest.json
@@ -1,0 +1,14 @@
+{
+  "origin": "https://jameskilby.co.uk",
+  "formFactor": "PHONE",
+  "results": [
+    {
+      "origin": "https://jameskilby.co.uk",
+      "data": null
+    },
+    {
+      "url": "https://jameskilby.co.uk/lab/",
+      "data": null
+    }
+  ]
+}

--- a/docs/SEO.md
+++ b/docs/SEO.md
@@ -202,8 +202,15 @@ python3 scripts/fetch_crux_metrics.py --form-factor DESKTOP
 python3 scripts/fetch_crux_metrics.py --url https://jameskilby.co.uk/some/post/
 ```
 
-- **Setup:** add `CRUX_API_KEY` as a GitHub secret to run it in CI. The CrUX
-  API needs only this key (no OAuth).
+- **Setup:** add `CRUX_API_KEY` as a GitHub secret. The `.github/workflows/crux-field-data.yml`
+  workflow then runs it weekly (and on demand via `workflow_dispatch`), writing
+  `data/crux-latest.json` and committing changes. The CrUX API needs only this
+  key (no OAuth).
+- **Current state (2026-07):** the origin is below CrUX's traffic threshold, so
+  there is **no field data yet** (`data/crux-latest.json` records `data: null`).
+  The workflow starts capturing real p75 LCP/INP/CLS automatically once traffic
+  crosses the threshold — until then, tune against nothing, not the Lighthouse
+  lab estimate.
 - Low-traffic URLs legitimately return "no field data" — that's reported, not
   treated as an error. Origin-level data is the most reliable for this site.
 - GSC query-level data (OAuth) is a possible follow-up; CrUX covers CWV.


### PR DESCRIPTION
## Why

Decision support for the "trim the inlined theme to shave LCP" question. That needs **real field data**, not Lighthouse's throttled lab estimate.

I queried CrUX directly with a key: the origin and `/lab/` return **"no field data"** on PHONE, DESKTOP, and ALL_FORM_FACTORS — the site is below CrUX's traffic threshold. So:

- There's **no real-user LCP problem** to chase (the only LCP signal is the pessimistic lab sim; real-connection LCP measured ~264ms).
- The FOUC-risky critical/async CSS split is **not justified** — recommend leaving the inlined theme as-is for now.

## What this adds

`.github/workflows/crux-field-data.yml` — runs `scripts/fetch_crux_metrics.py` **weekly + on demand** on a GitHub-hosted runner (CrUX API is public — no self-hosted runner needed), writes `data/crux-latest.json`, and commits when the data moves. It starts recording p75 LCP/INP/CLS **automatically** once traffic crosses CrUX's threshold, so we can revisit the perf question on evidence.

- Commits the current `null` baseline (`data/crux-latest.json`).
- Documents the state in `docs/SEO.md`.
- **Requires the `CRUX_API_KEY` repository secret** (free, no OAuth: https://goo.gle/crux-api-key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)