### PR TITLE
fix: key the font subset cache on the character set, not the HTML corpus

### DIFF
--- a/scripts/subset_fonts.py
+++ b/scripts/subset_fonts.py
@@ -211,38 +211,52 @@ FONT_SPECS = (
 )
 
 
-def _collect_chars(site_dir: Path, spec: FontSpec) -> set:
-    """Walk every HTML file and return the unique characters appearing
-    inside elements styled with this font."""
-    chars = set()
-    html_files = list(site_dir.rglob('*.html'))
+def collect_chars_for_specs(site_dir: Path, specs) -> dict:
+    """Walk every HTML file once and return {spec.target_rel: char set}.
+
+    Previously each spec walked and re-parsed the whole corpus itself, so a
+    255-page site cost five full BeautifulSoup passes — 9.6s of the step's
+    16.6s locally, and the bulk of its 46s in CI. Parsing once and fanning the
+    result out to every spec is the same work divided by len(FONT_SPECS).
+    """
+    collected = {spec.target_rel: set() for spec in specs}
     bad_selectors = set()
-    for f in html_files:
+
+    for f in sorted(site_dir.rglob('*.html')):
         try:
             body = f.read_text(encoding='utf-8', errors='ignore')
         except Exception as e:
             print(f"   ⚠️  Skipping unreadable {f}: {e}")
             continue
         soup = BeautifulSoup(body, 'html.parser')
-        for tag in spec.tag_selectors:
-            for el in soup.find_all(tag):
-                chars.update(el.get_text())
-        for sel in spec.class_selectors:
-            try:
-                for el in soup.select(sel):
+
+        for spec in specs:
+            chars = collected[spec.target_rel]
+            for tag in spec.tag_selectors:
+                for el in soup.find_all(tag):
                     chars.update(el.get_text())
-            except Exception as e:
-                # Bad selector syntax shouldn't kill the whole subset run —
-                # but a silently skipped selector means its characters are
-                # missing from the subset and render as .notdef boxes. Warn
-                # once per selector, not once per file.
-                if sel not in bad_selectors:
-                    bad_selectors.add(sel)
-                    print(f"   ⚠️  Selector {sel!r} failed ({e}) — its glyphs "
-                          f"will be missing from the subset unless covered "
-                          f"by another selector")
-                continue
-    return chars
+            for sel in spec.class_selectors:
+                try:
+                    for el in soup.select(sel):
+                        chars.update(el.get_text())
+                except Exception as e:
+                    # Bad selector syntax shouldn't kill the whole subset run —
+                    # but a silently skipped selector means its characters are
+                    # missing from the subset and render as .notdef boxes. Warn
+                    # once per selector, not once per file.
+                    if sel not in bad_selectors:
+                        bad_selectors.add(sel)
+                        print(f"   ⚠️  Selector {sel!r} failed ({e}) — its glyphs "
+                              f"will be missing from the subset unless covered "
+                              f"by another selector")
+                    continue
+
+    return collected
+
+
+def _collect_chars(site_dir: Path, spec: FontSpec) -> set:
+    """Single-spec wrapper, kept for standalone use and tests."""
+    return collect_chars_for_specs(site_dir, [spec])[spec.target_rel]
 
 
 def _subset_font(font_path: Path, characters: str) -> dict:
@@ -312,43 +326,23 @@ def _ensure_master(repo_root: Path, site_dir: Path, spec: FontSpec) -> Path | No
     return None
 
 
-def corpus_fingerprint(site_dir: Path) -> str:
-    """Hash every HTML file that feeds character collection.
+def _cache_key(master_path: Path, characters: str) -> str:
+    """Identity of a subset: the master font, and the glyphs kept from it.
 
-    Computed once per run and shared by all specs. This is what lets the
-    cache be checked BEFORE _collect_chars rather than after: the character
-    set is a pure function of (corpus, selectors), so an unchanged corpus
-    means an unchanged character set without having to parse anything.
+    Keyed on the resolved character set, NOT on a hash of the HTML corpus.
+    The corpus was the obvious choice and it never hit once: changelog and
+    stats pages embed build metrics and so change on every single deploy, so
+    a corpus hash is different every run even when no glyph is. Keying on the
+    output of the scan instead means the subset is skipped whenever the
+    characters are the same, however much the pages moved underneath.
 
