### PR TITLE
fix: pipeline cleanup — critical-CSS cap, budget headroom, Lighthouse history, build stamps, dns-prefetch, purge, image count

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -549,10 +549,16 @@ jobs:
           # — copying the old (smaller) file back served stale content and
           # the rsynced derivatives above then never regenerated.
 
-          # Count how many images still need modern formats
+          # Count how many images still need modern formats.
+          #
+          # Was TOTAL_IMAGES minus a bare count of every .avif on disk, which
+          # is not a subset of TOTAL_IMAGES — derivatives whose source is a
+          # format we don't count (or no longer present) inflate it, so the
+          # arithmetic went negative and the step reported "-300 of 1852".
+          # Ask the real question instead: which sources have no .avif sibling.
           TOTAL_IMAGES=$(find ./static-output/wp-content/uploads -type f \( -name "*.png" -o -name "*.jpg" -o -name "*.jpeg" \) | wc -l | xargs)
-          EXISTING_AVIF=$(find ./static-output/wp-content/uploads -type f -name "*.avif" | wc -l | xargs)
-          NEED_CONVERSION=$((TOTAL_IMAGES - EXISTING_AVIF))
+          NEED_CONVERSION=$(find ./static-output/wp-content/uploads -type f \( -name "*.png" -o -name "*.jpg" -o -name "*.jpeg" \) \
+            | while read -r img; do [ -f "${img%.*}.avif" ] || echo "$img"; done | wc -l | xargs)
           echo "📊 Images needing AVIF/WebP conversion: $NEED_CONVERSION of $TOTAL_IMAGES"
         fi
         

--- a/.github/workflows/force-full-deploy.yml
+++ b/.github/workflows/force-full-deploy.yml
@@ -119,7 +119,13 @@ jobs:
       run: |
         set -euo pipefail
         echo "🚀 Triggering deploy-static-site.yml on main..."
-        gh workflow run deploy-static-site.yml --ref main
+        # force_static_purge: the static-asset purge is normally gated on a
+        # diff of favicons/webmanifest/fonts. That gate is right for an
+        # incremental deploy, but a no-cache rebuild regenerates every asset
+        # from source — exactly the run where an edge copy is most likely to
+        # be stale in a way the diff can't see (subset fonts are served
+        # `immutable` for a year). Purge unconditionally here.
+        gh workflow run deploy-static-site.yml --ref main -f force_static_purge=true
         echo ""
         echo "✅ Triggered. The deploy uses the same concurrency group as a"
         echo "   manual run, so if a deploy is already in flight this one"

--- a/scripts/enhance_html_performance.py
+++ b/scripts/enhance_html_performance.py
@@ -232,10 +232,20 @@ class HTMLPerformanceEnhancer:
             seen_hosts.add(host)
 
         # 3. Add dns-prefetch for any referenced host without one.
-        for host in referenced_hosts - seen_hosts:
+        #
+        # sorted(): a bare set difference iterates in hash order, which varies
+        # between processes. Each new tag is inserted at head[0], so the walk
+        # order becomes the document order — the same page emitted its hints
+        # in a different sequence run to run and landed in the deploy diff.
+        #
+        # href before rel to match how the parser preserves attribute order on
+        # tags that already exist: otherwise a hint that gets pruned and
+        # recreated flips from `href rel` to `rel href` and rewrites the page
+        # again for no semantic change.
+        for host in sorted(referenced_hosts - seen_hosts):
             dns_prefetch = soup.new_tag('link')
-            dns_prefetch['rel'] = 'dns-prefetch'
             dns_prefetch['href'] = f'//{host}'
+            dns_prefetch['rel'] = 'dns-prefetch'
             soup.head.insert(0, dns_prefetch)
             modified = True
             self.optimizations_applied += 1

--- a/scripts/extract_critical_css.py
+++ b/scripts/extract_critical_css.py
@@ -27,12 +27,30 @@ class CriticalCSSExtractor:
         self.files_processed = 0
         self.css_inlined = 0
         self.css_truncated = 0
-        # Hard cap on critical CSS per page; rules beyond this are dropped.
-        self.max_critical_css = 15000
+        self.css_dropped_rules = 0
+        self.css_dropped_bytes = 0
+        self.sample_truncated = None
         # ~16 KB raw → ~5 KB on the wire after brotli. Below this we always
         # inline so the browser doesn't pay a render-blocking round-trip for
         # critical CSS. Measured: p90 page produces ~15 KB of critical CSS.
         self.max_inline_critical = 16384
