### PR TITLE
feat: assert output quality in CI and report it to Slack

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -24,6 +24,7 @@ on:
 # site back to main, so it must explicitly grant contents: write.
 permissions:
   contents: write
+  actions: write   # dispatch quality-checks.yml after a successful deploy
 
 # Prevent concurrent runs of this workflow
 concurrency:
@@ -938,6 +939,7 @@ jobs:
       continue-on-error: true
 
     - name: Validate HTML and deployment (parallel)
+      id: validation
       timeout-minutes: 10
       run: |
         echo "🔍 Running HTML validation and deployment validation in parallel..."
@@ -1113,6 +1115,16 @@ jobs:
           echo "pushed_sha=" >> $GITHUB_OUTPUT
           exit 0
         fi
+
+        # Diff size, captured before the commit. A build that rewrites ~1500
+        # files instead of ~20 is the shape the WP-Optimize timestamp churn
+        # took (every page rewritten for zero content change), and it was only
+        # ever visible by reading `git log --stat` after the fact.
+        DIFF_STAT=$(git diff --cached --shortstat | sed 's/^ *//')
+        DIFF_FILES=$(git diff --cached --name-only | wc -l | tr -d ' ')
+        echo "diff_stat=${DIFF_STAT:-none}" >> $GITHUB_OUTPUT
+        echo "diff_files=${DIFF_FILES}" >> $GITHUB_OUTPUT
+        echo "📊 Diff: ${DIFF_STAT}"
 
         echo "📝 Changes detected, committing..."
         git commit -m "🚀 Auto-update static site - $(date '+%Y-%m-%d %H:%M:%S')"
@@ -1523,6 +1535,32 @@ jobs:
           echo "⚠️ $COUNT non-blocking step(s) failed: $LIST"
         fi
 
+    - name: Trigger Lighthouse quality checks
+      # quality-checks.yml declares `push: paths: public/**`, but that trigger
+      # has never once fired: pushes made with the default GITHUB_TOKEN don't
+      # start other workflows (GitHub's loop prevention). Every run for the
+      # last six days came from its 03:00 schedule, so a regression shipped at
+      # 21:07 wasn't measured until the next morning — which is exactly how the
+      # 2026-08-08 CLS regression (0.63, perf 60) went unreported until someone
+      # ran PageSpeed by hand.
+      #
+      # Dispatching explicitly closes that loop: scores land in Slack minutes
+      # after the deploy instead of up to 24 hours later. Non-blocking — the
+      # site is already published by this point.
+      if: success() && steps.commit_push.outputs.pushed_sha != ''
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      run: |
+        echo "🔦 Dispatching quality-checks.yml against production..."
+        # run_lighthouse must be passed explicitly — the lighthouse job gates on
+        # `inputs.run_lighthouse == 'true'` for workflow_dispatch events.
+        gh workflow run quality-checks.yml --ref main \
+          -f run_lighthouse=true -f run_formatting=true \
+          && echo "✅ Lighthouse run queued" \
+          || echo "⚠️  Could not queue Lighthouse run (non-blocking)"
+
     - name: Notify Slack on Success
       if: success()
       uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
