### PR TITLE
fix: write gzip sidecars with mtime=0 so they stop churning

### DIFF
--- a/scripts/brotli_compress.py
+++ b/scripts/brotli_compress.py
@@ -190,16 +190,31 @@ class BrotliCompressor:
             original_data = file_path.read_bytes()
             original_size = len(original_data)
 
-            with _gzip.open(gz_file, 'wb', compresslevel=9) as f:
-                f.write(original_data)
-
-            compressed_size = gz_file.stat().st_size
+            # mtime=0, not gzip.open()'s default of "now". GzipFile stamps the
+            # current time into the header's MTIME field, so recompressing an
+            # unchanged page on a later build produced different bytes and got
+            # committed again: 589 of the 617 sidecars in the 2026-08-09 08:51
+            # deploy had a source file that never changed. Brotli's format has
+            # no timestamp, which is why only 14 .br moved in that same commit
+            # against 598 .gz. gzip.compress() also omits the FNAME header that
+            # gzip.open(path) writes, so the sidecar is a few bytes smaller.
+            #
+            # Compressing in memory first also mirrors the Brotli path above:
+            # the sidecar is only written once it's known to be worth keeping,
+            # instead of being written and then unlinked.
+            compressed_data = _gzip.compress(original_data, compresslevel=9,
+                                             mtime=0)
+            compressed_size = len(compressed_data)
 
             if compressed_size < original_size * 0.95:
+                gz_file.write_bytes(compressed_data)
                 return {'success': True, 'original_size': original_size,
                         'compressed_size': compressed_size, 'log': None}
             else:
-                gz_file.unlink()
+                # An earlier build may have left a sidecar that no longer
+                # clears the threshold — drop it rather than serve it stale.
+                if gz_file.exists():
+                    gz_file.unlink()
                 return {'success': False, 'original_size': 0,
                         'compressed_size': 0, 'log': None}
 

--- a/tests/test_gzip_determinism.py
+++ b/tests/test_gzip_determinism.py
@@ -1,0 +1,111 @@
+"""Gzip sidecars must be byte-identical for identical input.
+
+The pipeline commits pre-compressed .br/.gz next to every asset, so any
+non-determinism in the compressor lands in git. gzip.open(path, 'wb') stamps
+the current time into the header MTIME field, so recompressing an unchanged
+page on a later build produced different bytes: 589 of the 617 sidecars in
+the 2026-08-09 08:51 deploy had a source file that never changed. Brotli's
+format carries no timestamp, which is why only 14 .br moved in that commit
+against 598 .gz — these tests pin both sides.
+
+The HTML transformer rewrites every page each build, so source mtime always
+beats sidecar mtime and should_compress_gzip() always recompresses. Content
+stability is therefore the only thing standing between an unchanged page and
+a committed diff.
+"""
+
+import gzip
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'scripts'))
+
+pytest.importorskip('brotli')
+from brotli_compress import BrotliCompressor  # noqa: E402
+
+
+# Must exceed the 1 KB floor in should_compress_gzip and compress by >5%,
+# or the sidecar is skipped rather than written.
+PAYLOAD = ('<html><body>' + ('<p>compressible prose repeated. </p>' * 200)
+           + '</body></html>')
+
+
+def _compress(tmp_path: Path, name: str) -> bytes:
+    """Write PAYLOAD, gzip it through the pipeline, return the sidecar bytes."""
+    root = tmp_path / name
+    root.mkdir(parents=True, exist_ok=True)
+    source = root / 'index.html'
+    source.write_text(PAYLOAD, encoding='utf-8')
+
+    # quality=1: these tests are about determinism, not compression ratio,
+    # and q11 on every case makes the suite needlessly slow.
+    compressor = BrotliCompressor(root, quality=1)
+    result = compressor._compress_one_gzip(source)
+    assert result['success'] is True, f'gzip sidecar not written: {result}'
+    return (root / 'index.html.gz').read_bytes()
+
+
+def test_gzip_output_is_stable_across_time(tmp_path):
+    """The regression: same bytes in, same bytes out, a second later."""
+    first = _compress(tmp_path, 'first')
+    time.sleep(1.1)  # long enough to tick the header's 1-second MTIME field
+    second = _compress(tmp_path, 'second')
+
+    assert first == second, (
+        'gzip sidecar changed with wall-clock time — the header MTIME field '
+        'is being populated, which recommits every sidecar on every build'
+    )
+
+
+def test_gzip_header_mtime_is_zeroed(tmp_path):
+    """Assert the mechanism directly, so a future refactor back to
+    gzip.open(path) fails here with an obvious reason rather than only
+    tripping the timing test above."""
+    data = _compress(tmp_path, 'header')
+    mtime_field = int.from_bytes(data[4:8], 'little')
+    assert mtime_field == 0, f'gzip header MTIME is {mtime_field}, expected 0'
+
+
+def test_gzip_sidecar_round_trips(tmp_path):
+    """Determinism is worthless if the bytes don't decompress."""
+    data = _compress(tmp_path, 'roundtrip')
+    assert gzip.decompress(data).decode('utf-8') == PAYLOAD
+
+
+def test_brotli_output_is_stable_across_time(tmp_path):
+    """Brotli has no timestamp field, so this already held — pin it so the
+    two sidecars can't drift apart."""
+    root = tmp_path / 'brotli'
+    root.mkdir()
+    source = root / 'index.html'
+    source.write_text(PAYLOAD, encoding='utf-8')
+    compressor = BrotliCompressor(root, quality=1)
+
+    assert compressor._compress_one_gzip(source)['success'] is True
+    assert compressor._compress_one_brotli(source)['success'] is True
+    first = (root / 'index.html.br').read_bytes()
+
+    time.sleep(1.1)
+    assert compressor._compress_one_brotli(source)['success'] is True
+    assert (root / 'index.html.br').read_bytes() == first
+
+
+def test_incompressible_input_leaves_no_sidecar(tmp_path):
+    """Below the 5% threshold nothing should be written — and any sidecar an
+    earlier build left behind must be removed, not served stale."""
+    root = tmp_path / 'incompressible'
+    root.mkdir()
+    source = root / 'random.json'
+    # os.urandom is not meaningfully compressible.
+    import os
+    source.write_bytes(os.urandom(4096))
+    stale = root / 'random.json.gz'
+    stale.write_bytes(b'stale sidecar from an earlier build')
+
+    result = BrotliCompressor(root, quality=1)._compress_one_gzip(source)
+
+    assert result['success'] is False
+    assert not stale.exists(), 'stale sidecar left on disk'


