### PR TITLE
fix: resolve absolute stylesheet hrefs when extracting critical CSS

### DIFF
--- a/scripts/extract_critical_css.py
+++ b/scripts/extract_critical_css.py
@@ -16,6 +16,8 @@ import re
 import subprocess
 import json
 
+from enhance_html_performance import normalize_self_href
+
 
 class CriticalCSSExtractor:
     """Extract and inline critical CSS for faster rendering"""
@@ -374,11 +376,33 @@ class CriticalCSSExtractor:
         return False
 
     def _resolve_css_path(self, href):
-        """Resolve CSS file path from href"""
-        # Remove leading slash
-        href = href.lstrip('/')
+        """Resolve CSS file path from href.
 
-        # Try to find the file
+        Absolute same-site URLs and cache-busting query strings both have to
+        come off before the disk lookup. At the point this runs the hrefs are
+        absolute (`https://jameskilby.co.uk/wp-content/...`) —
+        convert_to_staging.py doesn't rewrite them to relative until "Prepare
+        output for deployment", long afterwards. lstrip('/') doesn't touch a
+        scheme, so the lookup became
+        `static-output/https:/jameskilby.co.uk/wp-content/...`, which never
+        exists.
+
+        This is the same defect #146 fixed in html_transformer's inliner; this
+        second copy of the resolver was left behind, and it fails silently:
+        an unresolvable sheet contributes no rules, and the caller can't tell
+        that apart from a sheet with nothing above the fold.
+
+        The cost was CLS. _convert_css_to_preload makes these same sheets load
+        async, so header.min.css (13.7 KB) and content.min.css (19.1 KB) —
+        which carry the above-fold layout — were being deferred with none of
+        their rules inlined. The homepage's critical CSS came out at 4,302
+        chars against the 11,684 it produces once the hrefs resolve, and
+        Lighthouse measured 0.647 CLS / P73 on 2026-08-09 07:58 UTC.
+        """
+        href = normalize_self_href(href or '').lstrip('/').split('?', 1)[0]
+        if not href:
+            return None
+
         css_path = self.public_dir / href
 
         if css_path.exists():

--- a/tests/test_extract_critical_css.py
+++ b/tests/test_extract_critical_css.py
@@ -161,3 +161,102 @@ def test_excluded_tuple_is_single_source():
     assert ex._convert_css_to_preload(soup) is False
     link = soup.find('link')
     assert link['rel'] == ['stylesheet']
+
+
+# ── href resolution ──────────────────────────────────────────────────────
+# At the point the transformer runs, stylesheet hrefs are absolute
+# (`https://jameskilby.co.uk/wp-content/...`) — convert_to_staging.py doesn't
+# rewrite them to relative until "Prepare output for deployment", long after.
+# _resolve_css_path used to do a bare lstrip('/'), which doesn't touch a
+# scheme, so the lookup missed and the sheet contributed nothing.
+#
+# It failed silently: an unresolvable sheet and a sheet with nothing above the
+# fold both yield zero rules. _convert_css_to_preload then deferred those same
+# sheets, so header.min.css (13.7 KB) and content.min.css (19.1 KB) loaded
+# async with none of their above-fold rules inlined — 0.647 CLS and P73 on
+# 2026-08-09. Same defect #146 fixed in html_transformer's inliner.
+
+def _extract_with_href(css, selectors, tmp_path, href):
+    (tmp_path / 'styles.css').write_text(css, encoding='utf-8')
+    soup = BeautifulSoup(
+        f'<html><head><link rel="stylesheet" href="{href}"></head>'
+        '<body><main><h1>t</h1><p>x</p></main></body></html>',
+        'html.parser')
+    ex = CriticalCSSExtractor()
+    ex.public_dir = tmp_path
+    return ex._extract_matching_css_rules(soup, selectors)
+
+
+def test_absolute_same_site_href_resolves(tmp_path):
+    out = _extract_with_href('p{color:red}', {'p'}, tmp_path,
+                             'https://jameskilby.co.uk/styles.css')
+    assert 'color:red' in out, 'absolute same-site href did not resolve to disk'
+
+
+def test_query_string_href_resolves(tmp_path):
+    out = _extract_with_href('p{color:red}', {'p'}, tmp_path,
+                             '/styles.css?ver=3.1.5')
+    assert 'color:red' in out, 'cache-busting query string broke the disk lookup'
+
+
+def test_absolute_href_with_query_resolves(tmp_path):
+    out = _extract_with_href('p{color:red}', {'p'}, tmp_path,
+                             'https://jameskilby.co.uk/styles.css?ver=3.1.5')
+    assert 'color:red' in out
+
+
+def test_href_form_does_not_change_the_output(tmp_path):
+    """The real invariant. A full build and an incremental build see the same
+    page with hrefs in different forms; if extraction depends on the form, the
+    two builds emit different critical CSS for identical content — which is
+    exactly the 4,621 vs 12,058 byte divergence measured before #148."""
+    css = 'p{color:red}h1{margin:0}main{display:block}'
+    outputs = {
+        href: _extract_with_href(css, {'p', 'h1', 'main'}, tmp_path, href)
+        for href in (
+            '/styles.css',
+            'styles.css',
+            '/styles.css?ver=3.1.5',
+            'https://jameskilby.co.uk/styles.css',
+            'https://jameskilby.co.uk/styles.css?ver=3.1.5',
+        )
+    }
+    distinct = set(outputs.values())
+    assert len(distinct) == 1, (
+        'critical CSS depends on href form: '
+        + repr({h: len(o) for h, o in outputs.items()})
+    )
+    assert 'color:red' in distinct.pop()
+
+
+def test_offsite_href_is_not_resolved(tmp_path):
+    """normalize_self_href only strips our own origin — a third-party sheet
+    must not be mapped onto a same-named local file."""
+    (tmp_path / 'styles.css').write_text('p{color:red}', encoding='utf-8')
+    out = _extract_with_href('p{color:red}', {'p'}, tmp_path,
+                             'https://cdn.example.com/styles.css')
+    assert out == ''
+
+
+def test_deferred_sheets_have_their_rules_inlined(tmp_path):
+    """End-to-end statement of the CLS guarantee: any sheet
+    _convert_css_to_preload defers must have contributed its above-fold rules
+    to the critical block first. A deferred sheet with no inlined rules is a
+    layout shift."""
+    (tmp_path / 'header.min.css').write_text(
+        'header{height:80px}main{display:block}', encoding='utf-8')
+    soup = BeautifulSoup(
+        '<html><head>'
+        '<link rel="stylesheet" href="https://jameskilby.co.uk/header.min.css">'
+        '</head><body><header>h</header><main><h1>t</h1></main></body></html>',
+        'html.parser')
+    ex = CriticalCSSExtractor()
+    ex.public_dir = tmp_path
+
+    critical = ex._extract_critical_css(soup)
+    deferred = ex._convert_css_to_preload(soup)
+
+    assert deferred is True, 'sheet was not deferred — fixture no longer valid'
+    assert 'height:80px' in critical, (
+        'header.min.css was deferred without its above-fold rules inlined'
+    )