@@ -1536,13 +1574,28 @@ jobs:
             "icon_emoji": ":github:",
             "attachments": [
               {
-                "color": "${{ steps.nonblocking_report.outputs.failed_count == '0' && 'good' || 'warning' }}",
-                "title": "${{ steps.nonblocking_report.outputs.failed_count == '0' && '✅ jkcoukblog Build Success' || '⚠️ jkcoukblog Build Success (with warnings)' }}",
+                "color": "${{ (steps.nonblocking_report.outputs.failed_count == '0' && steps.validation.outputs.pages_over_budget == '0' && steps.validation.outputs.pages_stale == '0' && steps.html_transformer.outputs.css_skip_missing == '0') && 'good' || 'warning' }}",
+                "title": "${{ (steps.nonblocking_report.outputs.failed_count == '0' && steps.validation.outputs.pages_over_budget == '0' && steps.validation.outputs.pages_stale == '0' && steps.html_transformer.outputs.css_skip_missing == '0') && '✅ jkcoukblog Build Success' || '⚠️ jkcoukblog Build Success (with warnings)' }}",
                 "text": "jkcoukblog static site built and pushed successfully!",
                 "fields": [
                   {
                     "title": "Non-blocking step failures",
                     "value": "${{ steps.nonblocking_report.outputs.failed_count == '0' && 'None' || steps.nonblocking_report.outputs.failed_list }}",
+                    "short": false
+                  },
+                  {
+                    "title": "Output budgets",
+                    "value": "Max stylesheets/page: ${{ steps.validation.outputs.max_stylesheets || 'n/a' }} · over budget: ${{ steps.validation.outputs.pages_over_budget || '?' }} · stale pages: ${{ steps.validation.outputs.pages_stale || '?' }}",
+                    "short": false
+                  },
+                  {
+                    "title": "CSS inlining",
+                    "value": "${{ steps.html_transformer.outputs.css_inlined || '?' }} inlined (${{ steps.html_transformer.outputs.css_inlined_kb || '?' }} KB) · ${{ steps.html_transformer.outputs.css_dropped_empty || '0' }} empty dropped · ${{ steps.html_transformer.outputs.css_skip_missing || '0' }} skipped-missing",
+                    "short": false
+                  },
+                  {
+                    "title": "Diff",
+                    "value": "${{ steps.commit_push.outputs.diff_files || '0' }} files — ${{ steps.commit_push.outputs.diff_stat || 'no changes' }}",
                     "short": false
                   },
                   {

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -212,6 +212,51 @@ jobs:
             echo "has_results=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Compare against previous scores
+        id: lh_delta
+        if: always() && steps.lighthouse_results.outputs.has_results == 'true'
+        continue-on-error: true
+        run: |
+          # data/lighthouse-latest.json still holds the PREVIOUS run's numbers
+          # at this point — the "Record" step below overwrites it. An absolute
+          # score is hard to act on; a delta is not. P77 alone reads as "a bit
+          # low", while "P77 ▼15" is unmistakably a regression.
+          PREV_FILE=data/lighthouse-latest.json
+          delta() {  # $1 current, $2 previous
+            if [ -z "$2" ] || [ "$2" = "null" ]; then echo ""; return; fi
+            D=$(( $1 - $2 ))
+            if [ "$D" -gt 0 ]; then echo " ▲$D"
+            elif [ "$D" -lt 0 ]; then echo " ▼${D#-}"
+            else echo " ="; fi
+          }
+
+          if [ -f "$PREV_FILE" ]; then
+            P_PREV=$(jq -r '.performance // empty' "$PREV_FILE")
+            A_PREV=$(jq -r '.accessibility // empty' "$PREV_FILE")
+            B_PREV=$(jq -r '.best_practices // empty' "$PREV_FILE")
+            S_PREV=$(jq -r '.seo // empty' "$PREV_FILE")
+            CLS_PREV=$(jq -r '.cls // empty' "$PREV_FILE")
+            MEASURED=$(jq -r '.measured_at // "unknown"' "$PREV_FILE")
+          fi
+
+          P_NOW=${{ steps.lighthouse_results.outputs.performance }}
+          echo "perf_delta=$(delta "$P_NOW" "${P_PREV:-}")" >> $GITHUB_OUTPUT
+          echo "a11y_delta=$(delta "${{ steps.lighthouse_results.outputs.accessibility }}" "${A_PREV:-}")" >> $GITHUB_OUTPUT
+          echo "bp_delta=$(delta "${{ steps.lighthouse_results.outputs.best_practices }}" "${B_PREV:-}")" >> $GITHUB_OUTPUT
+          echo "seo_delta=$(delta "${{ steps.lighthouse_results.outputs.seo }}" "${S_PREV:-}")" >> $GITHUB_OUTPUT
+          echo "prev_cls=${CLS_PREV:-n/a}" >> $GITHUB_OUTPUT
+          echo "prev_measured=${MEASURED:-unknown}" >> $GITHUB_OUTPUT
+
+          # A performance drop of 5+ points is a regression worth a red card,
+          # regardless of the absolute score. The existing `status` output only
+          # looks at absolutes, so a 92 -> 87 slide would still read as green.
+          if [ -n "${P_PREV:-}" ] && [ "$P_PREV" != "null" ] && [ $(( P_NOW - P_PREV )) -le -5 ]; then
+            echo "regressed=true" >> $GITHUB_OUTPUT
+            echo "⚠️  Performance regressed ${P_PREV} → ${P_NOW}"
+          else
+            echo "regressed=false" >> $GITHUB_OUTPUT
+          fi
+
       # Persist the real Lighthouse scores so the /changelog/ and /stats/ pages
       # can show genuine numbers. generate_changelog.py (run by the deploy
       # pipeline) reads data/lighthouse-latest.json and folds it into
@@ -261,8 +306,13 @@ jobs:
             git rebase origin/main && git push origin HEAD:main
           fi
 
-      - name: Notify Slack with metrics (on push/PR)
-        if: always() && steps.lighthouse_results.outputs.has_results == 'true' && (github.event_name == 'push' || github.event_name == 'pull_request')
+      - name: Notify Slack with metrics
+        # Deliberately not filtered by event. It used to fire only on
+        # push/pull_request, but the push trigger never fires (GITHUB_TOKEN
+        # pushes don't start workflows) — so in practice the only runs were
+        # scheduled ones, and those posted nothing at all. Every run reports
+        # now, including the deploy pipeline's explicit dispatch.
+        if: always() && steps.lighthouse_results.outputs.has_results == 'true'
         uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -274,28 +324,33 @@ jobs:
               "icon_emoji": ":lighthouse:",
               "attachments": [
                 {
-                  "color": "${{ steps.lighthouse_results.outputs.status }}",
-                  "title": "🚀 Lighthouse Performance Report",
-                  "text": "Performance metrics for <${{ steps.lighthouse_results.outputs.url }}|jameskilby.co.uk>",
+                  "color": "${{ steps.lh_delta.outputs.regressed == 'true' && 'danger' || steps.lighthouse_results.outputs.status }}",
+                  "title": "${{ steps.lh_delta.outputs.regressed == 'true' && '📉 Lighthouse Regression' || '🚀 Lighthouse Performance Report' }}",
+                  "text": "Performance metrics for <${{ steps.lighthouse_results.outputs.url }}|jameskilby.co.uk> · previous run ${{ steps.lh_delta.outputs.prev_measured || 'unknown' }}",
                   "fields": [
                     {
                       "title": "🎯 Performance",
-                      "value": "${{ steps.lighthouse_results.outputs.performance }}/100",
+                      "value": "${{ steps.lighthouse_results.outputs.performance }}/100${{ steps.lh_delta.outputs.perf_delta }}",
                       "short": true
                     },
                     {
                       "title": "♿ Accessibility",
-                      "value": "${{ steps.lighthouse_results.outputs.accessibility }}/100",
+                      "value": "${{ steps.lighthouse_results.outputs.accessibility }}/100${{ steps.lh_delta.outputs.a11y_delta }}",
                       "short": true
                     },
                     {
                       "title": "✅ Best Practices",
-                      "value": "${{ steps.lighthouse_results.outputs.best_practices }}/100",
+                      "value": "${{ steps.lighthouse_results.outputs.best_practices }}/100${{ steps.lh_delta.outputs.bp_delta }}",
                       "short": true
                     },
                     {
                       "title": "🔍 SEO",
-                      "value": "${{ steps.lighthouse_results.outputs.seo }}/100",
+                      "value": "${{ steps.lighthouse_results.outputs.seo }}/100${{ steps.lh_delta.outputs.seo_delta }}",
+                      "short": true
+                    },
+                    {
+                      "title": "📐 CLS",
+                      "value": "${{ steps.lighthouse_results.outputs.cls }} (was ${{ steps.lh_delta.outputs.prev_cls || 'n/a' }})",
                       "short": true
                     },
                     {

--- a/scripts/html_transformer.py
+++ b/scripts/html_transformer.py
@@ -16,6 +16,7 @@ Transform order (each depends on the previous being stable):
 The original standalone scripts remain functional for individual use.
 """
 
+import os
 import sys
 import re
 import time
@@ -92,6 +93,25 @@ class HTMLTransformer:
 
         elapsed = time.time() - start_time
         self._print_summary(elapsed)
+        self._write_github_output()
+
+    def _write_github_output(self):
+        """Expose the inlining counters to the workflow so Slack can report
+        them. `skip_not_on_disk` is the number that mattered: it read 1442 on
+        the 2026-08-08 build while the log otherwise looked like a clean
+        success, and nothing surfaced it outside the raw job output."""
+        out = os.environ.get('GITHUB_OUTPUT')
+        if not out:
+            return
+        s = self.wp_inline_stats
+        try:
+            with open(out, 'a', encoding='utf-8') as fh:
+                fh.write(f"css_inlined={s['inlined']}\n")
+                fh.write(f"css_inlined_kb={s['inlined_bytes'] // 1024}\n")
+                fh.write(f"css_dropped_empty={s['dropped_empty']}\n")
+                fh.write(f"css_skip_missing={s['skip_not_on_disk']}\n")
+        except OSError as e:
+            print(f"⚠️  Could not write GITHUB_OUTPUT: {e}")
 
     # Pre-compiled at class load so the per-file strip avoids re-parsing.
     # Kadence emits this inline `<script>` once per page — usually right

--- a/scripts/validate_deployment.py
+++ b/scripts/validate_deployment.py
@@ -13,6 +13,7 @@ Usage:
     python3 validate_deployment.py <site_directory>
 """
 
+import os
 import re
 import sys
 from pathlib import Path
@@ -625,6 +626,109 @@ class DeploymentValidator:
         else:
             print("   ✅ Path manifest stamped into _worker.js")
 
+    # Budget file that the Lighthouse PR gate asserts against. Read at runtime
+    # so this validator and the gate can't drift apart.
+    BUDGET_PATH = Path(__file__).parent.parent / '.github/lighthouse/budget.json'
+
+    # Markers that should never survive a build. wpo-minify paths come from
+    # WP-Optimize's minify cache, disabled in Aug 2026 — any page still
+    # carrying one was served from a stale incremental cache rather than
+    # regenerated.
+    STALE_MARKERS = ('wpo-minify',)
+
+    def _stylesheet_budget(self):
+        """Max stylesheets/page from budget.json, or None if unreadable."""
+        try:
+            budget = json.loads(self.BUDGET_PATH.read_text())
+        except (OSError, ValueError):
+            return None
+        for entry in budget:
+            for counts in entry.get('resourceCounts', []):
+                if counts.get('resourceType') == 'stylesheet':
+                    return counts.get('budget')
+        return None
+
+    # A stylesheet request is either a plain <link rel=stylesheet> or the
+    # async pattern critical CSS rewrites it into (rel=preload + as=style).
+    # <noscript> fallbacks duplicate the href, so count distinct hrefs only.
+    _CSS_REQ_RE = re.compile(
+        r'<link[^>]+(?:rel="stylesheet"|as="style")[^>]*href="([^"]+)"'
+        r'|<link[^>]+href="([^"]+)"[^>]*(?:rel="stylesheet"|as="style")',
+        re.IGNORECASE,
+    )
+
+    def validate_resource_budgets(self):
+        """Assert per-page stylesheet requests against the Lighthouse budget.
+
+        Why this exists: on 2026-08-08 a build shipped 172 of 254 pages over
+        the stylesheet budget (and 0.63 CLS with it) while every existing
+        validator passed and Slack reported success. The pipeline measured
+        how much work it did, never whether the output was correct. The
+        Lighthouse gate that would have caught it only runs against the
+        already-deployed site, too late to block anything.
+        """
+        print("📐 Validating per-page resource budgets...")
+
+        limit = self._stylesheet_budget()
+        if limit is None:
+            self.warnings.append(
+                f"Resource budget: could not read {self.BUDGET_PATH.name}, skipped")
+            return
+
+        html_files = self.find_files(['.html'])
+        over = []
+        stale = []
+        worst = 0
+
+        for f in html_files:
+            try:
+                html = f.read_text(encoding='utf-8', errors='replace')
+            except OSError:
+                continue
+            hrefs = {m.group(1) or m.group(2) for m in self._CSS_REQ_RE.finditer(html)}
+            count = len(hrefs)
+            worst = max(worst, count)
+            if count > limit:
+                over.append((f.relative_to(self.site_dir).as_posix(), count))
+            if any(marker in html for marker in self.STALE_MARKERS):
+                stale.append(f.relative_to(self.site_dir).as_posix())
+
+        self.stats['Max stylesheets/page'] = f"{worst} (budget {limit})"
+        self.stats['Pages over stylesheet budget'] = len(over)
+        self.stats['Pages with stale markers'] = len(stale)
+
+        # Warning, not error: shipping a slower page is better than blocking a
+        # content deploy. It goes to Slack in the build card, where a non-zero
+        # count is visible rather than buried in a log.
+        if over:
+            worst_pages = ", ".join(f"{p} ({n})" for p, n in
+                                    sorted(over, key=lambda x: -x[1])[:3])
+            self.warnings.append(
+                f"{len(over)}/{len(html_files)} pages exceed the stylesheet "
+                f"budget of {limit} (worst: {worst_pages})")
+        if stale:
+            self.warnings.append(
+                f"{len(stale)} page(s) carry stale build markers "
+                f"{self.STALE_MARKERS} — served from cache, not regenerated "
+                f"(e.g. {stale[0]})")
+
+        if not over and not stale:
+            print(f"   ✅ All {len(html_files)} pages within budget "
+                  f"(max {worst}/{limit}), no stale markers")
+
+    def write_github_output(self):
+        """Expose budget results to the workflow so Slack can report them."""
+        out = os.environ.get('GITHUB_OUTPUT')
+        if not out:
+            return
+        try:
+            with open(out, 'a', encoding='utf-8') as fh:
+                fh.write(f"max_stylesheets={self.stats.get('Max stylesheets/page', 'n/a')}\n")
+                fh.write(f"pages_over_budget={self.stats.get('Pages over stylesheet budget', 0)}\n")
+                fh.write(f"pages_stale={self.stats.get('Pages with stale markers', 0)}\n")
+        except OSError as e:
+            print(f"   ⚠️  Could not write GITHUB_OUTPUT: {e}")
+
     def validate_all(self):
         """Run all validation checks."""
         print("🔍 Running comprehensive deployment validation...\n")
@@ -638,6 +742,8 @@ class DeploymentValidator:
         self.validate_utterances_comments()
         self.validate_plausible_analytics()
         self.validate_worker_stamp()
+        self.validate_resource_budgets()
+        self.write_github_output()
 
         self.print_summary()
 

--- a/tests/test_resource_budgets.py
+++ b/tests/test_resource_budgets.py
@@ -1,0 +1,109 @@
+"""Tests for the per-page resource-budget validator.
+
+On 2026-08-08 a build shipped 172 of 254 pages over the Lighthouse stylesheet
+budget — and 0.63 CLS with it — while every existing validator passed and
+Slack reported success. The pipeline measured how much work it did, never
+whether the output was correct. This validator is the assertion that was
+missing, so its counting has to be exactly right.
+"""
+
+import json
+
+from validate_deployment import DeploymentValidator
+
+BUDGET = 5
+
+
+def _page(hrefs, stale=False):
+    links = []
+    for h in hrefs:
+        links.append(
+            f'<link as="style" href="{h}" media="all" '
+            f'onload="this.onload=null;this.rel=\'stylesheet\'" rel="preload"/>'
+        )
+        # noscript fallback duplicates the href — must not be double-counted
+        links.append(f'<noscript><link rel="stylesheet" href="{h}"/></noscript>')
+    marker = '<script src="/wp-content/cache/wpo-minify/123/a.js"></script>' if stale else ''
+    return f'<html><head>{"".join(links)}</head><body>{marker}</body></html>'
+
+
+def _site(tmp_path, pages):
+    for name, html in pages.items():
+        p = tmp_path / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(html, encoding='utf-8')
+    budget = tmp_path / 'budget.json'
+    budget.write_text(json.dumps([{
+        "path": "/*",
+        "resourceCounts": [{"resourceType": "stylesheet", "budget": BUDGET}],
+    }]), encoding='utf-8')
+    v = DeploymentValidator(tmp_path)
+    v.BUDGET_PATH = budget
+    return v
+
+
+def test_reads_budget_from_lighthouse_config(tmp_path):
+    v = _site(tmp_path, {'index.html': _page(['/a.css'])})
+    assert v._stylesheet_budget() == BUDGET
+
+
+def test_page_within_budget_produces_no_warning(tmp_path):
+    v = _site(tmp_path, {'index.html': _page([f'/c{i}.css' for i in range(BUDGET)])})
+    v.validate_resource_budgets()
+
+    assert v.warnings == []
+    assert v.stats['Pages over stylesheet budget'] == 0
+    assert v.stats['Max stylesheets/page'] == f"{BUDGET} (budget {BUDGET})"
+
+
+def test_page_over_budget_warns_without_erroring(tmp_path):
+    """A slower page shouldn't block a content deploy — it should be visible."""
+    v = _site(tmp_path, {'index.html': _page([f'/c{i}.css' for i in range(7)])})
+    v.validate_resource_budgets()
+
+    assert v.stats['Pages over stylesheet budget'] == 1
+    assert len(v.warnings) == 1
+    assert 'exceed the stylesheet budget' in v.warnings[0]
+    assert v.errors == []
+
+
+def test_noscript_duplicates_are_not_double_counted(tmp_path):
+    """Each stylesheet appears twice in the served HTML (async preload plus its
+    noscript fallback) but is one network request."""
+    v = _site(tmp_path, {'index.html': _page(['/a.css', '/b.css'])})
+    v.validate_resource_budgets()
+
+    assert v.stats['Max stylesheets/page'] == f"2 (budget {BUDGET})"
+
+
+def test_stale_build_markers_are_reported(tmp_path):
+    """wpo-minify paths mean the page came from a stale incremental cache
+    rather than being regenerated — 82 pages were in that state."""
+    v = _site(tmp_path, {'index.html': _page(['/a.css'], stale=True)})
+    v.validate_resource_budgets()
+
+    assert v.stats['Pages with stale markers'] == 1
+    assert any('stale build markers' in w for w in v.warnings)
+
+
+def test_missing_budget_file_degrades_to_warning(tmp_path):
+    v = _site(tmp_path, {'index.html': _page(['/a.css'])})
+    v.BUDGET_PATH = tmp_path / 'does-not-exist.json'
+    v.validate_resource_budgets()
+
+    assert any('could not read' in w for w in v.warnings)
+    assert v.errors == []
+
+
+def test_github_output_export(tmp_path, monkeypatch):
+    out = tmp_path / 'gh_output'
+    monkeypatch.setenv('GITHUB_OUTPUT', str(out))
+
+    v = _site(tmp_path, {'index.html': _page([f'/c{i}.css' for i in range(7)])})
+    v.validate_resource_budgets()
+    v.write_github_output()
+
+    written = out.read_text()
+    assert 'pages_over_budget=1' in written
+    assert 'max_stylesheets=7 (budget 5)' in written
+    assert 'pages_stale=0' in written


### PR DESCRIPTION
The 2026-08-08 incident shipped **172/254 pages over the stylesheet budget and 0.63 CLS**, while Slack posted **✅ Build Success**.

The card reported build *activity* — pages, size, images optimised, space saved. None of that can be wrong in a way that signals broken output. This adds numbers that can **fail**.

## 1. Resource-budget validator

New validator in `validate_deployment.py` (which had 8 validators and nothing on resource counts). Asserts per-page stylesheet requests against `.github/lighthouse/budget.json`, read at runtime so it can't drift from the Lighthouse gate. Also scans for stale build markers (`wpo-minify` paths = page served from a stale incremental cache rather than regenerated).

Verified against the actual broken commit `119afe209f`:

```
- 172/253 pages exceed the stylesheet budget of 5 (worst: category/ansible/index.html (7), ...)
- 82 page(s) carry stale build markers ('wpo-minify',) ...
  Max stylesheets/page: 7 (budget 5)
```

Exactly the numbers I'd measured by hand. Against current main: `0`, `0`, max `4/5`.

Warnings rather than errors — a slower page shouldn't block a content deploy, it should be visible.

## 2. Counters surfaced to Slack

- **Inlining stats** — `css_skip_missing` read **1442** on the broken build and existed only in raw job output
- **Commit diff size** — a ~1500-file rewrite vs ~20 is the exact shape the WP-Optimize churn took, previously only visible via `git log --stat` after the fact
- **Budget results** from the new validator

Any non-zero over-budget / stale / skipped-missing count flips the card to warning, so the colour tracks *output correctness*, not just step outcomes.

## 3. Closed the Lighthouse feedback loop

This turned out to be the real gap. `quality-checks.yml` declares `push: paths: public/**` — **that trigger has never fired.** Pushes made with `GITHUB_TOKEN` don't start other workflows:

```
2026-08-08T04:11:19Z  schedule  success
2026-08-07T04:55:31Z  schedule  success
2026-08-06T05:50:16Z  schedule  success   ← every run, six days
```

So a regression shipped at 21:07 wouldn't be measured until 03:00 the next morning. That's why nothing told you the score dropped.

- `deploy-static-site.yml` now dispatches `quality-checks.yml` explicitly after a successful deploy (non-blocking, needs `actions: write`)
- its Slack step was gated to `push`/`pull_request` — so scheduled runs, the *only* runs that actually happened, posted **nothing**. Now reports on every event.
- **score deltas** vs the previous `data/lighthouse-latest.json`. `P77 ▼15` is actionable where `P77` is not. A drop of 5+ points forces a red card even when the absolute score still looks acceptable — the existing `status` output only looks at absolutes, so a 92 → 87 slide read as green.

## Testing

151 tests pass, lint clean. 7 new tests cover budget parsing, over/under budget, `<noscript>` de-duplication (each sheet appears twice but is one request), stale markers, missing budget file, and the `GITHUB_OUTPUT` export. Delta shell logic verified for improvement, regression, no-change, and first-run cases.

Does **not** change `public/` output — CI and reporting only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)