-    Hashing the corpus costs a read; _collect_chars costs a BeautifulSoup
-    parse of every page, once per font. On the real 253-page site that is
-    16s — which is why checking the cache after it saved nothing measurable
-    (16.1s → 16.0s) in the first version of this.
-    """
-    h = hashlib.blake2b(digest_size=16)
-    for path in sorted(site_dir.rglob('*.html')):
-        h.update(str(path.relative_to(site_dir)).encode('utf-8'))
-        h.update(b'\0')
-        h.update(path.read_bytes())
-        h.update(b'\0')
-    return h.hexdigest()
-
-
-def _cache_key(master_path: Path, spec: 'FontSpec', corpus_hash: str) -> str:
-    """Identity of a subset: the master, the selectors that choose glyphs
-    from it, and the corpus those selectors run against.
-
-    The selectors are part of the key so that editing FONT_SPECS invalidates
-    the cache — otherwise a code change to which elements feed a font would
-    silently keep serving the previous subset.
+    This does mean the scan still runs — hence collect_chars_for_specs
+    parsing each page once for all fonts rather than once per font.
     """
     h = hashlib.blake2b(digest_size=16)
     h.update(master_path.read_bytes())
     h.update(b'\0')
-    h.update(repr((spec.tag_selectors, spec.class_selectors,
-                   spec.safety_pad)).encode('utf-8'))
-    h.update(b'\0')
-    h.update(corpus_hash.encode('ascii'))
+    h.update(characters.encode('utf-8'))
     return h.hexdigest()
 
 
@@ -373,13 +367,14 @@ def _save_cache(site_dir: Path, cache: dict) -> None:
 
 
 def _process_one(repo_root: Path, site_dir: Path, spec: FontSpec,
-                 corpus_hash: str, cache: dict) -> dict | None:
-    """Restore master → target, collect chars, subset target.
+                 used: set, cache: dict) -> dict | None:
+    """Restore master → target and subset it, unless the cache says the
+    identical subset is already deployed.
 
-    Whole step took ~43s of a 319s deploy (13.5%) rebuilding five files whose
-    content essentially never changes — the Anton character set has been
-    stable at ~87 glyphs. The cache check has to come before _collect_chars:
-    that scan is the expensive part, not the subsetting.
+    The step took ~43s of a 319s deploy (13.5%) rebuilding five files whose
+    glyph sets essentially never change — Anton has been stable at 87 used
+    characters. `used` is passed in because the scan is now shared across all
+    specs (see collect_chars_for_specs).
     """
     master_path = _ensure_master(repo_root, site_dir, spec)
     if not master_path:
@@ -388,18 +383,16 @@ def _process_one(repo_root: Path, site_dir: Path, spec: FontSpec,
     font_path = site_dir / spec.target_rel
     font_path.parent.mkdir(parents=True, exist_ok=True)
 
-    key = _cache_key(master_path, spec, corpus_hash)
+    full_set = ''.join(sorted(used | set(spec.safety_pad)))
+
+    key = _cache_key(master_path, full_set)
     cached = cache.get(spec.target_rel)
     if (cached and cached.get('key') == key and font_path.exists()
             and font_path.stat().st_size == cached.get('after')):
         return {'label': spec.label, 'file': font_path.name,
                 'before': cached.get('before', 0), 'after': cached['after'],
-                'chars': cached.get('total_chars', 0),
-                'used_chars': cached.get('used_chars', 0),
-                'total_chars': cached.get('total_chars', 0), 'cached': True}
-
-    used = _collect_chars(site_dir, spec)
-    full_set = ''.join(sorted(used | set(spec.safety_pad)))
+                'chars': len(full_set), 'used_chars': len(used),
+                'total_chars': len(full_set), 'cached': True}
 
     shutil.copy2(master_path, font_path)
 
@@ -433,13 +426,15 @@ def main():
     html_count = len(list(site_dir.rglob('*.html')))
     print(f"🔤 Subsetting {len(FONT_SPECS)} fonts against {html_count} HTML files in {site_dir}")
 
-    corpus_hash = corpus_fingerprint(site_dir)
     cache = _load_cache(site_dir)
+    # One parse of the corpus for every spec, rather than one per spec.
+    collected = collect_chars_for_specs(site_dir, FONT_SPECS)
 
     results = []
     for spec in FONT_SPECS:
         print(f"\n   • {spec.label} ({spec.target_rel})")
-        stats = _process_one(repo_root, site_dir, spec, corpus_hash, cache)
+        stats = _process_one(repo_root, site_dir, spec,
+                             collected[spec.target_rel], cache)
         if stats:
             saved = stats['before'] - stats['after']
             pct = saved / stats['before'] * 100 if stats['before'] else 0

