### PR TITLE
fix(power): refresh a stale power widget instead of skipping it

### DIFF
--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -35,6 +35,24 @@ try:
 except (ImportError, AttributeError):
     _NOINDEX_URL_PATH_PATTERNS = ()
 
+# Matches an already-injected homelab power widget: its root element through the
+# end of its IIFE <script>. The optional `-block` covers pre-explainer builds
+# whose root was the card itself, so a stale widget from any prior version is
+# still found and replaced. DOTALL: the span covers markup + CSS + JS.
+#
+# The leading optional comment matters: the partial opens with its maintainer
+# comment, so the span has to swallow an adjacent one or replacing a stale
+# widget would leave the old comment behind and duplicate it. (Only reachable in
+# unminified output — minify_html strips comments in a real build.)
+_POWER_WIDGET_SPAN_RE = re.compile(
+    r'(?:<!--(?:(?!-->).)*?-->\s*)?'
+    r'<div\b[^>]*\bid="homelab-power(?:-block)?"[^>]*>.*?\}\)\(\);\s*</script>',
+    re.IGNORECASE | re.DOTALL,
+)
+_POWER_WIDGET_VERSION_RE = re.compile(r'data-power-widget-version="([^"]+)"')
+_POWER_WIDGET_ROOT_RE = re.compile(r'(<div\b[^>]*\bid="homelab-power-block")')
+
+
 class WordPressStaticGenerator:
     def __init__(self, wp_url, auth_token, output_dir, target_domain, use_incremental=True):
         self.wp_url = wp_url.rstrip('/')