+        # Hard cap on critical CSS per page; rules beyond this are dropped.
+        #
+        # Pinned to max_inline_critical, not below it. The old value (15000)
+        # was tuned while _resolve_css_path silently failed on absolute hrefs
+        # and harvested almost nothing, so no page ever reached it. Once the
+        # resolver was fixed (#151) all 252 pages saturated the cap on the
+        # first deploy, dropping 13-31 above-fold rules each. Raising it to
+        # the inline threshold recovers ~1.4 KB per page of what was being
+        # discarded.
+        #
+        # It must never exceed max_inline_critical: above that,
+        # _inline_critical_css externalises the block to its own file, which
+        # adds a render-blocking stylesheet request — the opposite of the
+        # point, and it would push pages past the 5/5 Lighthouse stylesheet
+        # budget. _assert_cap_invariant() enforces the relationship.
+        self.max_critical_css = self.max_inline_critical
+        self._assert_cap_invariant()
         # Tokenized stylesheets keyed by path — the extractor runs once per
         # HTML page, and without this every page re-read and re-tokenized
         # every linked sheet (N pages × M sheets), the dominant cost of the
@@ -171,6 +189,22 @@ class CriticalCSSExtractor:
     # _convert_css_to_preload leaves them synchronous (brutalist-theme ships
     # the @font-face declarations; consolidated-inline-styles is theming
     # layered above critical CSS).
+    def _assert_cap_invariant(self):
+        """Fail loudly if the harvest cap could trigger externalisation.
+
+        These two constants are set independently and only interact at the
+        moment a page's block is written, so a well-meaning bump to
+        max_critical_css would otherwise show up as an extra render-blocking
+        stylesheet on every page rather than as an error here.
+        """
+        if self.max_critical_css > self.max_inline_critical:
+            raise ValueError(
+                f"max_critical_css ({self.max_critical_css}) exceeds "
+                f"max_inline_critical ({self.max_inline_critical}): every page "
+                "would externalise its critical CSS into an extra "
+                "render-blocking request. Raise max_inline_critical first."
+            )
+
     RENDER_BLOCKING_CSS = ('brutalist-theme', 'fonts.css', 'consolidated-inline-styles')
 
     def _extract_matching_css_rules(self, soup, selectors, file_path=None):
@@ -206,12 +240,22 @@ class CriticalCSSExtractor:
         size = 0
         for i, rule in enumerate(minified_rules):
             if size + len(rule) > self.max_critical_css:
+                dropped_rules = len(minified_rules) - i
                 dropped_bytes = sum(len(r) for r in minified_rules[i:])
-                where = f" in {file_path}" if file_path else ""
-                print(f"   ⚠️  Critical CSS over {self.max_critical_css}B cap{where}: "
-                      f"dropped {len(minified_rules) - i}/{len(minified_rules)} rules "
-                      f"({dropped_bytes}B)")
+                # One sample line, not one per page. When the cap binds it
+                # binds on essentially every page (252/252 after #151), and
+                # 252 near-identical warnings buried the signal rather than
+                # carrying it. The totals go to the run summary instead.
+                if self.css_truncated == 0:
+                    where = f" in {file_path}" if file_path else ""
+                    print(f"   ⚠️  Critical CSS over {self.max_critical_css}B cap{where}: "
+                          f"dropped {dropped_rules}/{len(minified_rules)} rules "
+                          f"({dropped_bytes}B) — first of possibly many, "
+                          f"totals in the summary")
+                    self.sample_truncated = str(file_path) if file_path else None
                 self.css_truncated += 1
+                self.css_dropped_rules += dropped_rules
+                self.css_dropped_bytes += dropped_bytes
                 break
             kept.append(rule)
             size += len(rule)

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -37,21 +37,56 @@ def load_lighthouse_history():
 # which then masqueraded as real data on /changelog/ and /stats/.
 LIGHTHOUSE_LATEST_FILE = Path('data/lighthouse-latest.json')
 
+SCORE_KEYS = ('performance', 'accessibility', 'best_practices', 'seo')
+
+
+def _median(values):
+    ordered = sorted(values)
+    n = len(ordered)
+    if not n:
+        return None
+    mid = n // 2
+    return ordered[mid] if n % 2 else round((ordered[mid - 1] + ordered[mid]) / 2)
+
+
 def save_lighthouse_scores(scores, history):
-    """Save current Lighthouse scores to history (one entry per date — latest wins)."""
+    """Save current Lighthouse scores to history (one entry per date, median of
+    that day's runs).
+
+    One row per date is right for a 90-day trend, but "latest wins" made the
+    row mean "whichever run happened to be last", which is not a property of
+    the day at all. On 2026-08-09 the day recorded P73 — a single cold-cache
+    outlier measured four minutes after a cache-purging deploy — while seven
+    other runs that day scored 91-93. The trend then showed a cliff that
+    nothing in the site had caused.
+
+    Keeping every sample and reporting the median fixes both halves: the row
+    resists a single bad run, and `samples` preserves the within-day detail
+    that "latest wins" discarded. Consumers read date/performance/... off the
+    entry as before and can ignore the extra keys.
+    """
     today = datetime.now().strftime('%Y-%m-%d')
