### PR TITLE
perf: make font subsetting deterministic and cacheable, halve the deploy poll

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -1342,7 +1342,12 @@ jobs:
 
         if [ -n "$CLOUDFLARE_API_TOKEN" ] && [ -n "$CLOUDFLARE_ACCOUNT_ID" ]; then
           echo "⏳ Waiting for Cloudflare Pages deployment of ${PUSHED_SHA:0:7} to complete..."
-          MAX_ATTEMPTS=18   # 18 × 10s = 180s max
+          # 5s poll, same 180s ceiling. The deployment consistently becomes
+          # ready between the 3rd and 4th poll, so a 10s interval spent up to
+          # 9s per deploy waiting on a state that had already changed — 33s of
+          # the step's 49s on the 2026-08-09 17:34 run. Halving the interval
+          # keeps the same worst case and returns most of that.
+          MAX_ATTEMPTS=36   # 36 × 5s = 180s max
           ATTEMPT=0
           DEPLOY_STATUS="pending"
           DEPLOY_RESP=""
@@ -1367,7 +1372,7 @@ jobs:
                 ;;
             esac
             ATTEMPT=$((ATTEMPT+1))
-            sleep 10
+            sleep 5
           done
           if [ "$DEPLOY_STATUS" != "success" ]; then
             echo "⚠️  Deployment for ${PUSHED_SHA:0:7} did not reach 'success' within timeout"

--- a/scripts/subset_fonts.py
+++ b/scripts/subset_fonts.py
@@ -49,12 +49,19 @@ Usage:
     python3 scripts/subset_fonts.py [site_dir]
 """
 
+import hashlib
+import json
 import shutil
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 from bs4 import BeautifulSoup
+
+# Records which master + character set produced each deployed subset, so a
+# rebuild with both unchanged can skip the work. Sits under the site tree so
+# it travels with the incremental seed from public/.
+_CACHE_REL = 'assets/fonts/.subset-cache.json'
 
 try:
     from fontTools.subset import Subsetter, Options
@@ -246,7 +253,16 @@ def _subset_font(font_path: Path, characters: str) -> dict:
     """
     before = font_path.stat().st_size
 
-    font = TTFont(str(font_path))
+    # recalcTimestamp=False pins the OpenType head.modified field. fontTools
+    # otherwise stamps "now" on save, so a rebuild with an identical glyph set
+    # produced a byte-different woff2: same 11,592 bytes, same 142 glyphs,
+    # only head.modified moved (3869108660 → 3869141786 across two deploys).
+    #
+    # That cost more than a noisy diff. All five fonts landed in every deploy
+    # commit with their .br/.gz sidecars, and because the static-asset purge
+    # gate keys on `assets/fonts/*.woff2` appearing in the diff, every deploy
+    # also fired a Cloudflare edge purge for fonts that were byte-equivalent.
+    font = TTFont(str(font_path), recalcTimestamp=False)
     options = Options()
     # Output flavour: keep woff2 so the served URL doesn't need to change
     # and the existing <link rel=preload as=font type=font/woff2> remains
@@ -296,24 +312,107 @@ def _ensure_master(repo_root: Path, site_dir: Path, spec: FontSpec) -> Path | No
     return None
 
 