--- a/tests/test_subset_fonts_cache.py
+++ b/tests/test_subset_fonts_cache.py
@@ -11,10 +11,22 @@ sidecars, and because the static-asset purge gate keys on
 Cloudflare edge purge for byte-equivalent fonts.
 
 Cost: the step took ~43s of a 319s deploy rebuilding files that essentially
-never change. The expensive half is _collect_chars parsing every page once per
-font — not the subsetting — so the cache has to be consulted before that scan.
-Measured on the real 253-page corpus: 16.6s uncached, 0.3s cached. Checking
-the cache after the scan (the obvious placement) saved nothing: 16.1s → 16.0s.
+never change. Two things drive it, and the first attempt fixed neither.
+
+  - The scan (_collect_chars) parsed every page once PER FONT — five full
+    BeautifulSoup passes over 255 pages. collect_chars_for_specs parses once
+    and fans out.
+  - The subsetting itself, skipped via a cache keyed on the master plus the
+    resolved character set.
+
+The cache was originally keyed on a hash of the HTML corpus, checked before
+the scan. It never hit once in production: changelog and stats pages embed
+build metrics, so the corpus differs on every single deploy even when no
+glyph does. Keying on the scan's output instead means pages can churn freely.
+
+Measured on the real 253-page corpus: 16.6s → 6.5s cold, 6.0s warm, and still
+6.0s warm when a per-build page has changed — the case that broke the first
+design.
 """
 
 import json
@@ -39,69 +51,54 @@ def _corpus(root: Path, pages: dict):
         p.write_text(f'<html><body>{body}</body></html>', encoding='utf-8')
 
 
-def test_corpus_fingerprint_tracks_content(tmp_path):
-    _corpus(tmp_path, {'a.html': '<h1>Alpha</h1>'})
-    first = subset_fonts.corpus_fingerprint(tmp_path)
-
-    assert subset_fonts.corpus_fingerprint(tmp_path) == first, 'not stable'
-
-    _corpus(tmp_path, {'a.html': '<h1>Beta</h1>'})
-    assert subset_fonts.corpus_fingerprint(tmp_path) != first, 'content ignored'
-
-
-def test_corpus_fingerprint_tracks_added_and_removed_pages(tmp_path):
-    _corpus(tmp_path, {'a.html': '<h1>A</h1>'})
-    one = subset_fonts.corpus_fingerprint(tmp_path)
-
-    _corpus(tmp_path, {'b.html': '<h1>B</h1>'})
-    two = subset_fonts.corpus_fingerprint(tmp_path)
-    assert two != one, 'a new page must invalidate'
-
-    (tmp_path / 'b.html').unlink()
-    assert subset_fonts.corpus_fingerprint(tmp_path) == one, 'removal must too'
-
-
-def test_corpus_fingerprint_ignores_non_html(tmp_path):
-    """Only HTML feeds character collection — images and fonts churning
-    must not force a re-subset."""
-    _corpus(tmp_path, {'a.html': '<h1>A</h1>'})
-    before = subset_fonts.corpus_fingerprint(tmp_path)
-
-    (tmp_path / 'notes.txt').write_text('anything', encoding='utf-8')
-    (tmp_path / 'img.bin').write_bytes(b'\x00\x01')
-
-    assert subset_fonts.corpus_fingerprint(tmp_path) == before
-
-
-def test_cache_key_covers_master_selectors_and_corpus(tmp_path):
-    """All three inputs decide the output; a key missing any of them serves
-    a stale subset after that input changes."""
+def test_cache_key_is_not_tied_to_the_corpus(tmp_path):
+    """The bug this replaced: the key was a hash of every HTML file, and
+    changelog/stats embed build metrics so they change on EVERY deploy. The
+    cache never hit once in production. Keying on the resolved character set
+    means pages can churn freely as long as no glyph changed."""
     master = tmp_path / 'master.woff2'
     master.write_bytes(b'font-bytes')
-    spec = subset_fonts.FONT_SPECS[0]
 
-    base = subset_fonts._cache_key(master, spec, 'corpus-1')
-
-    assert subset_fonts._cache_key(master, spec, 'corpus-2') != base, 'corpus'
-
-    master.write_bytes(b'different-font-bytes')
-    assert subset_fonts._cache_key(master, spec, 'corpus-1') != base, 'master'
-
-    master.write_bytes(b'font-bytes')
-    other = subset_fonts.FontSpec(
-        label=spec.label, target_rel=spec.target_rel, master_rel=spec.master_rel,
-        tag_selectors=spec.tag_selectors + ('h7',),
-        class_selectors=spec.class_selectors, safety_pad=spec.safety_pad)
-    assert subset_fonts._cache_key(master, other, 'corpus-1') != base, 'selectors'
+    assert (subset_fonts._cache_key(master, 'ABC')
+            == subset_fonts._cache_key(master, 'ABC'))
 
 
-def test_cache_key_is_stable_for_identical_inputs(tmp_path):
+def test_cache_key_covers_master_and_characters(tmp_path):
     master = tmp_path / 'master.woff2'
     master.write_bytes(b'font-bytes')
-    spec = subset_fonts.FONT_SPECS[0]
+    base = subset_fonts._cache_key(master, 'ABC')
 
-    assert (subset_fonts._cache_key(master, spec, 'c')
-            == subset_fonts._cache_key(master, spec, 'c'))
+    assert subset_fonts._cache_key(master, 'ABCD') != base, 'characters'
+
+    master.write_bytes(b'different')
+    assert subset_fonts._cache_key(master, 'ABC') != base, 'master'
+
+
+def test_single_parse_matches_per_spec_collection(tmp_path):
+    """collect_chars_for_specs parses each page once and fans out to every
+    spec; it must return exactly what the per-spec walk did."""
+    _corpus(tmp_path, {
+        'a.html': '<h1>Alpha</h1><code>x = 1</code>',
+        'sub/b.html': '<h2>Beta</h2><pre>def f()</pre>',
+    })
+    specs = list(subset_fonts.FONT_SPECS)
+
+    combined = subset_fonts.collect_chars_for_specs(tmp_path, specs)
+
+    for spec in specs:
+        assert combined[spec.target_rel] == subset_fonts._collect_chars(tmp_path, spec), (
+            f'{spec.label}: single-pass result differs from per-spec walk'
+        )
+
+
+def test_collection_ignores_pages_with_no_matching_elements(tmp_path):
+    _corpus(tmp_path, {'a.html': '<h1>Alpha</h1>', 'b.html': '<p>ignored</p>'})
+    anton = subset_fonts.FONT_SPECS[0]
+
+    chars = subset_fonts.collect_chars_for_specs(tmp_path, [anton])[anton.target_rel]
+
+    assert set('Alpha') <= chars
+    assert 'g' not in chars, 'body text leaked into a headings-only font'
 
 
 def test_cache_roundtrips(tmp_path):


### PR DESCRIPTION
**The cache added in #154 never hit.** Verified across the first two deploys after it merged — no `[cached]` markers, step still 46s both times.

## Cause

The key was a hash of every HTML file. `changelog/index.html` and `stats/index.html` embed build metrics and change on **every single deploy**, so the corpus hash differed every run even though no glyph did:

```
$ git diff --name-only 10f1a0ad9c d5410e1909 -- 'public/**/*.html'
public/changelog/index.html
public/stats/index.html
... (plus 3 pages of attribute-order noise, which #152 fixes)
```

This one is on me. The preceding work in this series was largely about cataloguing which files change on every build — changelog and stats were on that list — and I then keyed a cache on a hash that includes them. The local sandbox had no changelog page, so it hit every time.

## Fix

Key on `(master bytes, resolved character set)`. Pages can churn freely; what matters is whether the glyphs moved.

That means the scan runs every time, so it had to get cheaper. `_collect_chars` parsed every page once **per font** — five full BeautifulSoup passes over 255 pages, 9.6s of the 16.6s locally. `collect_chars_for_specs` parses each page once and fans out to every spec; `_collect_chars` stays as a single-spec wrapper for standalone use.

## Measured on the real 253-page corpus

| | time | cached |
|---|---:|---|
| before this PR | 16.6s | — |
| cold cache | 6.5s | 0/5 |
| warm cache | 6.0s | 5/5 |
| **warm + a per-build page changed** | **5.9s** | **5/5** |

That last row is the case that broke #154 — simulated by rewriting `changelog/index.html` between runs.

Extrapolating to CI (46s observed there vs 16.6s locally), expect roughly 46s → 17s rather than the ~1s #154's description claimed.

## What #154 did get right

Worth separating, since only half of it failed: `recalcTimestamp=False` works. Verified on the deployed font — `head.modified` went `3869141786` → `3691490476` and stopped moving, **0 woff2 in the latest deploy's diff**, and the whole commit is down to 33 files from 1762 at the start of this work.

## Tests

The corpus-fingerprint tests are replaced with ones asserting the key is independent of corpus churn, plus a test that the single-pass scan returns exactly what the per-spec walk did for every spec in `FONT_SPECS` — that equivalence is the risk in this refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)