### PR DESCRIPTION
Third in the churn series, after #148 (seed) and #149 (JSON ordering).

## The problem

**589 of the 617 sidecars** committed by the 08:51 deploy (`72716c5c5e`) had a source file that never changed. The split gives it away: **598 `.gz` against 14 `.br`** in the same commit.

Brotli's format carries no timestamp. Gzip's does, and `gzip.open(path, 'wb')` populates the header MTIME field with the current time. Same bytes in, different bytes out, one second apart:

```
gzip.open(path) byte-stable across time: False
mtime field a: 1786262237   b: 1786262238
```

They get recompressed in the first place because the HTML transformer rewrites all 255 pages every build, so source mtime always beats sidecar mtime and `should_compress_gzip()` never short-circuits. Content stability was the only thing standing between an unchanged page and a committed diff — and the header timestamp removed it.

## The fix

`gzip.compress(..., mtime=0)`.

It also omits the FNAME header that `gzip.open(path)` writes, so sidecars get slightly smaller — 11 bytes on a 140 KB page, roughly 7 KB across the site:

```
source            140,117 bytes
gzip.open(path)    30,234 bytes  (FNAME + live MTIME)
compress mtime=0   30,223 bytes  (delta -11)
```

Compressing in memory first also mirrors the Brotli path directly above it: write the sidecar only once it's known to clear the 5% threshold, rather than writing and then unlinking. A sidecar left by an earlier build that no longer clears the threshold is now removed instead of served stale.

## Does this change `public/`?

Yes — one-time. Every existing `.gz` carries a non-zero MTIME, so the next deploy rewrites all of them. After that they should drop out of the diff entirely.

No serving impact: the header MTIME is advisory metadata, browsers and Cloudflare ignore it, and the compressed payload is unchanged apart from the dropped FNAME field.

## Tests

5 tests in `tests/test_gzip_determinism.py`:

- byte-stability across a wall-clock tick (the regression itself)
- the header MTIME field asserted directly, so a refactor back to `gzip.open(path)` fails with an obvious reason rather than only tripping the timing test
- round-trip decompression — determinism is worthless if the bytes don't inflate
- the equivalent Brotli stability guarantee, so the two sidecars can't drift apart
- stale-sidecar cleanup on incompressible input

Verified the two gzip tests fail without the fix.

## Expected effect

Combined with #149, the steady-state deploy commit should go from 636 files to a few dozen — changelog, stats, build metrics, and the handful of files that genuinely carry a build timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)