### PR TITLE
fix: make grouped API endpoints and the search index order-stable

### DIFF
--- a/scripts/markdown_api.py
+++ b/scripts/markdown_api.py
@@ -10,12 +10,31 @@ from datetime import datetime
 import yaml
 import re
 
+def _newest_first(posts):
+    """Order posts newest-first, slug-ascending within a date.
+
+    Grouped endpoints used to emit posts in whatever order Path.glob() walked
+    the directory, which is filesystem order and not stable between builds.
+    Nothing about the output was wrong — the same posts, shuffled — but every
+    build rewrote the files, and on 2026-08-09 that was 32 category endpoints
+    and 13 archive endpoints churning 13k lines per deploy for no content
+    change. Sort the emitted list rather than relying on iteration order, so
+    the endpoints stay stable regardless of how the files are walked.
+
+    Dates are ISO-8601 with a Z suffix, so lexicographic ordering is
+    chronological. Posts with a missing or unparseable date sort last rather
+    than raising.
+    """
+    by_slug = sorted(posts, key=lambda p: p.get('slug') or '')
+    return sorted(by_slug, key=lambda p: p.get('date') or '', reverse=True)
+
+
 class MarkdownAPIGenerator:
     def __init__(self, markdown_dir, api_dir):
         self.markdown_dir = Path(markdown_dir)
         self.api_dir = Path(api_dir)
         self.api_dir.mkdir(parents=True, exist_ok=True)
-    
+
     def generate_api(self):
         """Generate complete API structure"""
         print("🔌 Generating Markdown API...")
@@ -77,7 +96,7 @@ class MarkdownAPIGenerator:
         posts_dir = self.markdown_dir / 'posts'
         
         if posts_dir.exists():
-            for md_file in posts_dir.glob('*.md'):
+            for md_file in sorted(posts_dir.glob('*.md')):
                 post_data = self._parse_markdown_file(md_file)
                 if post_data and 'categories' in post_data:
                     for category in post_data['categories']:
@@ -94,14 +113,15 @@ class MarkdownAPIGenerator:
                         categories[slug]['posts'].append(post_data)
         
         # Save each category
-        for slug, data in categories.items():
+        for slug, data in sorted(categories.items()):
+            data['posts'] = _newest_first(data['posts'])
             output_file = categories_dir / f'{slug}.json'
             output_file.write_text(json.dumps(data, indent=2, ensure_ascii=False))
-        
+
         # Save categories index
         categories_index = [
             {'name': data['name'], 'slug': slug, 'count': len(data['posts'])}
-            for slug, data in categories.items()
+            for slug, data in sorted(categories.items())
         ]
         
         index_file = categories_dir / 'index.json'
@@ -118,7 +138,7 @@ class MarkdownAPIGenerator:
         posts_dir = self.markdown_dir / 'posts'
         
         if posts_dir.exists():
-            for md_file in posts_dir.glob('*.md'):
+            for md_file in sorted(posts_dir.glob('*.md')):
                 post_data = self._parse_markdown_file(md_file)
                 if post_data and 'tags' in post_data:
                     for tag in post_data['tags']:
@@ -135,14 +155,15 @@ class MarkdownAPIGenerator:
                         tags[slug]['posts'].append(post_data)
         
         # Save each tag
-        for slug, data in tags.items():
+        for slug, data in sorted(tags.items()):
+            data['posts'] = _newest_first(data['posts'])
             output_file = tags_dir / f'{slug}.json'
             output_file.write_text(json.dumps(data, indent=2, ensure_ascii=False))
-        
+
         # Save tags index
         tags_index = [
             {'name': data['name'], 'slug': slug, 'count': len(data['posts'])}
-            for slug, data in tags.items()
+            for slug, data in sorted(tags.items())
         ]
         
         index_file = tags_dir / 'index.json'
@@ -159,7 +180,7 @@ class MarkdownAPIGenerator:
         posts_dir = self.markdown_dir / 'posts'
         
         if posts_dir.exists():