+
+    sample = {'timestamp': scores['timestamp'],
+              **{k: scores[k] for k in SCORE_KEYS}}
+
+    prior = next((e for e in history if e.get('date') == today), None)
+    samples = list(prior.get('samples', [])) if prior else []
+    # Pre-existing rows predate `samples`; fold the old aggregate in as one
+    # data point rather than discarding the day's history on upgrade.
+    if prior and not samples:
+        samples.append({'timestamp': prior.get('timestamp'),
+                        **{k: prior[k] for k in SCORE_KEYS if k in prior}})
+    samples.append(sample)
+
     entry = {
         'date': today,
         'timestamp': scores['timestamp'],
-        'performance': scores['performance'],
-        'accessibility': scores['accessibility'],
-        'best_practices': scores['best_practices'],
-        'seo': scores['seo']
+        'runs': len(samples),
+        **{k: _median([s[k] for s in samples if k in s]) for k in SCORE_KEYS},
+        'samples': samples,
     }
 
-    # Replace an existing same-date entry rather than appending a duplicate.
-    # The deploy pipeline runs many times a day; without this, history would
-    # fill with identical same-day rows and the trend series would be useless.
     history = [e for e in history if e.get('date') != today]
     history.append(entry)
 
@@ -65,7 +100,8 @@ def save_lighthouse_scores(scores, history):
     with open(history_file, 'w') as f:
         json.dump(history, f, indent=2)
 
-    print(f"✅ Saved Lighthouse scores to history ({len(history)} entries)")
+    print(f"✅ Saved Lighthouse scores to history ({len(history)} entries; "
+          f"today P{entry['performance']} = median of {entry['runs']} run(s))")
     return history
 
 def get_lighthouse_scores():

--- a/scripts/html_transformer.py
+++ b/scripts/html_transformer.py
@@ -944,7 +944,17 @@ class HTMLTransformer:
                 for p in type(self)._picture_repair_missing_samples:
                     print(f"     - {p}")
         if not self.skip_critical_css:
-            print(f"   Critical CSS: inlined in {self.critical_css.css_inlined} files")
+            cc = self.critical_css
+            print(f"   Critical CSS: inlined in {cc.css_inlined} files")
+            # Saturation is the number that matters: it says above-fold rules
+            # are being discarded, which the per-page warnings couldn't convey
+            # when they fired 252 times.
+            if cc.css_truncated:
+                print(f"      ⚠️  {cc.css_truncated}/{cc.css_inlined} pages hit the "
+                      f"{cc.max_critical_css}B cap — dropped "
+                      f"{cc.css_dropped_rules} rules, {cc.css_dropped_bytes / 1024:.1f} KB total")
+                if cc.sample_truncated:
+                    print(f"          sample: {cc.sample_truncated}")
         self._print_wp_inline_summary()
         print(f"{'='*60}")
 

--- a/scripts/markdown_api.py
+++ b/scripts/markdown_api.py
@@ -34,6 +34,9 @@ class MarkdownAPIGenerator:
         self.markdown_dir = Path(markdown_dir)
         self.api_dir = Path(api_dir)
         self.api_dir.mkdir(parents=True, exist_ok=True)
+        # Newest content timestamp seen while parsing, used to stamp the API
+        # index. See _generate_api_index for why this isn't datetime.now().
+        self.latest_content_ts = ''
 
     def generate_api(self):
         """Generate complete API structure"""
@@ -246,9 +249,14 @@ class MarkdownAPIGenerator:
     
     def _generate_api_index(self):
         """Generate API documentation/index"""