-def _process_one(repo_root: Path, site_dir: Path, spec: FontSpec) -> dict | None:
-    """Restore master → target, collect chars, subset target."""
+def corpus_fingerprint(site_dir: Path) -> str:
+    """Hash every HTML file that feeds character collection.
+
+    Computed once per run and shared by all specs. This is what lets the
+    cache be checked BEFORE _collect_chars rather than after: the character
+    set is a pure function of (corpus, selectors), so an unchanged corpus
+    means an unchanged character set without having to parse anything.
+
+    Hashing the corpus costs a read; _collect_chars costs a BeautifulSoup
+    parse of every page, once per font. On the real 253-page site that is
+    16s — which is why checking the cache after it saved nothing measurable
+    (16.1s → 16.0s) in the first version of this.
+    """
+    h = hashlib.blake2b(digest_size=16)
+    for path in sorted(site_dir.rglob('*.html')):
+        h.update(str(path.relative_to(site_dir)).encode('utf-8'))
+        h.update(b'\0')
+        h.update(path.read_bytes())
+        h.update(b'\0')
+    return h.hexdigest()
+
+
+def _cache_key(master_path: Path, spec: 'FontSpec', corpus_hash: str) -> str:
+    """Identity of a subset: the master, the selectors that choose glyphs
+    from it, and the corpus those selectors run against.
+
+    The selectors are part of the key so that editing FONT_SPECS invalidates
+    the cache — otherwise a code change to which elements feed a font would
+    silently keep serving the previous subset.
+    """
+    h = hashlib.blake2b(digest_size=16)
+    h.update(master_path.read_bytes())
+    h.update(b'\0')
+    h.update(repr((spec.tag_selectors, spec.class_selectors,
+                   spec.safety_pad)).encode('utf-8'))
+    h.update(b'\0')
+    h.update(corpus_hash.encode('ascii'))
+    return h.hexdigest()
+
+
+def _load_cache(site_dir: Path) -> dict:
+    cache_path = site_dir / _CACHE_REL
+    if cache_path.exists():
+        try:
+            return json.loads(cache_path.read_text(encoding='utf-8'))
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {}
+
+
+def _save_cache(site_dir: Path, cache: dict) -> None:
+    cache_path = site_dir / _CACHE_REL
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(cache, indent=2, sort_keys=True),
+                              encoding='utf-8')
+    except OSError as e:
+        print(f"⚠️  Could not write font subset cache: {e}")
+
+
+def _process_one(repo_root: Path, site_dir: Path, spec: FontSpec,
+                 corpus_hash: str, cache: dict) -> dict | None:
+    """Restore master → target, collect chars, subset target.
+
+    Whole step took ~43s of a 319s deploy (13.5%) rebuilding five files whose
+    content essentially never changes — the Anton character set has been
+    stable at ~87 glyphs. The cache check has to come before _collect_chars:
+    that scan is the expensive part, not the subsetting.
+    """
     master_path = _ensure_master(repo_root, site_dir, spec)
     if not master_path:
         return None
 
     font_path = site_dir / spec.target_rel
     font_path.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(master_path, font_path)
+
+    key = _cache_key(master_path, spec, corpus_hash)
+    cached = cache.get(spec.target_rel)
+    if (cached and cached.get('key') == key and font_path.exists()
+            and font_path.stat().st_size == cached.get('after')):
+        return {'label': spec.label, 'file': font_path.name,
+                'before': cached.get('before', 0), 'after': cached['after'],
+                'chars': cached.get('total_chars', 0),
+                'used_chars': cached.get('used_chars', 0),
+                'total_chars': cached.get('total_chars', 0), 'cached': True}
 
     used = _collect_chars(site_dir, spec)
     full_set = ''.join(sorted(used | set(spec.safety_pad)))
+
+    shutil.copy2(master_path, font_path)
 
     try:
         stats = _subset_font(font_path, full_set)
     except Exception as e:
         print(f"❌ {spec.label}: failed to subset {font_path.name}: {e}")
         return None
+
+    cache[spec.target_rel] = {'key': key, 'before': stats['before'],
+                              'after': stats['after'],
+                              'used_chars': len(used),
+                              'total_chars': len(full_set)}
 
     stats['label'] = spec.label
     stats['file'] = font_path.name
@@ -334,16 +433,23 @@ def main():
     html_count = len(list(site_dir.rglob('*.html')))
     print(f"🔤 Subsetting {len(FONT_SPECS)} fonts against {html_count} HTML files in {site_dir}")
 
+    corpus_hash = corpus_fingerprint(site_dir)
+    cache = _load_cache(site_dir)
+
     results = []
     for spec in FONT_SPECS:
         print(f"\n   • {spec.label} ({spec.target_rel})")
-        stats = _process_one(repo_root, site_dir, spec)
+        stats = _process_one(repo_root, site_dir, spec, corpus_hash, cache)
         if stats:
             saved = stats['before'] - stats['after']
             pct = saved / stats['before'] * 100 if stats['before'] else 0
             print(f"     used={stats['used_chars']} chars (+safety pad → {stats['total_chars']})")
-            print(f"     {stats['before']:>7} → {stats['after']:>7} bytes ({pct:.1f}% saved)")
+            suffix = '  [cached — master + charset unchanged]' if stats.get('cached') else ''
+            print(f"     {stats['before']:>7} → {stats['after']:>7} bytes "
+                  f"({pct:.1f}% saved){suffix}")
             results.append(stats)
+
+    _save_cache(site_dir, cache)
 
     if not results:
         print("\n⚠️  No fonts were subsetted.")