### PR DESCRIPTION
Fixes the CLS regression: **P73 / CLS 0.647** on the homepage at 2026-08-09 07:58 UTC, against P91–93 / CLS 0 all morning.

The two measurements straddle the force-full rebuild — P93 was taken at 07:35, mid-rebuild, so it scored the *old* output; P73 at 07:58 scored the rebuilt site.

## Cause

`_resolve_css_path` did a bare `lstrip('/')` before the disk lookup. At the point the transformer runs, hrefs are absolute — `convert_to_staging.py` doesn't rewrite them to relative until "Prepare output for deployment", long afterwards. `lstrip('/')` doesn't touch a scheme, so the lookup became:

```
static-output/https:/jameskilby.co.uk/wp-content/.../header.min.css
```

which never exists. Query strings failed the same way.

Measured against the live homepage, holding the CSS on disk constant and varying only the href form:

| href form | sheets resolved | critical CSS |
|---|---|---|
| relative | 3/3 | 11,684 chars |
| **absolute (the actual transform-time state)** | **0/3** | **0 chars** |
| relative + `?ver=` | 0/3 | 0 chars |

This is the **same defect #146 fixed** in `html_transformer`'s stylesheet inliner. There are two copies of the resolver; only one was fixed.

## Why it costs CLS

It fails silently — an unresolvable sheet and a sheet with nothing above the fold both yield zero rules, and the caller can't tell them apart. Meanwhile `_convert_css_to_preload` defers those exact sheets.

So `header.min.css` (13.7 KB) and `content.min.css` (19.1 KB), which carry the above-fold layout, were loaded async with **none of their rules inlined**. The page paints, then reflows. The homepage's critical CSS came out at 4,302 chars against the 11,684 it produces once hrefs resolve.

## Why it surfaced now, not on 2026-08-08

Incremental builds seeded `static-output` from `public/`, where `convert_to_staging` had already made hrefs relative — so the resolver worked *by accident* and pages got their full critical CSS.

#148 made incremental builds seed from raw generator output, correctly and identically to a full build, which removed the accident. **Full builds have always produced the degraded output.** The divergence measured before #148 — 4,621 vs 12,058 bytes of critical CSS on the same page — was this bug all along, and the stale seed was masking it.

## No externalisation risk

`max_critical_css` (15,000) sits below `max_inline_critical` (16,384), so a harvested block can never cross the threshold that spills it into a separate render-blocking file. Larger critical CSS will not add a stylesheet request or push pages past the 5/5 budget.

## Does this change `public/`?

Yes. Every page's `<style id="critical-css">` block grows — roughly 4.3 KB → 11.7 KB on the homepage. That's the intended effect: the deferred sheets' above-fold rules land in the inline block where they prevent the shift.

## Tests

6 tests appended to `tests/test_extract_critical_css.py`; **5 fail without the fix**. Each href form, the invariant that form must not change output at all (the full-vs-incremental divergence), that a third-party sheet is still not mapped onto a same-named local file, and an end-to-end assertion that any sheet `_convert_css_to_preload` defers has contributed its above-fold rules first — a deferred sheet with no inlined rules is a layout shift by definition.

## Verify after merge

Watch CLS on the next Quality Checks run. Expect it back to ~0 and Performance back to the low 90s. If CLS stays high, the remaining shift is not stylesheet-driven and needs a different investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)