+        # Content timestamp, not wall clock. datetime.now() rewrote this file
+        # on every build whether or not anything had changed, which meant the
+        # file plus its .br/.gz sidecars landed in every deploy commit. The
+        # field still answers "how fresh is this API" — it just answers it
+        # about the content rather than about the build machine.
         api_docs = {
             'version': '1.0',
-            'generated': datetime.now().isoformat(),
+            'generated': self.latest_content_ts or datetime.now().isoformat(),
             'base_url': '/api',
             'endpoints': {
                 'posts': {
@@ -357,6 +365,11 @@ class MarkdownAPIGenerator:
                 'api_url': f"/api/posts/{md_file.stem}.json"
             }
             
+            # Track the newest content timestamp across everything parsed.
+            for ts in (modified_value, date_value):
+                if isinstance(ts, str) and ts > self.latest_content_ts:
+                    self.latest_content_ts = ts
+
             # Optional fields
             if 'categories' in metadata:
                 post_data['categories'] = metadata['categories']

--- a/scripts/markdown_exporter.py
+++ b/scripts/markdown_exporter.py
@@ -423,7 +423,10 @@ class MarkdownExporter:
         print("\n📋 Creating markdown index...")
         
         index_data = {
-            'generated': datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ'),
+            # Filled in from the indexed content below, not datetime.now() —
+            # a wall-clock stamp rewrote this file (and its .br/.gz sidecars)
+            # on every build regardless of whether anything changed.
+            'generated': '',
             'total_files': self.stats['posts_exported'] + self.stats['pages_exported'],
             'posts': [],
             'pages': []
@@ -454,22 +457,32 @@ class MarkdownExporter:
                     except (yaml.YAMLError, KeyError, AttributeError, TypeError):
                         pass
         
+        # Newest content date across everything indexed. Falls back to the
+        # wall clock only when there is no dated content at all.
+        dates = [item['date'] for item in
+                 index_data['posts'] + index_data['pages']
+                 if isinstance(item.get('date'), str) and item['date']]
+        index_data['generated'] = (max(dates) if dates
+                                   else datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ'))
+
         # Save index
         index_file = self.markdown_dir / 'index.json'
         index_file.write_text(json.dumps(index_data, indent=2, ensure_ascii=False))
-        
+
         print(f"   ✅ Created index: {index_file}")
     
     def _create_markdown_sitemap(self):
         """Create sitemap of markdown files"""
         print("🗺️  Creating markdown sitemap...")
         
-        sitemap_lines = ['# Markdown Content Sitemap\n']
-        sitemap_lines.append(f'Generated: {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}\n')
-        sitemap_lines.append(f'Total Files: {self.stats["posts_exported"] + self.stats["pages_exported"]}\n')
-        
+        # Header is written after the body so `Generated:` can carry the
+        # newest content date rather than the wall clock — a build-time stamp
+        # rewrote SITEMAP.md and its sidecars on every deploy for no reason.
+        body_lines = []
+        newest = ''
+
         # List posts
-        sitemap_lines.append('## Blog Posts\n')
+        body_lines.append('## Blog Posts\n')
         posts_dir = self.markdown_dir / 'posts'
         if posts_dir.exists():
             for md_file in sorted(posts_dir.glob('*.md'), reverse=True):
@@ -482,12 +495,21 @@ class MarkdownExporter:
                         title = fm.get('title', md_file.stem)
                         url = fm.get('url', '')
                         date = fm.get('date', '')
-                        
-                        sitemap_lines.append(f"- [{title}]({url}) - {date}")
-                        sitemap_lines.append(f"  - Markdown: `/markdown/posts/{md_file.name}`\n")
+                        if isinstance(date, str) and date > newest:
+                            newest = date
+
+                        body_lines.append(f"- [{title}]({url}) - {date}")
+                        body_lines.append(f"  - Markdown: `/markdown/posts/{md_file.name}`\n")
                     except (yaml.YAMLError, KeyError, AttributeError, TypeError):
-                        sitemap_lines.append(f"- {md_file.name}\n")
-        
+                        body_lines.append(f"- {md_file.name}\n")
+
+        sitemap_lines = [
+            '# Markdown Content Sitemap\n',
+            f'Generated: {newest or datetime.now().strftime("%Y-%m-%d %H:%M:%S")}\n',
+            f'Total Files: {self.stats["posts_exported"] + self.stats["pages_exported"]}\n',
+            *body_lines,
+        ]
+
         # Save sitemap
         sitemap_file = self.markdown_dir / 'SITEMAP.md'
         sitemap_file.write_text('\n'.join(sitemap_lines))

--- a/scripts/validate_deployment.py
+++ b/scripts/validate_deployment.py
@@ -677,6 +677,7 @@ class DeploymentValidator:
 
         html_files = self.find_files(['.html'])
         over = []
+        at_limit = []
         stale = []
         worst = 0
 
@@ -690,11 +691,14 @@ class DeploymentValidator:
             worst = max(worst, count)
             if count > limit:
                 over.append((f.relative_to(self.site_dir).as_posix(), count))
+            elif count == limit:
+                at_limit.append(f.relative_to(self.site_dir).as_posix())
             if any(marker in html for marker in self.STALE_MARKERS):
                 stale.append(f.relative_to(self.site_dir).as_posix())
 
         self.stats['Max stylesheets/page'] = f"{worst} (budget {limit})"
         self.stats['Pages over stylesheet budget'] = len(over)
+        self.stats['Pages at stylesheet budget'] = len(at_limit)
         self.stats['Pages with stale markers'] = len(stale)
 
         # Warning, not error: shipping a slower page is better than blocking a
@@ -711,10 +715,19 @@ class DeploymentValidator:
                 f"{len(stale)} page(s) carry stale build markers "
                 f"{self.STALE_MARKERS} — served from cache, not regenerated "
                 f"(e.g. {stale[0]})")
+        # "Within budget" hid the difference between 3/5 and 5/5. The site sat
+        # at exactly 5/5 for a full day reading as a clean pass, with one
+        # stylesheet of margin before the same check starts failing.
+        if at_limit and not over:
+            self.warnings.append(
+                f"{len(at_limit)}/{len(html_files)} pages sit exactly at the "
+                f"stylesheet budget of {limit} — no headroom; one more sheet "
+                f"on any of them trips this check (e.g. {at_limit[0]})")
 
         if not over and not stale:
+            headroom = "no headroom" if at_limit else f"{limit - worst} to spare"
             print(f"   ✅ All {len(html_files)} pages within budget "
-                  f"(max {worst}/{limit}), no stale markers")
+                  f"(max {worst}/{limit}, {headroom}), no stale markers")
 
     def write_github_output(self):
         """Expose budget results to the workflow so Slack can report them."""
@@ -725,6 +738,7 @@ class DeploymentValidator:
             with open(out, 'a', encoding='utf-8') as fh:
                 fh.write(f"max_stylesheets={self.stats.get('Max stylesheets/page', 'n/a')}\n")
                 fh.write(f"pages_over_budget={self.stats.get('Pages over stylesheet budget', 0)}\n")
+                fh.write(f"pages_at_budget={self.stats.get('Pages at stylesheet budget', 0)}\n")
                 fh.write(f"pages_stale={self.stats.get('Pages with stale markers', 0)}\n")
         except OSError as e:
             print(f"   ⚠️  Could not write GITHUB_OUTPUT: {e}")

--- a/tests/test_build_stamp_stability.py
+++ b/tests/test_build_stamp_stability.py
@@ -1,0 +1,103 @@
+"""Generated indexes must not carry a wall-clock stamp.
+
+api/index.json, markdown/index.json and markdown/SITEMAP.md each embedded
+datetime.now(), so all three — plus their .br/.gz sidecars — were rewritten on
+every deploy whether or not any content had changed. They still answer "how
+fresh is this?"; they answer it about the content rather than the build
+machine, which is both more useful and stable.
+
+Also covers the dns-prefetch hint ordering: a bare set difference iterates in
+hash order, and since each new tag is inserted at head[0] that ordering became
+document order, so pages emitted their hints in a different sequence run to
+run.
+"""
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'scripts'))
+
+pytest.importorskip('yaml')
+from bs4 import BeautifulSoup  # noqa: E402
+from enhance_html_performance import HTMLPerformanceEnhancer  # noqa: E402
+from markdown_api import MarkdownAPIGenerator  # noqa: E402
+
+POST = """---
+title: "A Post"
+description: "d"
+date: "2024-03-01T09:00:00Z"
+modified: "2026-05-04T11:22:33Z"
+categories:
+  - Homelab
+tags:
+  - zfs
+url: "https://jameskilby.co.uk/a-post/"
+---
+
+Body.
+"""
+
+
+def _build_api(tmp_path: Path, name: str) -> dict:
+    md = tmp_path / name / 'markdown'
+    (md / 'posts').mkdir(parents=True)
+    (md / 'posts' / 'a-post.md').write_text(POST, encoding='utf-8')
+    api = tmp_path / name / 'api'
+    MarkdownAPIGenerator(md, api).generate_api()
+    return json.loads((api / 'index.json').read_text(encoding='utf-8'))
+
+
+def test_api_index_is_stable_across_builds(tmp_path):
+    first = _build_api(tmp_path, 'first')
+    time.sleep(1.1)
+    second = _build_api(tmp_path, 'second')
+    assert first == second, 'api/index.json changed with wall-clock time'
+
+
+def test_api_index_stamp_tracks_content(tmp_path):
+    """The field still has to mean something — newest content timestamp."""
+    index = _build_api(tmp_path, 'content')
+    assert index['generated'] == '2026-05-04T11:22:33Z'
+
+
+def test_dns_prefetch_hints_are_emitted_in_a_stable_order():
+    """Same input, same order — regardless of set iteration."""
+    html = (
+        '<html><head></head><body>'
+        '<script src="https://cdn.example.com/a.js"></script>'
+        '<script src="https://plausible.example.net/b.js"></script>'
+        '<img src="https://images.example.org/c.png">'
+        '<script src="https://utteranc.example/d.js"></script>'
+        '</body></html>'
+    )
+    soup = BeautifulSoup(html, 'html.parser')
+    HTMLPerformanceEnhancer().optimize_external_scripts(soup)
+    hrefs = [link.get('href') for link in soup.find_all('link', rel='dns-prefetch')]
+
+    assert len(hrefs) == 4
+    # Assert the ordering property rather than comparing repeated runs: set
+    # iteration is stable within a single process (PYTHONHASHSEED is fixed for
+    # its lifetime), so a loop here would pass with the bug present and only
+    # diverge between the separate build processes where it actually bit.
+    #
+    # Tags are inserted at head[0], so document order is the reverse of the
+    # order they were added in.
+    assert hrefs == sorted(hrefs, reverse=True), (
+        f'dns-prefetch hints are not in a deterministic order: {hrefs}'
+    )
+
+
+def test_dns_prefetch_attribute_order_is_href_then_rel():
+    """A pruned-and-recreated hint must serialise identically to one the
+    parser preserved, or the page is rewritten for no semantic change."""
+    soup = BeautifulSoup(
+        '<html><head></head><body>'
+        '<script src="https://cdn.example.com/a.js"></script>'
+        '</body></html>', 'html.parser')
+    HTMLPerformanceEnhancer().optimize_external_scripts(soup)
+    link = soup.find('link', rel='dns-prefetch')
+    assert list(link.attrs) == ['href', 'rel']