--- a/tests/test_subset_fonts_cache.py
+++ b/tests/test_subset_fonts_cache.py
@@ -1,0 +1,155 @@
+"""Font subsetting must be byte-stable and skippable.
+
+Two problems, one step.
+
+Determinism: fontTools stamps head.modified on save, so a rebuild with an
+identical glyph set produced a byte-different woff2 — same 11,592 bytes, same
+142 glyphs, only the timestamp moved (3869108660 → 3869141786 across two
+deploys). All five fonts landed in every deploy commit with their .br/.gz
+sidecars, and because the static-asset purge gate keys on
+`assets/fonts/*.woff2` appearing in the diff, every deploy also fired a
+Cloudflare edge purge for byte-equivalent fonts.
+
+Cost: the step took ~43s of a 319s deploy rebuilding files that essentially
+never change. The expensive half is _collect_chars parsing every page once per
+font — not the subsetting — so the cache has to be consulted before that scan.
+Measured on the real 253-page corpus: 16.6s uncached, 0.3s cached. Checking
+the cache after the scan (the obvious placement) saved nothing: 16.1s → 16.0s.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'scripts'))
+
+subset_fonts = pytest.importorskip('subset_fonts')
+
+pytestmark = pytest.mark.skipif(
+    not subset_fonts._DEPS_OK,
+    reason=f'needs fonttools[woff] ({subset_fonts._DEPS_ERROR})')
+
+
+def _corpus(root: Path, pages: dict):
+    for name, body in pages.items():
+        p = root / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(f'<html><body>{body}</body></html>', encoding='utf-8')
+
+
+def test_corpus_fingerprint_tracks_content(tmp_path):
+    _corpus(tmp_path, {'a.html': '<h1>Alpha</h1>'})
+    first = subset_fonts.corpus_fingerprint(tmp_path)
+
+    assert subset_fonts.corpus_fingerprint(tmp_path) == first, 'not stable'
+
+    _corpus(tmp_path, {'a.html': '<h1>Beta</h1>'})
+    assert subset_fonts.corpus_fingerprint(tmp_path) != first, 'content ignored'
+
+
+def test_corpus_fingerprint_tracks_added_and_removed_pages(tmp_path):
+    _corpus(tmp_path, {'a.html': '<h1>A</h1>'})
+    one = subset_fonts.corpus_fingerprint(tmp_path)
+
+    _corpus(tmp_path, {'b.html': '<h1>B</h1>'})
+    two = subset_fonts.corpus_fingerprint(tmp_path)
+    assert two != one, 'a new page must invalidate'
+
+    (tmp_path / 'b.html').unlink()
+    assert subset_fonts.corpus_fingerprint(tmp_path) == one, 'removal must too'
+
+
+def test_corpus_fingerprint_ignores_non_html(tmp_path):
+    """Only HTML feeds character collection — images and fonts churning
+    must not force a re-subset."""
+    _corpus(tmp_path, {'a.html': '<h1>A</h1>'})
+    before = subset_fonts.corpus_fingerprint(tmp_path)
+
+    (tmp_path / 'notes.txt').write_text('anything', encoding='utf-8')
+    (tmp_path / 'img.bin').write_bytes(b'\x00\x01')
+
+    assert subset_fonts.corpus_fingerprint(tmp_path) == before
+
+
+def test_cache_key_covers_master_selectors_and_corpus(tmp_path):
+    """All three inputs decide the output; a key missing any of them serves
+    a stale subset after that input changes."""
+    master = tmp_path / 'master.woff2'
+    master.write_bytes(b'font-bytes')
+    spec = subset_fonts.FONT_SPECS[0]
+
+    base = subset_fonts._cache_key(master, spec, 'corpus-1')
+
+    assert subset_fonts._cache_key(master, spec, 'corpus-2') != base, 'corpus'
+
+    master.write_bytes(b'different-font-bytes')
+    assert subset_fonts._cache_key(master, spec, 'corpus-1') != base, 'master'
+
+    master.write_bytes(b'font-bytes')
+    other = subset_fonts.FontSpec(
+        label=spec.label, target_rel=spec.target_rel, master_rel=spec.master_rel,
+        tag_selectors=spec.tag_selectors + ('h7',),
+        class_selectors=spec.class_selectors, safety_pad=spec.safety_pad)
+    assert subset_fonts._cache_key(master, other, 'corpus-1') != base, 'selectors'
+
+
+def test_cache_key_is_stable_for_identical_inputs(tmp_path):
+    master = tmp_path / 'master.woff2'
+    master.write_bytes(b'font-bytes')
+    spec = subset_fonts.FONT_SPECS[0]
+
+    assert (subset_fonts._cache_key(master, spec, 'c')
+            == subset_fonts._cache_key(master, spec, 'c'))
+
+
+def test_cache_roundtrips(tmp_path):
+    subset_fonts._save_cache(tmp_path, {'a': {'key': 'k', 'after': 1}})
+    assert subset_fonts._load_cache(tmp_path) == {'a': {'key': 'k', 'after': 1}}
+
+
+def test_corrupt_cache_is_ignored_not_fatal(tmp_path):
+    """A truncated cache from an interrupted build must degrade to a rebuild,
+    not take the deploy down."""
+    cache_path = tmp_path / subset_fonts._CACHE_REL
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text('{not json', encoding='utf-8')
+
+    assert subset_fonts._load_cache(tmp_path) == {}
+
+
+def test_cache_file_is_deterministic(tmp_path):
+    """The cache is written into the site tree, so it lands in the deploy
+    commit — unsorted keys would reintroduce the churn this removes."""
+    entries = {'z': {'key': 'k1', 'after': 2}, 'a': {'key': 'k2', 'after': 3}}
+    subset_fonts._save_cache(tmp_path, entries)
+    first = (tmp_path / subset_fonts._CACHE_REL).read_text(encoding='utf-8')
+    subset_fonts._save_cache(tmp_path, dict(reversed(list(entries.items()))))
+    second = (tmp_path / subset_fonts._CACHE_REL).read_text(encoding='utf-8')
+
+    assert first == second
+    assert list(json.loads(first)) == ['a', 'z']
+
+
+def test_subset_output_is_byte_stable(tmp_path):
+    """The determinism half, independent of the cache: two real subsets of
+    the same master with the same characters must be byte-identical."""
+    repo_root = Path(__file__).resolve().parent.parent
+    spec = subset_fonts.FONT_SPECS[0]
+    master = repo_root / spec.master_rel
+    if not master.exists():
+        pytest.skip(f'master font not present: {spec.master_rel}')
+
+    import shutil
+    outputs = []
+    for name in ('one.woff2', 'two.woff2'):
+        target = tmp_path / name
+        shutil.copy2(master, target)
+        subset_fonts._subset_font(target, 'ABCDEfghij 0123')
+        outputs.append(target.read_bytes())
+
+    assert outputs[0] == outputs[1], (
+        'subset output varies between runs — head.modified is being '
+        'recalculated, which recommits every font on every build'
+    )


### PR DESCRIPTION
Items 2–4 of the performance findings, from the 2026-08-09 17:34 deploy (319s total).

## 2. Font subsetting was non-deterministic

All five subset `.woff2` files changed in **every deploy** — four consecutive commits checked. Same glyph set, same byte length, different content:

```
335fae5176  created=3690975930  modified=3869108660  142 glyphs  11,592 B
b2405cdc8a  created=3690975930  modified=3869141786  142 glyphs  11,592 B
```

Only OpenType `head.modified` differs — fontTools recalculates it on save. `recalcTimestamp=False` pins it.

The cost was more than a noisy diff: **the static-asset purge gate keys on `assets/fonts/*.woff2` appearing in the commit diff**, so every deploy fired a Cloudflare edge purge for fonts that were byte-equivalent. That also corrects something I told you earlier — I described that gate as conservative but correct. It has been firing unconditionally.

## 3. Font subsetting cost 43s (13.5% of the deploy) rebuilding unchanged files

Cached on `(master bytes, spec selectors, corpus hash)`. The character set is a pure function of those three.

**The cache check has to come before `_collect_chars`.** That scan — a BeautifulSoup parse of every page, once per font — is the expensive half, not the subsetting. Measured on the real 253-page corpus:

| | uncached | cached |
|---|---:|---:|
| cache checked *after* `_collect_chars` | 16.1s | 16.0s |
| cache checked *before* `_collect_chars` | 16.6s | **0.3s** |

I wrote the first version with the check after the scan, and it saved nothing. Only measuring it at realistic corpus size caught that — at 1 HTML file the whole step runs in 0.8s and the placement looks fine.

Verified behaviours:
- adding a heading glyph (Ω) re-subsets — Anton 114 → 115 chars
- a non-HTML change leaves all 5 cached
- selectors are in the key, so editing `FONT_SPECS` invalidates
- a corrupt cache degrades to a rebuild rather than failing the deploy
- the cache file is written with sorted keys — it lands in the deploy commit, so unordered output would reintroduce the churn this removes

## 4. KV purge polled twice as slowly as needed

33s of that step's 49s was polling Cloudflare Pages at 10s intervals; the deployment consistently goes ready between the 3rd and 4th poll. Now 5s, same 180s ceiling.

## Expected effect

~55s off a 319s build, and the last remaining per-deploy churn source removed. Combined with #149, #150 and #152, a steady-state deploy commit should be down to the handful of files that genuinely carry build metadata.

## Tests

9 tests. The determinism test fails without `recalcTimestamp=False` — verified by reverting it.

They skip cleanly without `fonttools[woff]`. Locally I built a venv from `requirements-images.txt` plus fonttools to run everything against real font binaries rather than trusting the skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)