-            for md_file in posts_dir.glob('*.md'):
+            for md_file in sorted(posts_dir.glob('*.md')):
                 post_data = self._parse_markdown_file(md_file)
                 if post_data and 'date' in post_data:
                     try:
@@ -182,7 +203,8 @@ class MarkdownAPIGenerator:
                               f"{post_data.get('slug', 'unknown')} — {e}")
         
         # Save each month
-        for year_month, data in archives.items():
+        for year_month, data in sorted(archives.items()):
+            data['posts'] = _newest_first(data['posts'])
             output_file = archive_dir / f'{year_month}.json'
             output_file.write_text(json.dumps(data, indent=2, ensure_ascii=False))
         
@@ -212,7 +234,7 @@ class MarkdownAPIGenerator:
         count = 0
         
         if posts_dir.exists():
-            for md_file in posts_dir.glob('*.md'):
+            for md_file in sorted(posts_dir.glob('*.md')):
                 post_data = self._parse_markdown_file(md_file, include_content=True)
                 if post_data:
                     slug = md_file.stem

--- a/scripts/wp_to_static_generator.py
+++ b/scripts/wp_to_static_generator.py
@@ -5147,8 +5147,11 @@ document.addEventListener('DOMContentLoaded', function() {
         
         search_index = []
         
-        # Process all HTML files
-        for html_file in self.output_dir.rglob('*.html'):
+        # Process all HTML files. sorted() because rglob walks in filesystem
+        # order, which is not stable between builds — search-index.json and
+        # its .min sibling were being rewritten (and re-uploaded to KV) every
+        # deploy with the same entries in a different order.
+        for html_file in sorted(self.output_dir.rglob('*.html')):
             try:
                 relative_path = html_file.relative_to(self.output_dir)
                 

--- a/tests/test_markdown_api_ordering.py
+++ b/tests/test_markdown_api_ordering.py
@@ -1,0 +1,191 @@
+"""Grouped API endpoints must be byte-stable between builds.
+
+/api/categories/*.json, /api/tags/*.json and /api/archive/*.json used to emit
+posts in Path.glob() order — filesystem order, which is not stable across
+builds. The content was never wrong, just shuffled, so nothing failed: the
+only symptom was that every deploy rewrote the endpoints. On 2026-08-09 that
+was 32 category and 13 archive endpoints churning 13,234 lines (against
+13,234 deletions — a pure permutation) for zero content change, plus their
+Brotli/Gzip sidecars and a needless KV re-upload of the search index.
+
+These tests pin the emitted order rather than the iteration order, so the
+endpoints stay stable however the directory happens to be walked.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'scripts'))
+
+pytest.importorskip('yaml')
+from markdown_api import MarkdownAPIGenerator, _newest_first  # noqa: E402
+
+
+POSTS = [
+    # (slug, date, categories, tags)
+    ('oldest-post', '2019-03-01T09:00:00Z', ['Homelab'], ['zfs']),
+    ('middle-post', '2022-07-14T18:30:00Z', ['Homelab', 'VMware'], ['zfs', 'vsan']),
+    ('newest-post', '2026-01-05T07:15:00Z', ['VMware'], ['vsan']),
+    # Same timestamp as middle-post — the slug tiebreaker has to decide, or
+    # the order is left to sort stability over an unstable input.
+    ('middle-post-duplicate-date', '2022-07-14T18:30:00Z', ['Homelab'], ['zfs']),
+]
+
+
+def _write_corpus(root: Path, order):
+    """Write the markdown corpus, creating files in the given order.
+
+    Creation order is what drives filesystem walk order on most filesystems,
+    so writing the same corpus in two different orders is how these tests
+    reproduce the original bug.
+    """
+    posts_dir = root / 'posts'
+    posts_dir.mkdir(parents=True, exist_ok=True)
+    by_slug = {p[0]: p for p in POSTS}
+    for slug in order:
+        _, date, categories, tags = by_slug[slug]
+        frontmatter = {
+            'title': slug.replace('-', ' ').title(),
+            'description': f'Description for {slug}',
+            'date': date,
+            'modified': date,
+            'categories': categories,
+            'tags': tags,
+            'url': f'https://jameskilby.co.uk/{slug}/',
+        }
+        lines = ['---']
+        for key, value in frontmatter.items():
+            if isinstance(value, list):
+                lines.append(f'{key}:')
+                lines.extend(f'  - {item}' for item in value)
+            else:
+                lines.append(f'{key}: "{value}"')
+        lines += ['---', '', f'Body text for {slug}.', '']
+        (posts_dir / f'{slug}.md').write_text('\n'.join(lines), encoding='utf-8')
+
+
+def _generate(tmp_path: Path, order, label: str) -> dict:
+    """Generate the API from a corpus written in `order`; return {path: text}."""
+    markdown_dir = tmp_path / label / 'markdown'
+    api_dir = tmp_path / label / 'api'
+    _write_corpus(markdown_dir, order)
+    MarkdownAPIGenerator(markdown_dir, api_dir).generate_api()
+    return {
+        str(p.relative_to(api_dir)): p.read_text(encoding='utf-8')
+        for p in sorted(api_dir.rglob('*.json'))
+    }
+
+
+def test_newest_first_orders_by_date_then_slug():
+    posts = [
+        {'slug': 'b', 'date': '2020-01-01T00:00:00Z'},
+        {'slug': 'a', 'date': '2026-01-01T00:00:00Z'},
+        {'slug': 'c', 'date': '2020-01-01T00:00:00Z'},
+    ]
+    assert [p['slug'] for p in _newest_first(posts)] == ['a', 'b', 'c']
+
+
+def test_newest_first_tolerates_missing_dates():
+    """A post with no date must sort last, not raise — the archive endpoint
+    already logs and skips unparseable dates, and the grouped endpoints
+    shouldn't be the thing that takes the build down."""
+    posts = [
+        {'slug': 'no-date'},
+        {'slug': 'dated', 'date': '2021-01-01T00:00:00Z'},
+        {'slug': 'null-date', 'date': None},
+    ]
+    assert [p['slug'] for p in _newest_first(posts)] == ['dated', 'no-date', 'null-date']
+
+
+# /api/index.json carries a `generated: datetime.now()` field, so it is
+# rewritten every build by construction and can't be compared byte-for-byte.
+# That is a separate (and much smaller) source of churn — one file plus its
+# sidecars — left alone here because the field is part of the published API
+# surface, not an accident of iteration order.
+TIMESTAMPED = {'index.json'}
+
+
+def test_output_is_identical_regardless_of_walk_order(tmp_path, monkeypatch):
+    """The regression itself: same corpus, different walk order, same bytes.
+
+    Creation order alone doesn't reliably change the walk order — on APFS
+    these fixtures come back identically ordered either way, so a test built
+    only on creation order passes whether the bug is fixed or not. Patching
+    glob for the second run reproduces a different walk on any filesystem.
+    """
+    natural = _generate(tmp_path, [p[0] for p in POSTS], 'natural')
+
+    original = Path.glob
+    monkeypatch.setattr(
+        Path, 'glob',
+        lambda self, pattern, *a, **kw: iter(
+            sorted(original(self, pattern, *a, **kw), reverse=True)
+        ),
+    )
+    walked_backwards = _generate(tmp_path, [p[0] for p in POSTS], 'backwards')
+
+    assert natural.keys() == walked_backwards.keys()
+    differing = [
+        name for name in natural
+        if name not in TIMESTAMPED and natural[name] != walked_backwards[name]
+    ]
+    assert not differing, f'endpoints differ with walk order: {differing}'
+
+
+def test_only_the_timestamped_index_is_allowed_to_churn(tmp_path):
+    """Pin the exemption so it stays one known file rather than a growing
+    list of things quietly excused from determinism."""
+    api = _generate(tmp_path, [p[0] for p in POSTS], 'exemption')
+    for name in TIMESTAMPED:
+        assert name in api, f'{name} is exempted but no longer generated'
+        assert 'generated' in json.loads(api[name])
+
+
+def test_category_posts_are_newest_first(tmp_path):
+    api = _generate(tmp_path, [p[0] for p in POSTS], 'cats')
+    homelab = json.loads(api['categories/homelab.json'])
+    assert [p['slug'] for p in homelab['posts']] == [
+        'middle-post',
+        'middle-post-duplicate-date',
+        'oldest-post',
+    ]
+
+
+def test_tag_posts_are_newest_first(tmp_path):
+    api = _generate(tmp_path, [p[0] for p in POSTS], 'tags')
+    zfs = json.loads(api['tags/zfs.json'])
+    assert [p['slug'] for p in zfs['posts']] == [
+        'middle-post',
+        'middle-post-duplicate-date',
+        'oldest-post',
+    ]
+
+
+def test_archive_posts_are_newest_first(tmp_path):
+    api = _generate(tmp_path, [p[0] for p in POSTS], 'archive')
+    july = json.loads(api['archive/2022-07.json'])
+    assert [p['slug'] for p in july['posts']] == [
+        'middle-post',
+        'middle-post-duplicate-date',
+    ]
+
+
+def test_index_endpoints_are_slug_sorted(tmp_path):
+    api = _generate(tmp_path, [p[0] for p in POSTS], 'indexes')
+    categories = json.loads(api['categories/index.json'])
+    tags = json.loads(api['tags/index.json'])
+    assert [c['slug'] for c in categories] == sorted(c['slug'] for c in categories)
+    assert [t['slug'] for t in tags] == sorted(t['slug'] for t in tags)
+
+
+def test_grouped_endpoints_carry_every_post(tmp_path):
+    """Sorting must not drop or duplicate anything."""
+    api = _generate(tmp_path, [p[0] for p in POSTS], 'coverage')
+    from_categories = set()
+    for name, text in api.items():
+        if name.startswith('categories/') and not name.endswith('index.json'):
+            from_categories.update(p['slug'] for p in json.loads(text)['posts'])
+    assert from_categories == {p[0] for p in POSTS}

--- a/tests/test_search_index_ordering.py
+++ b/tests/test_search_index_ordering.py
@@ -1,0 +1,87 @@
+"""search-index.json must be byte-stable between builds.
+
+generate_search_index() walked output_dir.rglob('*.html'), which yields
+filesystem order — not stable across builds. The same pages came out in a
+different order every deploy, rewriting search-index.json and its .min
+sibling (and re-uploading the index to Workers KV) for no content change.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'scripts'))
+
+from wp_to_static_generator import WordPressStaticGenerator  # noqa: E402
+
+# The indexer skips anything under 50 words as a navigation page.
+BODY = ' '.join(f'word{i}' for i in range(80))
+
+PAGES = ['zebra', 'alpha', 'middle', 'beta']
+
+
+def _page(slug: str) -> str:
+    return (
+        f'<html><head><title>{slug} - James Kilby</title>'
+        f'<meta name="description" content="Description for {slug}">'
+        f'</head><body><main><p>{slug} {BODY}</p></main></body></html>'
+    )
+
+
+def _build(root: Path, order) -> list:
+    """Write the pages in `order`, index them, return the index entries."""
+    for slug in order:
+        page_dir = root / slug
+        page_dir.mkdir(parents=True, exist_ok=True)
+        (page_dir / 'index.html').write_text(_page(slug), encoding='utf-8')
+
+    generator = WordPressStaticGenerator(
+        'https://wordpress.example',
+        'test-token',
+        str(root),
+        'https://example.com',
+        use_incremental=False,
+    )
+    generator.generate_search_index()
+    return json.loads((root / 'search-index.json').read_text(encoding='utf-8'))
+
+
+def test_index_order_is_independent_of_walk_order(tmp_path, monkeypatch):
+    """Creation order alone doesn't reliably change rglob's order — on APFS
+    both corpora come back identically ordered, so the test would pass with
+    the bug present. Patching rglob for the second build reproduces a
+    different walk on any filesystem."""
+    natural = _build(tmp_path / 'natural', PAGES)
+
+    original = Path.rglob
+    monkeypatch.setattr(
+        Path, 'rglob',
+        lambda self, pattern, *a, **kw: iter(
+            sorted(original(self, pattern, *a, **kw), reverse=True)
+        ),
+    )
+    walked_backwards = _build(tmp_path / 'backwards', PAGES)
+
+    assert [e['url'] for e in natural] == [e['url'] for e in walked_backwards]
+
+
+def test_index_is_path_sorted(tmp_path):
+    entries = _build(tmp_path / 'sorted', PAGES)
+    urls = [e['url'] for e in entries]
+    assert urls == sorted(urls), f'expected path-sorted entries, got {urls}'
+
+
+def test_min_variant_matches_the_full_index(tmp_path):
+    """Both files are written from the same list; if they ever diverge the
+    KV upload and the client-side search disagree about the corpus."""
+    root = tmp_path / 'min'
+    entries = _build(root, PAGES)
+    minified = json.loads((root / 'search-index.min.json').read_text(encoding='utf-8'))
+    assert minified == entries
+
+
+def test_every_page_is_indexed(tmp_path):
+    """Sorting must not drop entries."""
+    entries = _build(tmp_path / 'coverage', PAGES)
+    slugs = {e['url'].rstrip('/').rsplit('/', 1)[-1] for e in entries}
+    assert slugs == set(PAGES)


### PR DESCRIPTION
Follow-up to #148. With the seed fix landed, HTML churn per deploy dropped from 254 files to 3. What's left is JSON.

Run `31301066739` committed 32 category endpoints, 13 archive endpoints and both search-index variants, at **13,234 insertions against exactly 13,234 deletions**. I diffed all 32 category files: every one contains the identical set of posts in a different order. Zero content change.

## Cause

Two unsorted directory walks, both yielding filesystem order:

| file | walk |
|---|---|
| `scripts/markdown_api.py` | `posts_dir.glob('*.md')` in the category, tag, archive and individual-post generators |
| `scripts/wp_to_static_generator.py` | `output_dir.rglob('*.html')` in the search indexer |

`_generate_posts_list()` a few lines above the first one already does `sorted(...)`, so this reads as an oversight rather than intent.

## Fix

Sorting the walk alone would be enough for determinism, but it would leave the emitted order as "whichever post happened to be walked first" — arbitrary, and liable to shift again the moment a slug changes. So the grouped endpoints sort the list they emit:

- **newest first, slug-ascending within a date**, via a shared `_newest_first()`. That's what an API consumer expects from a blog, and it matches the archive index's existing `sorted(..., reverse=True)`.
- category and tag index files sort by slug.
- posts with a missing or unparseable date sort last rather than raising — the archive generator already logs and skips those, and the grouped endpoints shouldn't be what takes a build down.

## Not fixed, deliberately

`/api/index.json` and `/markdown/index.json` carry a `generated: datetime.now()` field, so they're rewritten every build by construction. That's one file each plus sidecars. The field is part of the published API surface, so dropping it is a call for the API's owner rather than something to fold into a churn cleanup. `TIMESTAMPED` in the test names the exemption explicitly so it stays one known file rather than a growing list of things excused from determinism.

## Does this change `public/`?

Yes — one-time. Every category, tag and archive endpoint gets rewritten once into the new newest-first order, and `search-index.json` / `.min.json` into path-sorted order. After that they should stop appearing in deploy diffs entirely.

`search-index.json` is uploaded to the `SEARCH_INDEX` KV namespace each deploy; contents are unchanged, only entry order, and `search.js` feeds the whole array to Fuse so ranking is unaffected.

## Tests

13 tests across two new files. Verified they fail without the fix (6 of 13) and pass with it.

The two walk-order tests patch `glob`/`rglob` for the second pass rather than relying on file creation order — on APFS both corpora come back identically ordered, so a creation-order-only test passes whether the bug is present or not. Worth knowing if you touch them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)