--- a/tests/test_extract_critical_css.py
+++ b/tests/test_extract_critical_css.py
@@ -7,6 +7,7 @@ sheets are already applied at first paint, so they're skipped (see
 CriticalCSSExtractor.RENDER_BLOCKING_CSS). These tests therefore feed CSS via
 an external <link>, which also exercises _resolve_css_path."""
 
+import pytest
 from bs4 import BeautifulSoup
 
 from extract_critical_css import CriticalCSSExtractor
@@ -260,3 +261,42 @@ def test_deferred_sheets_have_their_rules_inlined(tmp_path):
     assert 'height:80px' in critical, (
         'header.min.css was deferred without its above-fold rules inlined'
     )
+
+
+# ── cap invariant and truncation accounting ──────────────────────────────
+
+def test_harvest_cap_cannot_trigger_externalisation():
+    """max_critical_css above max_inline_critical would externalise every
+    page's block into an extra render-blocking request — the opposite of what
+    critical CSS is for, and enough to push pages past the 5/5 stylesheet
+    budget. The two constants are set independently, so the relationship has
+    to be asserted rather than assumed."""
+    ex = CriticalCSSExtractor()
+    assert ex.max_critical_css <= ex.max_inline_critical
+
+    ex.max_critical_css = ex.max_inline_critical + 1
+    with pytest.raises(ValueError, match='render-blocking'):
+        ex._assert_cap_invariant()
+
+
+def test_truncation_totals_are_accumulated(tmp_path):
+    """Saturation was reported as one warning line per page. At 252/252 pages
+    that buried the fact rather than conveying it, so the run summary needs
+    totals to print instead."""
+    # Same shape as test_truncation_keeps_braces_balanced: enough matching
+    # rules that the cap binds.
+    big = (''.join(f'p{{padding:{i}px;color:#0{i % 10}{i % 10}}}' for i in range(300))
+           + '@media (max-width:600px){'
+           + ''.join(f'h1{{margin:{i}px}}' for i in range(600)) + '}')
+    ex, out = _extract(big, {'p', 'h1'}, tmp_path)
+    # Re-run over a second page to prove the counters accumulate.
+    ex._extract_matching_css_rules(
+        BeautifulSoup('<html><head><link rel="stylesheet" href="/styles.css">'
+                      '</head><body><main><p>x</p></main></body></html>',
+                      'html.parser'),
+        {'p', 'h1'})
+
+    assert ex.css_truncated == 2
+    assert ex.css_dropped_rules > 0
+    assert ex.css_dropped_bytes > 0
+    assert len(out) <= ex.max_critical_css

--- a/tests/test_lighthouse_history.py
+++ b/tests/test_lighthouse_history.py
@@ -1,0 +1,94 @@
+"""One Lighthouse row per day, but a representative one.
+
+"Latest wins" made the daily row mean "whichever run happened to be last",
+which is not a property of the day. On 2026-08-09 the row recorded P73 — a
+single cold-cache outlier measured four minutes after a cache-purging deploy
+— while seven other runs that day scored 91-93. The 90-day trend then showed
+a cliff that nothing in the site had caused, and the six good runs were gone.
+"""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'scripts'))
+
+from generate_changelog import _median, save_lighthouse_scores  # noqa: E402
+
+
+def _scores(performance, ts='2026-08-09T10:00:00'):
+    return {'timestamp': ts, 'performance': performance,
+            'accessibility': 96, 'best_practices': 93, 'seo': 100}
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """save_lighthouse_scores writes a fixed relative path."""
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.mark.parametrize('values,expected', [
+    ([93], 93),
+    ([91, 93], 92),
+    ([93, 73, 92], 92),
+    ([91, 92, 93, 93], 92),
+])
+def test_median(values, expected):
+    assert _median(values) == expected
+
+
+def test_single_outlier_does_not_define_the_day():
+    """The actual regression, with the day's real numbers."""
+    history = []
+    for p in (93, 91, 92, 93, 91, 92, 93):
+        history = save_lighthouse_scores(_scores(p), history)
+    history = save_lighthouse_scores(_scores(73), history)   # cold-cache run
+
+    today = history[-1]
+    assert today['runs'] == 8
+    assert today['performance'] == 92, (
+        f"one outlier moved the daily row to P{today['performance']}"
+    )
+
+
+def test_every_run_is_retained_as_a_sample():
+    history = []
+    for p in (93, 73, 92):
+        history = save_lighthouse_scores(_scores(p), history)
+
+    samples = history[-1]['samples']
+    assert [s['performance'] for s in samples] == [93, 73, 92]
+
+
+def test_one_row_per_date():
+    """The 90-day trend still wants a single point per day."""
+    history = []
+    for p in (93, 91, 92):
+        history = save_lighthouse_scores(_scores(p), history)
+    assert len(history) == 1
+
+
+def test_legacy_row_is_folded_in_not_discarded():
+    """Rows written before `samples` existed must survive the upgrade as a
+    data point rather than being dropped on the first write of the day."""
+    today = datetime.now().strftime('%Y-%m-%d')
+    legacy = [{'date': today, 'timestamp': 'old', 'performance': 90,
+               'accessibility': 96, 'best_practices': 93, 'seo': 100}]
+
+    history = save_lighthouse_scores(_scores(94), legacy)
+
+    assert history[-1]['runs'] == 2
+    assert [s['performance'] for s in history[-1]['samples']] == [90, 94]
+    assert history[-1]['performance'] == 92
+
+
+def test_consumer_keys_are_preserved():
+    """generate_changelog and generate_stats_page both read history[-1] and
+    pull these keys straight off it."""
+    history = save_lighthouse_scores(_scores(93), [])
+    entry = history[-1]
+    for key in ('date', 'timestamp', 'performance', 'accessibility',
+                'best_practices', 'seo'):
+        assert key in entry, f'consumers read {key!r} off the daily row'