@@ -5022,10 +5040,20 @@ document.addEventListener('DOMContentLoaded', function() {
         styling are versioned and reviewed like the rest of the pipeline. It
         polls the same-origin /api/power endpoint served by the Pages worker.
 
-        Idempotent + self-healing, mirroring inject_search_script: the widget
-        carries a stable `id="homelab-power"`, so a page that already has it
-        (an unchanged page kept from a previous build) is skipped rather than
-        given a duplicate. Only the lab page is touched.
+        Idempotent AND self-updating, mirroring inject_search_script's `?v=`
+        cache-buster. The injected root is stamped with a content hash of the
+        partial, so we can tell three cases apart:
+
+          - no widget present     -> inject before the first matching anchor
+          - present, hash current -> leave alone (no churn in public/)
+          - present, hash stale   -> replace in place, keeping its position
+
+        The stale case matters because public/ is committed: a previous build's
+        lab page already carries a widget, and an unchanged page is kept as-is
+        by the incremental build. The original guard only asked "is a widget
+        present?", so once any copy was baked into public/ the partial was
+        frozen — edits to it could never reach the site. Comparing the hash is
+        what makes an edit actually ship. Only the lab page is touched.
         """
         print("🔌 Injecting homelab power widget...")
 
@@ -5050,14 +5078,38 @@ document.addEventListener('DOMContentLoaded', function() {
             print(f"   ⚠️  Could not read lab page: {e}")
             return
 
-        if 'id="homelab-power"' in html:
-            print("   ℹ️  Power widget already present on lab page")
+        import hashlib
+        version = hashlib.blake2b(partial.encode('utf-8'), digest_size=6).hexdigest()
+        stamped, stamp_count = _POWER_WIDGET_ROOT_RE.subn(
+            r'\1 data-power-widget-version="%s"' % version, partial, count=1)
+        if stamp_count != 1:
+            # Without the stamp we cannot tell current from stale, and would
+            # rewrite the widget on every build. Fail loudly rather than churn.
+            print("   ⚠️  Could not stamp widget version (partial root changed?);"
+                  " power widget not injected")
+            return
+        # Normalise the edges so both paths below emit byte-identical markup:
+        # the span matched on a refresh ends at </script>, but the partial file
+        # carries a trailing newline, which would otherwise accumulate.
+        stamped = stamped.strip()
+
+        existing = _POWER_WIDGET_SPAN_RE.search(html)
+        if existing:
+            found = _POWER_WIDGET_VERSION_RE.search(existing.group(0))
+            if found and found.group(1) == version:
+                print("   ℹ️  Power widget already current on lab page")
+                return
+            # Stale (or unversioned, i.e. pre-dating the stamp). Swap it in
+            # place so it keeps whatever position the earlier build chose.
+            html = html[:existing.start()] + stamped + html[existing.end():]
+            target.write_text(html, encoding='utf-8')
+            print("   ♻️  Refreshed stale power widget on lab page")
             return
 
         for anchor in self._POWER_WIDGET_ANCHORS:
             if anchor in html:
                 # Insert once, before the anchor.
-                html = html.replace(anchor, partial + '\n' + anchor, 1)
+                html = html.replace(anchor, stamped + '\n' + anchor, 1)
                 target.write_text(html, encoding='utf-8')
                 print("   ✅ Injected homelab power widget into lab page")
                 return

--- a/tests/test_power_widget_injection.py
+++ b/tests/test_power_widget_injection.py
@@ -81,6 +81,70 @@ def test_missing_lab_page_is_noop(tmp_path):
     G.inject_power_widget(stub)  # should simply print + return
 
 
+def test_stale_widget_is_replaced_in_place(tmp_path):
+    """An older widget baked into public/ must be swapped for the current one.
+
+    Regression: the guard only asked "is a widget present?", so once any copy
+    was committed under public/ the partial was frozen and edits to it could
+    never reach the site.
+    """
+    once = _run(tmp_path, _lab_html(TOC))
+    stale = once.replace('data-power-widget-version="', 'data-power-widget-version="old', 1)
+    assert stale != once
+    lab = tmp_path / 'lab'
+    (lab / 'index.html').write_text(stale)
+    stub = types.SimpleNamespace(
+        output_dir=tmp_path, _POWER_WIDGET_ANCHORS=G._POWER_WIDGET_ANCHORS)
+    G.inject_power_widget(stub)
+    out = (lab / 'index.html').read_text()
+    assert out == once, "stale widget should be refreshed back to current"
+    assert out.count('id="homelab-power"') == 1
+    # still positioned before the TOC, i.e. replaced in place
+    assert out.index('id="homelab-power"') < out.index('id="rank-math-toc"')
+
+
+def test_unversioned_legacy_widget_is_replaced(tmp_path):
+    """A widget from before the version stamp existed must still be upgraded.
+
+    This is the exact shape sitting in public/lab/index.html today: the card as
+    the root element, no wrapper and no version attribute.
+    """
+    legacy = (
+        '<div id="homelab-power" class="hp" aria-live="polite">'
+        '<span class="hp-watts">—</span></div>'
+        '<style>#homelab-power{color:red}</style>'
+        '<script>(function(){var x=1;})();</script>'
+    )
+    html = f"<html><body><main><p>Intro.</p>{legacy}{TOC}<h2>At a Glance</h2></main></body></html>"
+    out = _run(tmp_path, html)
+    assert 'data-power-widget-version="' in out, "legacy widget should be upgraded"
+    assert 'What am I looking at' in out, "current partial's explainer should be present"
+    assert out.count('id="homelab-power"') == 1, "must not leave the old copy behind"
+    assert '#homelab-power{color:red}' not in out, "old widget CSS should be gone"
+
+
+def test_repeated_runs_are_stable(tmp_path):
+    """Three consecutive builds must not churn the page (noisy public/ diffs)."""
+    first = _run(tmp_path, _lab_html(TOC))
+    lab = tmp_path / 'lab'
+    for _ in range(2):
+        stub = types.SimpleNamespace(
+            output_dir=tmp_path, _POWER_WIDGET_ANCHORS=G._POWER_WIDGET_ANCHORS)
+        G.inject_power_widget(stub)
+    assert (lab / 'index.html').read_text() == first
+
+
+def test_partial_root_is_stampable():
+    """The injector stamps the version onto this exact root; guard the contract."""
+    from pathlib import Path
+    import re as _re
+    import wp_to_static_generator as mod
+    partial = (Path(mod.__file__).parent / 'partials'
+               / 'homelab-power-widget.html').read_text()
+    assert _re.search(r'<div\b[^>]*\bid="homelab-power-block"', partial), \
+        "inject_power_widget stamps id=homelab-power-block; root must keep it"
+
+
 def test_partial_contains_expected_hooks():
     # Guard the contract the injector/JS relies on.
     from pathlib import Path


### PR DESCRIPTION
**Edits to the widget partial could never reach the live site.** This is why #136 merged, deployed, and yet `/lab/` still serves the pre-explainer markup.

## Root cause

`public/` is committed, so a previous build's lab page already carries a widget. The guard only asked whether one was *present*:

```python
if 'id="homelab-power"' in html:
    print("   ℹ️  Power widget already present on lab page")
    return
```

Once any copy was baked into `public/lab/index.html`, that check always hit and injection was skipped forever — freezing the partial. Editing `scripts/partials/homelab-power-widget.html` had no effect, ever.

`inject_search_script` already solves exactly this with a `?v=<hash>` cache-buster, and carries a comment about having been bitten by this same class of bug. `inject_power_widget` mirrored its structure but omitted the versioning.

## Fix

Stamp the injected root with a content hash of the partial and compare it. Three cases:

| State | Action |
|---|---|
| absent | inject before the first matching anchor (unchanged) |
| hash current | leave alone — no churn in `public/` |
| hash stale | replace in place, keeping the position the earlier build chose |

Two details that matter:
- The span regex also matches an **unversioned** root (`id="homelab-power"` — the shape sitting in `public/` today), so the existing stale copy upgrades rather than getting a sibling.
- It swallows an **adjacent leading comment**, or refreshing would orphan the partial's maintainer comment and duplicate it.

## Verification

Ran against the **real committed `public/lab/index.html`** — the page being served right now:

```
BEFORE:  homelab-power-block → 0 | What am I looking at → 0 | id="homelab-power" → 1
         ♻️  Refreshed stale power widget on lab page
AFTER:   homelab-power-block → 9 | What am I looking at → 1 | id="homelab-power" → 1
re-run:  ℹ️  Power widget already current  →  no churn
```

New tests: stale-is-replaced-in-place, unversioned-legacy-is-upgraded, repeated-runs-are-stable, plus a root-is-stampable contract guard. **Full suite: 129 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)