--- a/tests/test_resource_budgets.py
+++ b/tests/test_resource_budgets.py
@@ -48,12 +48,44 @@ def test_reads_budget_from_lighthouse_config(tmp_path):
 
 
 def test_page_within_budget_produces_no_warning(tmp_path):
-    v = _site(tmp_path, {'index.html': _page([f'/c{i}.css' for i in range(BUDGET)])})
+    """Strictly under the budget — the only genuinely quiet case."""
+    v = _site(tmp_path, {'index.html': _page([f'/c{i}.css' for i in range(BUDGET - 1)])})
     v.validate_resource_budgets()
 
     assert v.warnings == []
     assert v.stats['Pages over stylesheet budget'] == 0
-    assert v.stats['Max stylesheets/page'] == f"{BUDGET} (budget {BUDGET})"
+    assert v.stats['Pages at stylesheet budget'] == 0
+    assert v.stats['Max stylesheets/page'] == f"{BUDGET - 1} (budget {BUDGET})"
+
+
+def test_page_exactly_at_budget_warns_about_no_headroom(tmp_path):
+    """Exactly at the budget used to read as a clean pass, identical to 1/5.
+
+    The site sat at 5/5 for a full day reporting "All 253 pages within
+    budget" — true, and one stylesheet away from the same check failing. The
+    distinction between "fine" and "out of room" is the whole point of
+    tracking the budget, so it has to be visible before it trips.
+    """
+    v = _site(tmp_path, {'index.html': _page([f'/c{i}.css' for i in range(BUDGET)])})
+    v.validate_resource_budgets()
+
+    assert v.stats['Pages at stylesheet budget'] == 1
+    assert v.stats['Pages over stylesheet budget'] == 0, 'at the limit is not over it'
+    assert len(v.warnings) == 1
+    assert 'no headroom' in v.warnings[0]
+
+
+def test_headroom_warning_is_suppressed_when_something_is_already_over(tmp_path):
+    """Over-budget is the actionable warning; don't bury it under a second
+    one saying other pages are close."""
+    v = _site(tmp_path, {
+        'over.html': _page([f'/c{i}.css' for i in range(BUDGET + 1)]),
+        'at.html': _page([f'/c{i}.css' for i in range(BUDGET)]),
+    })
+    v.validate_resource_budgets()
+
+    assert len(v.warnings) == 1
+    assert 'exceed the stylesheet budget' in v.warnings[0]
 
 
 def test_page_over_budget_warns_without_erroring(tmp_path):


### PR DESCRIPTION
The seven outstanding items, one commit each (5 commits — 4/5 and 6/7 are paired because they share a test file and a workflow respectively).

## 1. Critical-CSS cap saturation — `991a2294f0`

`max_critical_css` was 15000, tuned while `_resolve_css_path` silently failed on absolute hrefs and harvested almost nothing, so no page ever reached it. #151 fixed the resolver and all 252 pages saturated it on the first deploy:

```
159 × dropped 18/127 rules (3067B)
 33 × dropped 18/130 rules (3067B)
 15 × dropped 31/142 rules (5015B)
```

Pinned to `max_inline_critical` (16384), recovering ~1.4 KB/page of discarded above-fold rules. It must never exceed that — `_inline_critical_css` externalises anything larger into its own render-blocking file, which would also push pages past the 5/5 budget — so `_assert_cap_invariant()` makes that a startup error rather than a silent extra request per page.

Saturation now reports as one sample line plus totals in the run summary, instead of 252 near-identical warnings.

## 2. Stylesheet budget headroom — `e373e42380`

`All 253 pages within budget (max 5/5)` read as a clean pass, indistinguishable from 1/5. Pages at exactly the limit are now counted, warned about (suppressed when something is already over — that's the actionable one), exported to the Slack card, and the success line prints remaining headroom.

`test_page_within_budget_produces_no_warning` previously asserted silence at exactly the budget; it now covers strictly-under, with two new tests on the boundary.

## 3. Lighthouse history — `2f4570cca8`

The file recorded `{'date': '2026-08-09', 'performance': 73}` — a single cold-cache run taken four minutes after a cache-purging deploy — while seven other runs that day scored 91–93. One row per date is right for a 90-day trend; "latest wins" is not. Now keeps every run in `samples` and reports the **median**. Legacy rows fold in as a data point rather than being dropped on upgrade. Consumers read the same keys off `history[-1]`.

## 4 + 5. Build stamps and dns-prefetch — `364aba34b7`

`api/index.json`, `markdown/index.json` and `markdown/SITEMAP.md` embedded `datetime.now()`, so all three plus sidecars landed in every commit. They now carry the newest content timestamp across what they index.

`optimize_external_scripts` walked a bare set difference and inserted each tag at `head[0]`, so hash order became document order and hints came out in a different sequence run to run. `sorted()` fixes it; attributes are set href-then-rel so a pruned-and-recreated hint doesn't flip attribute order. This was the residual 2-pages-per-build noise after #148.

## 6 + 7. Workflow — `274241e465`

force-full now dispatches with `force_static_purge=true`. The diff gate is right for an incremental deploy, but a no-cache rebuild regenerates every asset from source — the run where a stale edge copy is most likely and least visible. Subset fonts are served `immutable` for a year.

`Images needing AVIF/WebP conversion: -300 of 1852` subtracted every `.avif` on disk from the png/jpg/jpeg count, but the former isn't a subset of the latter. Verified on the current tree: 1852 sources, 2152 `.avif`, hence −300. Now counts sources with no `.avif` sibling — reads **0** on the same tree.

## Tests

198 passing. 14 new/changed; verified 5 fail without their fix (the two build-stamp tests, both dns-prefetch tests, and the budget boundary test).

Two testing notes worth keeping:
- The dns-prefetch test asserts the **sorted property**, not repeated runs. Set iteration is stable within a process, so a loop passes with the bug present and only diverges across the separate build processes where it actually bit. Same trap as the `glob` tests in #149.
- The cap-invariant test guards the *relationship*, not the value — it passes at 15000 too. That's deliberate: the value is a tuning decision, the invariant is a correctness one.

## Does this change `public/`?

Yes, one-time: every page's critical CSS grows by up to ~1.4 KB (item 1), and the three stamped files change shape once (item 4). After that, items 4, 5 and 7 should each remove churn from steady-state deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)